### PR TITLE
Get mustache plugin working with new comment system

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -545,7 +545,7 @@ CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
 #     'planetoid',
 #     'ipynb',
 #     'local_search',
-#     'mustache',
+#     'render_mustache',
 # ]
 
 # List of regular expressions, links matching them will always be considered

--- a/nikola/data/themes/base/templates/mustache-comment-form.tmpl
+++ b/nikola/data/themes/base/templates/mustache-comment-form.tmpl
@@ -1,0 +1,5 @@
+## -*- coding: utf-8 -*-
+<%namespace name="comments" file="comments_helper.tmpl"/>
+% if not post.meta('nocomments'):
+    ${comments.comment_form(post.permalink(absolute=True), post.title(), post.base_path)}
+% endif

--- a/nikola/plugins/task/mustache/__init__.py
+++ b/nikola/plugins/task/mustache/__init__.py
@@ -105,25 +105,11 @@ class Mustache(Task):
                 post.date.strftime(self.site.GLOBAL_CONTEXT['date_format']),
             })
 
-            # Disqus comments
-            data["disqus_html"] = ('<div id="disqus_thread"></div> <script '
-                                   'type="text/javascript">var disqus_'
-                                   'shortname="%s";var disqus_url="%s";'
-                                   '(function(){var a=document.createElement'
-                                   '("script");a.type="text/javascript";'
-                                   'a.async=true;a.src="http://"+disqus_'
-                                   'shortname+".disqus.com/embed.js";('
-                                   'document.getElementsByTagName("head")'
-                                   '[0]||document.getElementsByTagName("body")'
-                                   '[0]).appendChild(a)})();        </script>'
-                                   '<noscript>Please enable JavaScript to view'
-                                   ' the <a href="http://disqus.com/'
-                                   '?ref_noscript">comments powered by DISQUS.'
-                                   '</a></noscript><a href="http://disqus.com"'
-                                   'class="dsq-brlink">comments powered by <sp'
-                                   'an class="logo-disqus">DISQUS</span></a>' %
-                                   (self.site.config['DISQUS_FORUM'],
-                                    post.permalink(absolute=True)))
+            # Comments
+            context = dict(post=post, lang=self.site.current_lang())
+            context.update(self.site.GLOBAL_CONTEXT)
+            data["comment_html"] = self.site.template_system.render_template(
+                'mustache-comment-form.tmpl', None, context).strip()
 
             # Post translations
             translations = []

--- a/nikola/plugins/task/mustache/mustache-template.html
+++ b/nikola/plugins/task/mustache/mustache-template.html
@@ -5,7 +5,7 @@
     <hr>
     <h2>{{title}}</h2>
     Posted on: {{date}}</br>
-    {{#tags?}} More posts about: 
+    {{#tags?}} More posts about:
     {{#tags}}<a class="tag" href={{link}}><span class="badge badge-info">{{name}}</span></a>{{/tags}}
     </br>
     {{/tags?}}
@@ -14,13 +14,13 @@
     {{{text}}}
     <ul class="pager">
     {{#prev}}
-    <li class="previous"><a href="javascript:load_data('{{prev}}')">{{message_Previous post}}</a></li>    
+    <li class="previous"><a href="javascript:load_data('{{prev}}')">{{message_Previous post}}</a></li>
     {{/prev}}
     {{#next}}
     <li class="next"><a href="javascript:load_data('{{next}}')">{{message_Next post}}</a></li>
     {{/next}}
     </ul>
-    {{{disqus_html}}}
+    {{{comment_html}}}
     </div>
     <div class="footerbox">
     {{{CONTENT_FOOTER}}}

--- a/nikola/plugins/task/mustache/mustache.html
+++ b/nikola/plugins/task/mustache/mustache.html
@@ -4,14 +4,12 @@
     <link href="/assets/css/rst.css" rel="stylesheet" type="text/css">
     <link href="/assets/css/code.css" rel="stylesheet" type="text/css">
     <link href="/assets/css/colorbox.css" rel="stylesheet" type="text/css"/>
-    <link href="/assets/css/slides.css" rel="stylesheet" type="text/css"/>
     <link href="/assets/css/theme.css" rel="stylesheet" type="text/css"/>
     <link href="/assets/css/custom.css" rel="stylesheet" type="text/css">
-    <script src="/assets/js/jquery-1.7.2.min.js" type="text/javascript"></script>    
+    <script src="/assets/js/jquery-1.10.2.min.js" type="text/javascript"></script>
     <script src="https://raw.github.com/jonnyreeves/jquery-Mustache/master/src/jquery.mustache.js"></script>
     <script src="https://raw.github.com/janl/mustache.js/master/mustache.js"></script>
     <script src="/assets/js/jquery.colorbox-min.js" type="text/javascript"></script>
-    <script src="/assets/js/slides.min.jquery.js" type="text/javascript"></script>
     <script type="text/javascript">
 function load_data(dataurl) {
     jQuery.getJSON(dataurl, function(data) {
@@ -29,7 +27,7 @@ $.Mustache.load('/mustache-template.html')
             load_data('{{first_post_data}}');
         };
     })
-});    
+});
 </script>
 </head>
 <body style="padding-top: 0;">


### PR DESCRIPTION
This commit has multiple fixes to get the mustache task working:
- Update mustache.html to remove unused files/update versions
- Remove disqus dependency and use the new comment system
- Minor fix in template for the config file

Known issues:
- We try to load custom.css even if none is defined.
- raw.github.com urls are use for a couple of libraries.  These will
  soon stop working modern browsers. Ref: http://bit.ly/11E92ln
