### PR TITLE
Add Alternative to inject Add_this service into template

### DIFF
--- a/docs/creating-a-theme.txt
+++ b/docs/creating-a-theme.txt
@@ -94,7 +94,7 @@ The general page layout for the theme is done by the ``base.tmpl`` template, whi
                 ${html_sidebar_links()}
                 <li>${search_form}
                 </ul>
-        ${add_this}
+        ${social_buttons_code}
         ${analytics}
         <script type="text/javascript">jQuery("a.image-reference").colorbox({rel:"gal",maxWidth:"80%",maxHeight:"80%",scalePhotos:true});</script>
     </body>

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -660,10 +660,10 @@ Analytics
     a Google analytics snippet or something similar, but you can really put anything
     there.
 
-Add_this
-    The ``ADD_THIS_DATA`` option lets you define a HTML snippet that will be added
-    at the bottom of body. The main usage is a Add this snippet or something similar,
-    but you can really put anything there.
+Social_buttons_code
+    The ``SOCIAL_BUTTONS_CODE`` option lets you define a HTML snippet that will be added
+    at the bottom of body. It could be used to add snippet for AddThis, but you can
+    really put anything there.
 
 
 Adding Files

--- a/docs/theming.txt
+++ b/docs/theming.txt
@@ -146,7 +146,7 @@ base.tmpl
       * ``license`` a larger license badge
       * ``analytics`` google scripts, or any JS you want to tack at the end of the body
         of the page.
-      * ``add_this`` add_this scripts, or any JS you want to tack at the end of the body
+      * ``social_buttons_code`` scripts, or any JS you want to tack at the end of the body
         of the page.
       * ``disqus_forum``: a `Disqus <http://disqus.com>`_ ID you can use to enable comments.
 

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -361,9 +361,9 @@ CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
 # Defaults to true
 # ADD_THIS_BUTTONS = True
 
-# Content of the Add_this code, customize it to fit your needs
+# Content of the AddThis code, customize it to fit your needs
 # Visit addthis.com to generate code samples
-# ADD_THIS_DATA = """
+# SOCIAL_BUTTONS_CODE = """
 # <!-- Social buttons -->
 # <div id="addthisbox" class="addthis_toolbox addthis_peekaboo_style addthis_default_style addthis_label_style addthis_32x32_style">
 # <a class="addthis_button_more">Share</a>
@@ -379,7 +379,7 @@ CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
 #
 # Add it to GLOBAL_CONTEXT as follow:
 # GLOBAL_CONTEXT = {
-#     'add_this': ADD_THIS_DATA,
+#     'social_buttons_code': SOCIAL_BUTTONS_CODE,
 # }
 
 # Hide link to source for the posts?

