### PR TITLE
Fix bundles when using less files.

### DIFF
--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -86,6 +86,7 @@ class BuildBundles(LateTask):
                 file_dep = filter(None, file_dep)  # removes missing files
                 task = {
                     'file_dep': file_dep,
+                    'task_dep': ['copy_assets'],
                     'basename': str(self.name),
                     'name': str(output_path),
                     'actions': [(build_bundle, (name, files))],


### PR DESCRIPTION
Change the file_deps to the output folder, since #651 changed the
build_less to write files directly to output directory, and copy
assets should've already run, when we are building bundles.
