### PR TITLE
Fix sitemap links for sites in subdirectories

### DIFF
--- a/nikola/plugins/task_sitemap/__init__.py
+++ b/nikola/plugins/task_sitemap/__init__.py
@@ -54,16 +54,16 @@ get_lastmod = lambda p: datetime.datetime.fromtimestamp(os.stat(p).st_mtime).iso
 
 
 def get_base_path(base):
-    """returns the path of a base URL if it contains one.
+    u"""returns the path of a base URL if it contains one.
 
-    >>> get_base_path('http://some.site')
-    u'/'
-    >>> get_base_path('http://some.site/')
-    u'/'
-    >>> get_base_path('http://some.site/some/sub-path')
-    u'/some/sub-path/'
-    >>> get_base_path('http://some.site/some/sub-path/')
-    u'/some/sub-path/'
+    >>> get_base_path('http://some.site') == '/'
+    True
+    >>> get_base_path('http://some.site/') == '/'
+    True
+    >>> get_base_path('http://some.site/some/sub-path') == '/some/sub-path/'
+    True
+    >>> get_base_path('http://some.site/some/sub-path/') == '/some/sub-path/'
+    True
     """
     # first parse the base_url for some path
     base_parsed = urlparse(base)
@@ -152,3 +152,7 @@ class Sitemap(LateTask):
             "task_dep": ["render_site"],
         }
         yield task
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
This PR fixes the bug which causes sitemap to render incorrectly for sites in subdirectories.

For http://some.site/somedir, the links are rendered as:
`http://some.site/some-link.html` instead of `http://some.site/somedir/some-link.html`
this PR fixes this

Any suggestions on strategy to write tests for this ?
