### PR TITLE
Revert commit 798e4aa which inadvertantly broke link rewriting in wordpr...

### DIFF
--- a/nikola/plugins/command_import_wordpress.py
+++ b/nikola/plugins/command_import_wordpress.py
@@ -182,14 +182,17 @@ class CommandImportWordpress(Command):
         with open(filename, "wb+") as fd:
             doc = html.document_fromstring(content)
             doc.rewrite_links(replacer)
-            # Replace H1 elements with H2 elements
-            for tag in doc.findall('.//h1'):
-                if not tag.text:
-                    print("Failed to fix bad title: %r" %
-                          html.tostring(tag))
-                else:
-                    tag.getparent().replace(tag, builder.E.h2(tag.text))
+            for n in reversed(range(1,9)):
+                for tag in doc.findall('.//h%i' % n):
+                    if not tag.text:
+                        print("Failed to fix bad title: %r" %
+                              html.tostring(tag))
+                    else:
+                        tag.getparent().replace(tag,
+                                builder.E('h%i' % (n + 1), tag.text))
+
             fd.write(html.tostring(doc, encoding='utf8'))
+
 
     @staticmethod
     def write_metadata(filename, title, slug, post_date, description, tags):


### PR DESCRIPTION
Sorry about this one.
The second patch I submitted over the weekend breaks the worpress import command.
Relevant patch is 798e4aa61b8413750d1d005d2535666c9d7b81b8, and pull request #230.
