### PR TITLE
Use jsDelivr's CDN instead of depending on raw.github.com urls.

### DIFF
--- a/nikola/plugins/task/mustache/mustache.html
+++ b/nikola/plugins/task/mustache/mustache.html
@@ -7,8 +7,8 @@
     <link href="/assets/css/theme.css" rel="stylesheet" type="text/css"/>
     <link href="/assets/css/custom.css" rel="stylesheet" type="text/css">
     <script src="/assets/js/jquery-1.10.2.min.js" type="text/javascript"></script>
-    <script src="https://raw.github.com/jonnyreeves/jquery-Mustache/master/src/jquery.mustache.js"></script>
-    <script src="https://raw.github.com/janl/mustache.js/master/mustache.js"></script>
+    <script src="//cdn.jsdelivr.net/jquery.mustache/0.2.7/jquery.mustache.js"></script>
+    <script src="//cdn.jsdelivr.net/mustache.js/0.7.2/mustache.js"></script>
     <script src="/assets/js/jquery.colorbox-min.js" type="text/javascript"></script>
     <script type="text/javascript">
 function load_data(dataurl) {


### PR DESCRIPTION
GitHub doesn't like using the raw.github.com urls for loading
assets. See http://bit.ly/11E92ln.
