### PR TITLE
Add a FUTURE_IS_NOW option to publish future dated posts right away.

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -329,6 +329,9 @@ CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
 # to the metadata
 # PRETTY_URLS = False
 
+# Publish future dated posts right away instead of scheduling them
+# FUTURE_IS_NOW = True
+
 # Do you want a add a Mathjax config file?
 # MATHJAX_CONFIG = ""
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -153,6 +153,7 @@ class Nikola(object):
                 ("stories/*.txt", "stories", "story.tmpl", False),
             ),
             'PRETTY_URLS': False,
+            'FUTURE_IS_NOW': True,
             'READ_MORE_LINK': '<p class="more"><a href="{link}">{read_more}…</a></p>',
             'REDIRECTIONS': [],
             'RSS_LINK': None,
@@ -677,7 +678,10 @@ class Nikola(object):
         tzinfo = None
         if self.config['TIMEZONE'] is not None:
             tzinfo = pytz.timezone(self.config['TIMEZONE'])
-        current_time = utils.current_time(tzinfo)
+        if self.config['FUTURE_IS_NOW']:
+            current_time = None
+        else:
+            current_time = utils.current_time(tzinfo)
         targets = set([])
         for wildcard, destination, template_name, use_in_feeds in \
                 self.config['post_pages']:

--- a/nikola/plugins/task_render_posts.py
+++ b/nikola/plugins/task_render_posts.py
@@ -83,6 +83,9 @@ class RenderPosts(Task):
                     'clean': True,
                     'uptodate': [utils.config_changed(deps_dict)],
                 }
+                if post.publish_later:
+                    print('%s is scheduled to be published in the future (%s)'
+                           %(post.source_path, post.date))
                 if post.meta('password'):
                     task['actions'].append((wrap_encrypt, (dest, post.meta('password'))))
                 yield task

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -100,7 +100,7 @@ class DemoBuildTest(EmptyBuildTest):
         self.assertTrue('<loc>http://nikola.ralsina.com.ar/</loc>' in sitemap_data)
 
 
-class FuturePostTest(DemoBuildTest):
+class FuturePostTest(EmptyBuildTest):
     """Test a site with future posts."""
 
     def fill_site(self):
@@ -108,6 +108,11 @@ class FuturePostTest(DemoBuildTest):
         from nikola.utils import current_time
         self.init_command.copy_sample_site(self.target_dir)
         self.init_command.create_configuration(self.target_dir)
+
+        # Add the config option to allow future posts
+        with codecs.open(os.path.join(self.target_dir, 'conf.py'), "ab+", "utf8") as outf:
+            outf.write('\nFUTURE_IS_NOW = False\n')
+
         with codecs.open(os.path.join(self.target_dir, 'posts', 'empty1.txt'), "wb+", "utf8") as outf:
             outf.write(
                 ".. title: foo\n"


### PR DESCRIPTION
Also, print a message when post is ignored as scheduled to future.
The scheduling feature is turned off by default.

This PR addresses the concerns raised in #486
