### PR TITLE
Fix gallery folder links broke on Windows, replace os.sep with "/".

### DIFF
--- a/nikola/plugins/task_render_galleries.py
+++ b/nikola/plugins/task_render_galleries.py
@@ -126,8 +126,8 @@ class Galleries(Task):
                 pass
 
             # List of sub-galleries
-            folder_list = [x.split(os.sep)[-2] + os.sep for x in
-                           glob.glob(os.path.join(gallery_path, '*') + os.sep)]
+            folder_list = [x.split(os.sep)[-2] + "/" for x in
+                           glob.glob(os.path.join(gallery_path, '*') + "/")]
 
             crumbs = gallery_path.split(os.sep)[:-1]
             crumbs.append(os.path.basename(gallery_name))


### PR DESCRIPTION
On Windows, os.sep is "\", not "/", so for example, galleires/demo generate a link "/demo%5c", and this commit fixes it into "/demo/".
