### PR TITLE
Fixed for install_theme error:  "TypeError: unicode argument expected" 

### DIFF
--- a/nikola/plugins/command_install_theme.py
+++ b/nikola/plugins/command_install_theme.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 from optparse import OptionParser
 import os
 import json
-from io import StringIO
+from io import BytesIO
 
 try:
     import requests
@@ -84,7 +84,7 @@ class CommandInstallTheme(Command):
                     except:
                         raise OSError("mkdir 'theme' error!")
                 print('Downloading: %s' % data[name])
-                zip_file = StringIO()
+                zip_file = BytesIO()
                 zip_file.write(requests.get(data[name]).content)
                 print('Extracting: %s into themes' % name)
                 utils.extract_all(zip_file)

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -345,21 +345,21 @@ class UnsafeZipException(Exception):
 def extract_all(zipfile):
     pwd = os.getcwd()
     os.chdir('themes')
-    z = list(zip(zipfile))
-    namelist = z.namelist()
-    for f in namelist:
-        if f.endswith('/') and '..' in f:
-            raise UnsafeZipException(
-                'The zip file contains ".." and is not safe to expand.')
-    for f in namelist:
-        if f.endswith('/'):
-            if not os.path.isdir(f):
-                try:
-                    os.makedirs(f)
-                except:
-                    raise OSError("mkdir '%s' error!" % f)
-        else:
-            z.extract(f)
+    with zip(zipfile) as z:
+        namelist = z.namelist()
+        for f in namelist:
+            if f.endswith('/') and '..' in f:
+                raise UnsafeZipException(
+                    'The zip file contains ".." and is not safe to expand.')
+        for f in namelist:
+            if f.endswith('/'):
+                if not os.path.isdir(f):
+                    try:
+                        os.makedirs(f)
+                    except:
+                        raise OSError("mkdir '%s' error!" % f)
+            else:
+                z.extract(f)
     os.chdir(pwd)
 
 


### PR DESCRIPTION
Hi.  With Nikola 5.1, I got this error when attempting to use the `install_theme` command:

```
$ nikola install_theme -n blogtxt
Downloading: http://nikola.ralsina.com.ar/themes/blogtxt.zip
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/Current/bin/nikola", line 66, in <module>
    site.commands[cmd_name].run(*sys.argv[2:])
  File "/Library/Frameworks/Python.framework/Versions/Current/lib/python2.7/site-packages/nikola/plugins/command_install_theme.py", line 88, in run
    zip_file.write(requests.get(data[name]).content)
TypeError: unicode argument expected, got 'str'
```

This was on Mac OS X 10.8 with Python 2.7.3.  I built Nikola from source with the master branch, and reproduced the error.

Here's a pull request which fixed the error for me.  Thanks!
