### PR TITLE
Correct some URLs in manual.txt

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -186,7 +186,7 @@ This is currently lacking on detail. Considering the niche Nikola is aimed at,
 I suspect that's not a problem yet. So, when I say "get", the specific details
 of how to "get" something for your specific operating system are left to you.
 
-The short version is: ``pip install https://github.com/ralsina/nikola/zipball/master``
+The short version is: ``pip install https://github.com/ralsina/nikola/archive/master.zip``
 
 Longer version:
 
@@ -206,7 +206,7 @@ Longer version:
       #. Get `Pygments <http://pygments.org/>`_
       #. Get `unidecode <http://pypi.python.org/pypi/Unidecode/>`_
       #. Get `lxml <http://lxml.de/>`_
-      #. Get `yapsy <http://yapsy.sourceforge.com>`_
+      #. Get `yapsy <http://yapsy.sourceforge.net>`_
       #. Get `configparser <http://pypi.python.org/pypi/configparser/3.2.0r3>`_
 
 #. run ``python setup.py install``


### PR DESCRIPTION
The URLs for Nikola's zipball at github and yapsy were wrong

Signed-off-by: Stefan Naewe stefan.naewe@gmail.com
