### PR TITLE
Prefer setuptools over distribute when installing.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,22 @@ import os
 import subprocess
 import sys
 from fnmatch import fnmatchcase
-from distutils.util import convert_path
-from distutils.command.install import install
+
+
+try:
+    # Prefer setuptools for the installation to have no problem with the
+    # "--single-version-externally-managed" option that pip uses when 
+    # installing packages.
+    from setuptools import setup
+    from setuptools import convert_path 
+
+    from setuptools.command.install import install
+except ImportError:
+    print '\n*** setuptools not found! Falling back to distutils\n\n'
+    from distutils.core import setup
+
+    from distutils.command.install import install
+    from distutils.util import convert_path
 
 dependencies = [
     'doit>=0.18.1',


### PR DESCRIPTION
This fixes https://github.com/ralsina/nikola/issues/184 at least for me.
It seems to be a problem with `distribute`.

Inspiration for this is taken from https://github.com/afflux/pure-python-otr/commit/a494434c645b8240700fc033c1dad04955db9f76
