### PR TITLE
Enable post/stories in .html

### DIFF
--- a/nikola/plugins/task_render_sources.py
+++ b/nikola/plugins/task_render_sources.py
@@ -56,6 +56,9 @@ class Sources(Task):
                 output_name = os.path.join(kw['output_folder'],
                     post.destination_path(lang, post.source_ext()))
                 source = post.source_path
+                if source.endswith('.html'):
+                    print("Avoiting to render source of .html page")
+                    continue
                 if lang != kw["default_lang"]:
                     source_lang = source + '.' + lang
                     if os.path.exists(source_lang):


### PR DESCRIPTION
If you put an .html file in 'post' or 'stories' directory, when nikola builds it generate an ERROR because two diferent tasks has the same target: render_sources and render_pages
This pages avoids to copy _sources_ of .html pages.
