### PR TITLE
Fix the pip install command

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -183,7 +183,7 @@ This is currently lacking on detail. Considering the niche Nikola is aimed at,
 I suspect that's not a problem yet. So, when I say "get", the specific details
 of how to "get" something for your specific operating system are left to you.
 
-The short version is: ``pip install https://github.com/ralsina/nikola``
+The short version is: ``pip install git+https://github.com/ralsina/nikola``
 
 Longer version:
 


### PR DESCRIPTION
- pip seems to need 'git+https' in order to know how to install the package
  correctly from a repository

pip was generating the following error if I was using just 'https' (I don't believe it was related to running it in a virtualenv):

---

/data/develop/nikola/env/bin/pip run on Tue Jun 19 15:23:48 2012
Downloading/unpacking https://github.com/ralsina/nikola

  Downloading from URL https://github.com/ralsina/nikola
  Cannot unpack file /tmp/pip-9IvWLo-unpack/nikola (downloaded from /tmp/pip-htsLAd-build, content-type: text/html; charset=utf-8); cannot detect archive format

Cannot determine archive format of /tmp/pip-htsLAd-build

Exception information:
Traceback (most recent call last):
  File "/data/develop/nikola/env/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/basecommand.py", line 104, in main
    status = self.run(options, args)
  File "/data/develop/nikola/env/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/commands/install.py", line 245, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/data/develop/nikola/env/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/req.py", line 985, in prepare_files
    self.unpack_url(url, location, self.is_download)
  File "/data/develop/nikola/env/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/req.py", line 1109, in unpack_url
    retval = unpack_http_url(link, location, self.download_cache, self.download_dir)
  File "/data/develop/nikola/env/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/download.py", line 456, in unpack_http_url
    unpack_file(temp_location, location, content_type, link)
  File "/data/develop/nikola/env/local/lib/python2.7/site-packages/pip-1.1-py2.7.egg/pip/util.py", line 505, in unpack_file
    raise InstallationError('Cannot determine archive format of %s' % location)
InstallationError: Cannot determine archive format of /tmp/pip-htsLAd-build
