### PR TITLE
Fixed TemplateSyntaxError when using jinja-default template

### DIFF
--- a/nikola/data/themes/jinja-default/templates/post.tmpl
+++ b/nikola/data/themes/jinja-default/templates/post.tmpl
@@ -3,7 +3,7 @@
 {% if post.meta('keywords') %}
     <meta name="keywords" content="{{post.meta('keywords')}}"/>
 {% endif %}
-{% block %}
+{% endblock %}
 {% block content %}
     <div class="postbox">
     <h1><a href='{{permalink}}'>{{title}}</a></h1>


### PR DESCRIPTION
The `jinja-default` template has a missing `%}` in `post.tmpl` - which causes a
`TemplateSyntaxError: expected token 'end of statement block', got 'href'` when doing a build using this theme.

There's also a missing endblock on line 6 which I just found, which wasn't in the version of this theme from 5.4.4, where I found the other issue.

This fixes them, allowing you to actually use that theme.
