### PR TITLE
Compile less files directly to the output dir, instead of theme dir.

### DIFF
--- a/nikola/plugins/task/build_less.py
+++ b/nikola/plugins/task/build_less.py
@@ -69,7 +69,7 @@ class BuildLess(Task):
 
         # Build targets and write CSS files
         base_path = utils.get_theme_path(self.site.THEMES[0])
-        dst_dir = os.path.join(base_path, "assets", "css")
+        dst_dir = os.path.join(self.site.config['OUTPUT_FOLDER'], 'assets', 'css')
         # Make everything depend on all sources, rough but enough
         deps = glob.glob(os.path.join(
             base_path,


### PR DESCRIPTION
The compiled css files should be directly written to the output directory, instead of writing to the theme directory. 
