### PR TITLE
Updated german translation

### DIFF
--- a/nikola/data/themes/default/messages/de.py
+++ b/nikola/data/themes/default/messages/de.py
@@ -16,4 +16,6 @@ MESSAGES = {
     u"&larr; Previous post": u"&larr; Vorheriger Eintrag",
     u"Next post &rarr;": u"N&auml;chster Eintrag &rarr;",
     u"Source": u"Source",
+    u"Read more": u"Weiterlesen",
+    u"old posts page %d": u'Vorherige Eintr&auml;ge %d'
 }

--- a/nikola/data/themes/default/messages/localization_tests.py
+++ b/nikola/data/themes/default/messages/localization_tests.py
@@ -1,0 +1,13 @@
+import unittest
+
+import de
+import en
+
+class TranslationsTest(unittest.TestCase):
+    def test_de(self):
+        for message in en.MESSAGES:
+            self.assertIn(message, de.MESSAGES, '"%s" was not found in the translation de.py.' % (message, ))
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Updated the german translation.

Added a small testcase to make sure that no translation in de.py is missing.
For now this is just in the messages folder but I think this should be put somewhere else. Has https://github.com/ralsina/nikola/issues/45 brought up a default place for tests yet?

Background with this is that I used `import_wordpress` and when I tried to `build` it crashed because of the missing translations.
