### PR TITLE
ENH: Allow posts to be scheduled in the future.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -663,6 +663,7 @@ class Nikola(object):
         tzinfo = None
         if self.config['TIMEZONE'] is not None:
             tzinfo = pytz.timezone(self.config['TIMEZONE'])
+        current_time = utils.current_time(tzinfo)
         targets = set([])
         for wildcard, destination, template_name, use_in_feeds in \
                 self.config['post_pages']:
@@ -698,6 +699,7 @@ class Nikola(object):
                         self.config['STRIP_INDEXES'],
                         self.config['INDEX_FILE'],
                         tzinfo,
+                        current_time,
                         self.config['HIDE_UNTRANSLATED_POSTS'],
                         self.config['PRETTY_URLS'],
                     )

--- a/nikola/plugins/task_localsearch/__init__.py
+++ b/nikola/plugins/task_localsearch/__init__.py
@@ -68,7 +68,7 @@ class Tipue(LateTask):
             for lang in kw["translations"]:
                 for post in posts:
                     # Don't index drafts (Issue #387)
-                    if post.is_draft or post.is_retired:
+                    if post.is_draft or post.is_retired or post.publish_later:
                         continue
                     text = post.text(lang, strip_html=True)
                     text = text.replace('^', '')

--- a/nikola/plugins/task_sitemap/__init__.py
+++ b/nikola/plugins/task_sitemap/__init__.py
@@ -94,7 +94,7 @@ class Sitemap(LateTask):
                         real_path = os.path.join(root, fname)
                         path = os.path.relpath(real_path, output)
                         post = self.site.post_per_file.get(path)
-                        if post and (post.is_draft or post.is_retired):
+                        if post and (post.is_draft or post.is_retired or post.publish_later):
                             continue
                         path = path.replace(os.sep, '/')
                         lastmod = get_lastmod(real_path)

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -33,7 +33,7 @@ import string
 
 import lxml.html
 
-from .utils import to_datetime, slugify, bytes_str, Functionary, LocaleBorg
+from .utils import (to_datetime, slugify, bytes_str, Functionary, LocaleBorg)
 
 __all__ = ['Post']
 
@@ -48,7 +48,7 @@ class Post(object):
         self, source_path, cache_folder, destination, use_in_feeds,
         translations, default_lang, base_url, messages, template_name,
         file_metadata_regexp=None, strip_indexes=False, index_file='index.html',
-        tzinfo=None, skip_untranslated=False, pretty_urls=False,
+        tzinfo=None, current_time=None, skip_untranslated=False, pretty_urls=False,
     ):
         """Initialize post.
 
@@ -114,6 +114,8 @@ class Post(object):
         # If timezone is set, build localized datetime.
         self.date = to_datetime(self.meta[default_lang]['date'], tzinfo)
 
+        self.publish_later = False if current_time is None else self.date >= current_time
+
         is_draft = False
         is_retired = False
         self._tags = {}
@@ -130,7 +132,8 @@ class Post(object):
         # While draft comes from the tags, it's not really a tag
         self.is_draft = is_draft
         self.is_retired = is_retired
-        self.use_in_feeds = use_in_feeds and not is_draft and not is_retired
+        self.use_in_feeds = use_in_feeds and not is_draft and not is_retired \
+            and not self.publish_later
 
         # If mathjax is a tag, then enable mathjax rendering support
         self.is_mathjax = 'mathjax' in self.tags

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -434,6 +434,13 @@ def to_datetime(value, tzinfo=None):
     raise ValueError('Unrecognized date/time: {0!r}'.format(value))
 
 
+def current_time(tzinfo=None):
+    dt = datetime.datetime.now()
+    if tzinfo is not None:
+        dt = tzinfo.localize(dt)
+    return dt
+
+
 def apply_filters(task, filters):
     """
     Given a task, checks its targets.


### PR DESCRIPTION
Adds the feature of scheduling posts to be published in future.  Of
course, this would need the site to be built and deployed for the new
pages to show up.