--- a/nikola/data/samplesite/stories/configsample.rst
+++ b/nikola/data/samplesite/stories/configsample.rst
@@ -185,9 +185,9 @@
             <!-- End of Google Analytics -->
         """
 
-    # Content of the Add_this code, customize it to fit your needs
+    # Content of the AddThis code, customize it to fit your needs
     # Visit addthis.com to generate code samples
-    ADD_THIS_DATA = """
+    SOCIAL_BUTTONS_CODE = """
     <!-- Social buttons -->
     <div id="addthisbox" class="addthis_toolbox addthis_peekaboo_style addthis_default_style addthis_label_style addthis_32x32_style">
     <a class="addthis_button_more">Share</a>
@@ -205,7 +205,7 @@
     # It can be anything, data, functions, modules, etc.
     GLOBAL_CONTEXT = {
         'analytics': ANALYTICS,
-        'add_this': ADD_THIS_DATA,
+        'social_buttons_code': SOCIAL_BUTTONS_CODE,
         'blog_title': BLOG_TITLE,
         'blog_url': BLOG_URL,
         'translations': TRANSLATIONS,

--- a/nikola/data/themes/default/templates/base.tmpl
+++ b/nikola/data/themes/default/templates/base.tmpl
@@ -45,7 +45,7 @@ ${set_locale(lang)}
             <ul class="unstyled">
             <li>${license}
             ${base_helper.html_social()}
-            ${add_this}
+            ${social_buttons_code}
             ${base_helper.html_sidebar_links()}
             <li>${search_form}
             </ul>
@@ -56,7 +56,7 @@ ${set_locale(lang)}
     </div>
 </div>
     ${base_helper.late_load_js()}
-    ${add_this}
+    ${social_buttons_code}
     ${analytics}
     <script type="text/javascript">jQuery("a.image-reference").colorbox({rel:"gal",maxWidth:"100%",maxHeight:"100%",scalePhotos:true});</script>
     <%block name="extra_js"></%block>

--- a/nikola/data/themes/jinja-default/templates/base.tmpl
+++ b/nikola/data/themes/jinja-default/templates/base.tmpl
@@ -54,7 +54,7 @@
     </div>
 </div>
     {{ base_helper.late_load_js() }}
-    {{ add_this }}
+    {{ social_buttons_code }}
     {{ analytics }}
     <script type="text/javascript">jQuery("a.image-reference").colorbox({rel:"gal",maxWidth:"80%",maxHeight:"80%",scalePhotos:true});</script>
     {% block extra_js %}

--- a/nikola/data/themes/jinja-site/templates/base.tmpl
+++ b/nikola/data/themes/jinja-site/templates/base.tmpl
@@ -63,7 +63,7 @@
 </div>
 {{ base_helper.html_social() }}
 {{ base_helper.late_load_js() }}
-{{ add_this }}
+{{ social_buttons_code }}
 {{ analytics }}
     <script type="text/javascript">jQuery("a.image-reference").colorbox({rel:"gal",maxWidth:"80%",maxHeight:"80%",scalePhotos:true});</script>
     {% block extra_js %}

--- a/nikola/data/themes/monospace/templates/base.tmpl
+++ b/nikola/data/themes/monospace/templates/base.tmpl
@@ -41,7 +41,7 @@ ${set_locale(lang)}
             ${content_footer}
         </div>
     </div>
-    ${add_this}
+    ${social_buttons_code}
     ${analytics}
     <%block name="extra_js"></%block>
 </body>

--- a/nikola/data/themes/orphan/templates/base.tmpl
+++ b/nikola/data/themes/orphan/templates/base.tmpl
@@ -33,7 +33,7 @@ ${set_locale(lang)}
             ${html_sidebar_links()}
             <li>${search_form}
             </ul>
-    ${add_this}
+    ${social_buttons_code}
     ${analytics}
     <%block name="extra_js"></%block>
 </body>

--- a/nikola/data/themes/site-reveal/templates/base.tmpl
+++ b/nikola/data/themes/site-reveal/templates/base.tmpl
@@ -73,7 +73,7 @@ ${html_reveal_body()}
 
 ${html_social()}
 ${late_load_js()}
-${add_this}
+${social_buttons_code}
 ${analytics}
     <script type="text/javascript">jQuery("a.image-reference").colorbox({rel:"gal",maxWidth:"80%",maxHeight:"80%",scalePhotos:true});</script>
     <%block name="extra_js"></%block>

--- a/nikola/data/themes/site/templates/base.tmpl
+++ b/nikola/data/themes/site/templates/base.tmpl
@@ -64,7 +64,7 @@ ${set_locale(lang)}
 </div>
 ${base_helper.html_social()}
 
-${add_this}
+${social_buttons_code}
 
 ${base_helper.late_load_js()}
 ${analytics}

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -100,7 +100,7 @@ class Nikola(object):
         self.config = {
             'ADD_THIS_BUTTONS': True,
             'ANALYTICS': '',
-            'ADD_THIS_DATA': '',
+            'SOCIAL_BUTTONS_CODE': '',
             'ARCHIVE_PATH': "",
             'ARCHIVE_FILENAME': "archive.html",
             'CACHE_FOLDER': 'cache',
@@ -301,7 +301,7 @@ class Nikola(object):
         self._GLOBAL_CONTEXT['blog_url'] = self.config.get('SITE_URL', self.config.get('BLOG_URL'))
         self._GLOBAL_CONTEXT['blog_desc'] = self.config.get('BLOG_DESCRIPTION')
         self._GLOBAL_CONTEXT['analytics'] = self.config.get('ANALYTICS')
-        self._GLOBAL_CONTEXT['add_this'] = self.config.get('ADD_THIS_DATA')
+        self._GLOBAL_CONTEXT['social_buttons_code'] = self.config.get('SOCIAL_BUTTONS_CODE')
         self._GLOBAL_CONTEXT['translations'] = self.config.get('TRANSLATIONS')
         self._GLOBAL_CONTEXT['license'] = self.config.get('LICENSE')
         self._GLOBAL_CONTEXT['search_form'] = self.config.get('SEARCH_FORM')

--- a/tests/data/translated_titles/conf.py
+++ b/tests/data/translated_titles/conf.py
@@ -344,9 +344,9 @@ CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
 # in the default template (base.tmpl).
 # ANALYTICS = ""
 
-# Add-this script or whatever else you use. Added to the bottom of <body>
+# HTML snippet that will be added at the bottom of body of <body>
 # in the default template (base.tmpl).
-# ADD_THIS_DATA = ""
+# SOCIAL_BUTTONS_CODE = ""
 
 # The possibility to extract metadata from the filename by using a
 # regular expression.


### PR DESCRIPTION
I know we killed mans for less than that, so if this is an other bad idea, sorry :)

The problem I see with html_social function:
- it seems to only be used for Add_this at the moment
- if you want to change the add_this code you have to rewrite the full template base_helper.html
- if you change the template you lose your add_this code
- not really neat if you want to keep the add_this code up to date

So I wonder if it won't make more sense to take the same approach used for the google analytic, and make this code live in the conf.py.

Here a pull-request to illustrate, if it's worth talking about it, I will continue on the patch.
