### PR TITLE
Do not show an 'unknown command' message when invoking nikola without arguments

### DIFF
--- a/scripts/nikola
+++ b/scripts/nikola
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     site = nikola.Nikola(**config)
 
     if len(sys.argv) < 2:
-        sys.argv[1:] = 'help'
+        sys.argv.append('help')
     cmd_name = sys.argv[1]
 
     if cmd_name in ("help", "--help", "-h"):


### PR DESCRIPTION
Calling 'nikola' without an option should show the help.
Right now it work but also shows an message "Unknown command: h" because the way the "help" is appended makes sys.argv look like ['nikola', 'h', 'e', 'l', 'p'].
This can be seen in the output on https://travis-ci.org/okin/nikola/jobs/3815662

This fixes this and does not show unknown command message.
