### PR TITLE
Fix to delete saved ipynb from the list of files to be render.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -676,7 +676,7 @@ class Nikola(object):
                         full_list.append(orig_name)
                 # We eliminate from the list the files inside any .ipynb folder
                 full_list = [p for p in full_list \
-                        if not ".ipynb_checkpoints" in p.split("/")]
+                        if not any([x.startswith('.') for x in p.split(os.sep)])]
 
                 for base_path in full_list:
                     post = Post(


### PR DESCRIPTION
A little hack to avoid problems with the saved ipynb files inside a hidden folder called ipynb_checkpoints (yes IPython write _states_ of the notebook in a hidden folder to _save_ the the current notebook).
Nikola tries to render, but this folder is garbage at the time of render the posts. So, I _clean_ any occurrence of files living inside .ipynb_checkpoints folders, from the `full_list` containing the sources files of the posts.

Cheers

Damián.
