### PR TITLE
Make python markdown do syntax-hilighted code

### DIFF
--- a/nikola/md.py
+++ b/nikola/md.py
@@ -3,6 +3,7 @@
 __all__ = ['compile_html']
 
 import codecs
+import re
 
 from markdown import markdown
 
@@ -10,6 +11,13 @@ from markdown import markdown
 def compile_html(source, dest):
     with codecs.open(source, "r", "utf8") as in_file:
         data = in_file.read()
-        output = markdown(data)
+
+    output = markdown(data, ['fenced_code', 'codehilite'])
+    # python-markdown's highlighter uses the class 'codehilite' to wrap code,
+    # instead of the standard 'code'. None of the standard pygments
+    # stylesheets use this class, so swap it to be 'code'
+    output = re.sub(r'(<div[^>]+class="[^"]*)codehilite([^>]+)', r'\1code\2',
+                    output)
+
     with codecs.open(dest, "w+", "utf8") as out_file:
         out_file.write(output)


### PR DESCRIPTION
In order for this to work the fenced_code extension needs to be used as well, but fenced code is easier to produce programmatically and is nicer to write if you don't have a decent text editor, so I don't think that it's a loss to have it enabled.

Additionally, use the [codehilite](http://freewisdom.org/projects/python-markdown/CodeHilite) and [fenced_code](#http://freewisdom.org/projects/python-markdown/Fenced_Code_Blocks) extensions, and add a regexp substitution
to make the codehilite extension match pygments' css "api".

That regexp is necessary because codehilite produces html surrounded by a div with the `codehilite` class, instead of the standard `code` class, and pygments' stylesheet doesn't apply to it.
