### PR TITLE
Re-enabling unicode literals as default.

### DIFF
--- a/nikola/plugins/task_render_tags.py
+++ b/nikola/plugins/task_render_tags.py
@@ -22,7 +22,7 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#from __future__ import unicode_literals
+from __future__ import unicode_literals
 import codecs
 import json
 import os


### PR DESCRIPTION
Without this I wasn't able to correctly render the tag pages because when they did contain unicode.
