### PR TITLE
Implement ReSTExtensionTestCase.assertIn() for 2.6

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,58 @@
+# coding: utf8
+# Author: Rodrigo Bistolfi
+# Date: 03/2013
+
+
+""" Base class for Nikola test cases """
+
+
+__all__ = ["BaseTestCase"]
+
+
+import sys
+import unittest
+
+
+if sys.version_info < (2, 7):
+
+    try:
+        import unittest2
+        _unittest2 = True
+    except ImportError:
+        _unittest2 = False
+
+    if _unittest2:
+        BaseTestCase = unittest2.TestCase
+
+    else:
+
+        class BaseTestCase(unittest.TestCase):
+            """ Base class for providing 2.6 compatibility """
+
+            def assertIs(self, first, second, msg=None):
+                self.assertTrue(first is second)
+
+            def assertIsNot(self, first, second, msg=None):
+                self.assertTrue(first is not second)
+
+            def assertIsNone(self, expr, msg=None):
+                self.assertTrue(expr is None)
+
+            def assertIsNotNone(self, expr, msg=None):
+                self.assertTrue(expr is not None)
+
+            def assertIn(self, first, second, msg=None):
+                self.assertTrue(first in second)
+
+            def assertNotIn(self, first, second, msg=None):
+                self.assertTrue(first not in second)
+
+            def assertIsInstance(self, obj, cls, msg=None):
+                self.assertTrue(isinstance(obj, cls))
+
+            def assertNotIsInstance(self, obj, cls, msg=None):
+                self.assertFalse(isinstance(obj, cls))
+
+
+else:
+    BaseTestCase = unittest.TestCase

--- a/tests/test_rst_extensions.py
+++ b/tests/test_rst_extensions.py
@@ -38,9 +38,10 @@ from docutils.core import publish_parts
 import unittest
 import nikola.plugins.compile_rest
 from nikola.utils import _reload
+from base import BaseTestCase
 
 
-class ReSTExtensionTestCase(unittest.TestCase):
+class ReSTExtensionTestCase(BaseTestCase):
     """ Base class for testing ReST extensions """
 
     sample = None
@@ -71,14 +72,6 @@ class ReSTExtensionTestCase(unittest.TestCase):
                 self.assertTrue(arg_attrs.issubset(tag_attrs))
             if text:
                 self.assertIn(text, tag.text)
-
-    def assertIn(self, member, container, msg=None):
-        """ Missing in 2.6. Uses TestCase.assertIn if present """
-        parent = super(ReSTExtensionTestCase, self)
-        try:
-            parent.assertIn(member, container, msg=msg)
-        except AttributeError:
-            self.assertTrue(member in container)
 
 
 class ReSTExtensionTestCaseTestCase(ReSTExtensionTestCase):


### PR DESCRIPTION
Fixes build in Python 2.6
