### PR TITLE
Compile Posts based on file extension instead of project setting

### DIFF
--- a/nikola/data/samplesite/conf.py
+++ b/nikola/data/samplesite/conf.py
@@ -30,6 +30,17 @@ post_pages = (
     ("stories/*.txt", "stories", "story.tmpl", False),
 )
 
+# A mapping of languages to file-extensions that represent that language.
+# Feel free to add or delete extensions to any list, but don't add any new
+# compilers unless you write the interface for it yourself.
+#
+# 'rest' is reStructuredText
+# 'markdown' is MarkDown
+post_compilers = {
+    "rest": ('.txt', '.rst'),
+    "markdown": ('.md', '.mdown', '.markdown')
+    }
+
 # What is the default language?
 
 DEFAULT_LANG = "en"
@@ -90,11 +101,6 @@ THUMBNAIL_SIZE = 180
 ##############################################################################
 # HTML fragments and diverse things that are used by the templates
 ##############################################################################
-
-# What markup are you using for your posts. Possible values include:
-# "rest" => reStructuredText
-# "markdown" => MarkDown
-INPUT_FORMAT = 'rest'
 
 # Data about this site
 BLOG_TITLE = "Demo Site"


### PR DESCRIPTION
First attempt at issue #22

Everything works correctly here, but I'm not sure about the implementation.

The first problem might have just come from the fact that I'm not familiar with the code base, but because of the way that global configuration is set up it seems like the only way to get access to a conf during a doit run is by adding code inside of `nikola.Nikola`.

So, originally I had a utility function inside of `Nikola`, but I would have needed to either never cache the results of figuring out what compiler a given file extension maps to, or create a cache and make it a class global property. Instead of that I just created a new class in utils that has a private cache variable (`inverse_post_compilers`) and every time we run into a new extension the compiler for it gets added.

The code is mostly ugly because of error checking, the api that it enables (see [nikola/nikola.py:174](https://github.com/quodlibetor/nikola/pull/new#L2R174), [nikola/nikola.py:354](https://github.com/quodlibetor/nikola/pull/new#L2R354), [nikola/nikola.py:811](https://github.com/quodlibetor/nikola/pull/new#L2R811)) is exactly the same, and I think that this `post_compilers` format (i.e., `'language': ['list', 'of', 'extensions']`) is the most intuitive and least tedious for users.
