### PR TITLE
Update task_render_galleries.py based on Issue #489

### DIFF
--- a/nikola/plugins/task_render_galleries.py
+++ b/nikola/plugins/task_render_galleries.py
@@ -31,14 +31,9 @@ import os
 
 Image = None
 try:
-    import Image as _Image
-    import ExifTags
-    Image = _Image
+    from PIL import Image, ExifTags  # NOQA
 except ImportError:
-    try:
-        from PIL import Image, ExifTags  # NOQA
-    except ImportError:
-        pass
+    pass
 
 
 from nikola.plugin_categories import Task


### PR DESCRIPTION
This will prevent the IOError which occurs because of importing the image module which is not from PIL as mentioned in issue #489
