### PR TITLE
Fixed Jinja dependency scanning with dynamic deps

### DIFF
--- a/nikola/plugins/template_jinja.py
+++ b/nikola/plugins/template_jinja.py
@@ -90,7 +90,8 @@ class JinjaTemplates(TemplateSystem):
                 ast = self.lookup.parse(source)
                 dep_names = meta.find_referenced_templates(ast)
                 for dep_name in dep_names:
-                    if dep_name not in visited_templates:
+                    if (dep_name not in visited_templates
+                            and dep_name is not None):
                         visited_templates.add(dep_name)
                         queue.append(dep_name)
             self.dependency_cache[template_name] = deps


### PR DESCRIPTION
I realized today that I forgot to handle a specific case in my yesterday's patch.

If a Jinja template contains an include or extends with a variable instead
of a constant string, find_referenced_templates yields None for that
dependency. This could cause the dependency scanning algorithm to crash.
