### PR TITLE
Added support to generate a naive ipynb and fixed README.

### DIFF
--- a/extra_plugins/compile_ipynb/README.txt
+++ b/extra_plugins/compile_ipynb/README.txt
@@ -17,6 +17,17 @@ post_pages = (
 
 in your conf.py
 
+Then... to use it:
+
+$nikola new_page -f ipynb
+
+**NOTE**: DO NOT use the -2 option in nikola new_page, by default this compiler 
+create one metadata file and the corresponding naive IPython notebook.
+
+$nikola build
+
+And deploy the output folder... to see it locally: $nikola serve
+
 If you have any doubts, just ask: @damianavila
 
 Cheers.

--- a/extra_plugins/compile_ipynb/__init__.py
+++ b/extra_plugins/compile_ipynb/__init__.py
@@ -24,6 +24,7 @@
 
 """Implementation of compile_html based on nbconvert."""
 
+from __future__ import unicode_literals, print_function
 import codecs
 import os
 
@@ -61,14 +62,35 @@ class CompileIPynb(PageCompiler):
         d_name = os.path.dirname(path)
         if not os.path.isdir(d_name):
             os.makedirs(os.path.dirname(path))
-        with codecs.open(path, "wb+", "utf8") as fd:
+        meta_path = os.path.join(d_name, slug + ".meta")
+        with codecs.open(meta_path, "wb+", "utf8") as fd:
             if onefile:
-                fd.write('<!-- \n')
-                fd.write('.. title: %s\n' % title)
-                fd.write('.. slug: %s\n' % slug)
-                fd.write('.. date: %s\n' % date)
-                fd.write('.. tags: %s\n' % tags)
-                fd.write('.. link: \n')
-                fd.write('.. description: \n')
-                fd.write('-->\n\n')
-            fd.write("\nWrite your post here.")
+                fd.write('%s\n' % title)
+                fd.write('%s\n' % slug)
+                fd.write('%s\n' % date)
+                fd.write('%s\n' % tags)
+        print("Your post's metadata is at: ", meta_path)
+        with codecs.open(path, "wb+", "utf8") as fd:
+            fd.write(
+"""{
+ "metadata": {
+  "name": "%s"
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}""" % slug)


### PR DESCRIPTION
I made some changes to make more easy to integrate the work with Nikola and IPython.
Now, when you call:

```
$nikola new_post -f ipynb
```

Nikola will write two files: a meta file and a **naive** ipynb with the proper title. This one can be modified by IPython just starting the notebook in the post folder.

Abrazo.

Damián.
