### PR TITLE
re-write README on generated site

### DIFF
--- a/nikola/data/samplesite/README.txt
+++ b/nikola/data/samplesite/README.txt
@@ -1,31 +1,20 @@
-How To make This Work
----------------------
+This folder contains the source used to generate a static site by nikola.
 
-The full manual is in stories/manual.txt, but here is the very short version:
+Installation and documentation at http://nikola.ralsina.com.ar
 
-1. Install docutils (http://docutils.sourceforge.net)
-2. Install Mako (http://makotemplates.org)
-3. Install doit (http://python-doit.sourceforge.net)
-4. Install PIL (http://www.pythonware.com/products/pil/)
-5. Install Pygments (http://pygments.org/)
-6. Install unidecode (http://pypi.python.org/pypi/Unidecode/)
-7. Install lxml (http://lxml.de/)
+Configuration file for the site is `conf.py`.
 
-To build or update the demo site run this command in the nikola's folder::
+To build the site::
 
-    doit
+    nikola build
 
 To see it::
 
-    doit serve -p 8000
+    nikola serve
 
 And point your browser to http://localhost:8000
 
-Notes on Requirements
----------------------
 
-If you don't have PIL, then image galleries will be inefficient because Nikola
-will not generate thumbnails. Alternatively, you may install pillow instead of
-PIL.
+To check all available commands::
 
-If you don't have pygments, the code-block directive will not highlight syntax.
+    nikola help


### PR DESCRIPTION
README was outdated showing to use "doit"

I ended up rewriting it... because i dont see much value including installation instructions here,
and it will always be out-dated :).

I guess this file will be read in 2 cases.

1) the user who just created the site 
  -> give info on basic commands: build, serve. and point to conf.py

2) a user who finds this folder and have no idea how the content is generated.
  -> direct him to nikola homepage. at this point the included docs where probably already removed...
