### PR TITLE
Add vimeo rst directive with doco

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -783,6 +783,26 @@ Once you have that, all you need to do is::
 
     .. youtube:: 8N_tupPBtWQ
 
+Vimeo
+~~~~~~~
+
+To link to a vimeo video, you need the id of the video. For example, if the
+URL of the video is http://www.vimeo.com/20241459 then the id is **20241459**
+
+Once you have that, all you need to do is::
+
+    .. vimeo:: 20241459
+
+If you are running python 2.6 or later, or have the json module installed and
+have internet connectivity when generating your site, the height and width of
+the embedded player will be set to the native height and width of the video.
+You can override this if you wish::
+
+    .. vimeo:: 20241459
+        height=240
+        width=320
+
+
 code-block
 ~~~~~~~~~~
 

--- a/nikola/plugins/compile_rest/__init__.py
+++ b/nikola/plugins/compile_rest/__init__.py
@@ -38,6 +38,8 @@ directives.register_directive('listing', listings_directive)
 
 from .youtube import youtube
 directives.register_directive('youtube', youtube)
+from .vimeo import vimeo
+directives.register_directive('vimeo', vimeo)
 from .slides import slides
 directives.register_directive('slides', slides)
 from .gist_directive import GitHubGist

--- a/nikola/plugins/compile_rest/vimeo.py
+++ b/nikola/plugins/compile_rest/vimeo.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2012 Roberto Alsina y otros.
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+import urllib2
+
+try:
+    import json # python 2.6 or higher
+except ImportError:
+    json = None
+
+CODE = """\
+<iframe src="http://player.vimeo.com/video/%(vimeo_id)s"
+ width="%(width)s" height="%(height)s"
+frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen>
+</iframe>
+"""
+
+VIDEO_DEFAULT_HEIGHT=500
+VIDEO_DEFAULT_WIDTH=281
+
+def vimeo(name, args, options, content, lineno,
+            contentOffset, blockText, state, stateMachine):
+    """ Restructured text extension for inserting vimeo embedded videos """
+    if len(content) == 0:
+        return
+
+    string_vars = {
+        'vimeo_id': content[0],
+        }
+    extra_args = content[1:]  # Because content[0] is ID
+    extra_args = [ea.strip().split("=") for ea in extra_args]  # key=value
+    extra_args = [ea for ea in extra_args if len(ea) == 2]  # drop bad lines
+    extra_args = dict(extra_args)
+    if 'width' in extra_args:
+        string_vars['width'] = extra_args.pop('width')
+    if 'height' in extra_args:
+        string_vars['height'] = extra_args.pop('height')
+
+    # Only need to make a connection if width and height aren't provided
+    if 'height' not in string_vars or 'width' not in string_vars:
+        string_vars['height'] = VIDEO_DEFAULT_HEIGHT
+        string_vars['width'] = VIDEO_DEFAULT_WIDTH
+
+        if json: # we can attempt to retrieve video attributes from vimeo
+            try:
+                u = urllib2.urlopen('http://vimeo.com/api/v2/video/%(vimeo_id)s.json' %
+                                    string_vars)
+                video_attributes = json.load(u)[0]
+                u.close()
+                string_vars['height'] = video_attributes['height']
+                string_vars['width'] = video_attributes['width']
+            except (urllib2.URLError, urllib2.HTTPError):
+                # fall back to the defaults
+                pass
+
+    return [nodes.raw('', CODE % string_vars, format='html')]
+
+vimeo.content = True
+directives.register_directive('vimeo', vimeo)


### PR DESCRIPTION
I created a vimeo rst directive based on the existing youtube directive, but added the ability to automatically find the video height and width from the vimeo API. When I added the doco I added an example with parameters, which should also give people hints when using the youtube directive.

I wasn't sure which version of python you are targetting, so the API call will only work with python 2.6 (it requires the json module) but it will silently fall back to default size if json is unavailable. I tried to keep the coding style as close as I could to what I've seen in the project.

Comments welcome
