### PR TITLE
Created listing.tmpl template for jinja_default theme

### DIFF
--- a/nikola/data/themes/jinja-default/templates/listing.tmpl
+++ b/nikola/data/themes/jinja-default/templates/listing.tmpl
@@ -1,0 +1,9 @@
+{% extends "base.tmpl" %}
+{% block content %}
+<ul class="breadcrumb">
+    {% for link, crumb in crumbs %}
+        <li><a href="{{link}}">/ {{crumb}}</a></li>
+    {% endfor %}
+</ul>
+{{code}}
+{% endblock %}


### PR DESCRIPTION
After i copied jinja_default and broke inheritance of the default theme, doit coughed for a missing listing.tmpl template. 
