### PR TITLE
Avoid #391

### DIFF
--- a/nikola/plugins/command_import_wordpress.py
+++ b/nikola/plugins/command_import_wordpress.py
@@ -101,7 +101,8 @@ class CommandImportWordpress(Command):
 
         options['filename'] = args.pop(0)
 
-        if args and options['output_folder'] == 'new_site':
+        if args and ('output_folder' not in args or
+                     options['output_folder'] == 'new_site'):
             options['output_folder'] = args.pop(0)
 
         if args:


### PR DESCRIPTION
The problem that occured at https://github.com/ralsina/nikola/issues/391 was placing an option after the filename. The second argument is treated as the folder to import to because of backwards compatibility reasons.

While this approach won't fix exactly the case of #391 it should warn users about a `misplacement` of the options.
