### PR TITLE
Add nikola.bat for setup on Windows.

### DIFF
--- a/scripts/nikola.bat
+++ b/scripts/nikola.bat
@@ -1,0 +1,2 @@
+@echo off
+python "%~dpn0" %*

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,17 @@ dependencies = [
     'pytz',
 ]
 
+########### platform specific stuff #############
+import platform
+platform_system = platform.system()
+
+scripts = ['scripts/nikola']
+# platform specific scripts
+if platform_system == "Windows":
+    scripts.append('scripts/nikola.bat')
+
+##################################################
+
 if sys.version_info[0] == 2:
     # in Python 3 this becomes a builtin, for Python 2 we need the backport
     dependencies.append('configparser')
@@ -196,7 +207,7 @@ setup(name='Nikola',
                 'nikola.plugins.compile_markdown',
                 'nikola.plugins.task_sitemap',
                 'nikola.plugins.compile_rest'],
-      scripts=['scripts/nikola'],
+      scripts=scripts,
       install_requires=dependencies,
       package_data=find_package_data(),
       cmdclass={'install': nikola_install},


### PR DESCRIPTION
Add nikola.bat for Windows users, otherwise the command 'nikola' will not be found in Windows' command line.
