### PR TITLE
Check whether bootstrap_path exists at all

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -401,7 +401,7 @@ class Nikola(object):
             if self.config['USE_CDN']:
                 bootstrap_path = utils.get_asset_path(os.path.join(
                     'assets', 'css', 'bootstrap.min.css'), self._THEMES)
-                if bootstrap_path.split(os.sep)[-4] != 'site':
+                if bootstrap_path and bootstrap_path.split(os.sep)[-4] != 'site':
                     warnings.warn('The USE_CDN option may be incompatible with your theme, because it uses a hosted version of bootstrap.')
 
         return self._THEMES


### PR DESCRIPTION
If a theme doesn't provide bootstrap.min.css, bootstrap_path is None. If USE_CDN is set, the old code causes nikola try to check if a bootstrap.min.css is present, even if not necessary at all.
