### PR TITLE
Travis refinements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
 script:
  - nosetests --with-doctest
  - nikola help
- - "flake8 nikola"
+ - "flake8 --exit-zero nikola"


### PR DESCRIPTION
Removing flake8 as a dependency from requirements files because we don't run it on travis.
Now running the nikola command with the help argument because without we just get an error.
