### PR TITLE
Sort tags case insensitive.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,7 @@ Features
 * Using the filename as slug if no slug is found in the metadata.
 * Make it possible to extract metadata from filename by using regexp.
 * When using import_wordpress users can exclude drafts with the ``-d`` switch.
+* Sort tags case insensitive.
 
 Bugfixes
 --------

--- a/nikola/plugins/task_render_tags.py
+++ b/nikola/plugins/task_render_tags.py
@@ -106,7 +106,8 @@ class RenderTags(Task):
     def list_tags_page(self, kw):
         """a global "all your tags" page for each language"""
         tags = list(self.site.posts_per_tag.keys())
-        tags.sort()
+        # We want our tags to be sorted case insensitive
+        tags.sort(cmp=lambda x, y: cmp(x.lower(), y.lower()))
         template_name = "tags.tmpl"
         kw['tags'] = tags
         for lang in kw["translations"]:


### PR DESCRIPTION
Tags we're sortet in a way that first all tags starting with an uppercase letter came and after all uppercase letters the lowercase letters came.

It kind of confused me so here is my approach on doing it better by sorting the tags case insensitive.
