### PR TITLE
Add options to toggle deploying drafts and future posts

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -557,11 +557,14 @@ Drafts
 
 If you add a "draft" tag to a post, then it will not be shown in indexes and feeds.
 It *will* be compiled, and if you deploy it it *will* be made available, so use
-with care.
+with care. If you wish your drafts to be not available in your deployed site, you
+can set ``DEPLOY_DRAFTS = False`` in your configuration.
 
 Also if a post has a date in the future, it will not be shown in indexes until you rebuild after
 that date. This behaviour can be disabled by setting ``FUTURE_IS_NOW = True`` in your
-configuration, which will make future posts be published immediately.
+configuration, which will make future posts be published immediately.  Posts dated in the future
+are *not* deployed by default (when ``FUTURE_IS_NOW = False``).  To make future posts available
+in the deployed site, you can set ``DEPLOY_FUTURE = True`` in your configuration.
 
 Retired Posts
 ~~~~~~~~~~~~~

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -333,6 +333,12 @@ CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
 # Defaults to False.
 # FUTURE_IS_NOW = False
 
+# If True, future dated posts are allowed in deployed output
+# Only the individual posts are published/deployed; not in indexes/sitemap
+# DEPLOY_FUTURE = False
+# If False, draft posts will not be deployed
+# DEPLOY_DRAFTS = True
+
 # Do you want a add a Mathjax config file?
 # MATHJAX_CONFIG = ""
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -183,6 +183,8 @@ class Nikola(object):
             'USE_CDN': False,
             'USE_FILENAME_AS_TITLE': True,
             'TIMEZONE': None,
+            'DEPLOY_DRAFTS': True,
+            'DEPLOY_FUTURE': False,
         }
 
         self.config.update(config)

--- a/nikola/plugins/command/deploy.py
+++ b/nikola/plugins/command/deploy.py
@@ -34,6 +34,7 @@ import time
 
 
 from nikola.plugin_categories import Command
+from nikola.utils import remove_file
 
 
 class Deploy(Command):
@@ -53,6 +54,19 @@ class Deploy(Command):
                   "And is probably not what you want to do.\n"
                   "Think about it for 5 seconds, I'll wait :-)\n\n")
             time.sleep(5)
+
+        deploy_drafts = self.site.config.get('DEPLOY_DRAFTS', True)
+        deploy_future = self.site.config.get('DEPLOY_FUTURE', False)
+        if not (deploy_drafts and deploy_future):
+            # Remove drafts and future posts
+            out_dir = self.site.config['OUTPUT_FOLDER']
+            self.site.scan_posts()
+            for post in self.site.timeline:
+                if (not deploy_drafts and post.is_draft) or \
+                   (not deploy_future and post.publish_later):
+                    remove_file(os.path.join(out_dir, post.destination_path()))
+                    remove_file(os.path.join(out_dir, post.source_path))
+
         for command in self.site.config['DEPLOY_COMMANDS']:
             try:
                 with open(timestamp_path, 'rb') as inf:


### PR DESCRIPTION
Future dated posts are not deployed, by default.  Drafts are deployed
by default, but this can be turned off by setting DEPLOY_DRAFTS to
False. Fixes #583.
