### PR TITLE
Make the nikola script work with Buildout 2.1.0

### DIFF
--- a/scripts/nikola
+++ b/scripts/nikola
@@ -2,7 +2,6 @@
 
 """Nikola main script."""
 
-from __future__ import print_function
 import os
 import sys
 


### PR DESCRIPTION
Buildout generates scripts with patches to insert the locations of required eggs into sys.path.

The `__future__` import of `print_function` ends up in the middle of the
script generated by Buildout, and causes errors at execution time. This can be seen in [the resulting script file](https://gist.github.com/kamitchell/5477735).

Since there are no print statements in this file, the `__future__` import
isn't necessary, so its removal should not cause any problems.

There's a pending fix on Buildout's end as their pull request buildout/buildout#112, but it hasn't made it to a release yet.
