### PR TITLE
fix installing from a git clone , windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ def copy_messages():
 
         shutil.copytree(original_messages_directory, theme_messages_directory)
 
-def copy_harlinked_for_windows():
+def copy_hardlinked_for_windows():
     """replaces the hardlinked files with a copy of the original content.
     
     In windows (msysgit), a symlink is converted to a text file with a
@@ -130,7 +130,7 @@ def install_manpages(root, prefix):
 
 class nikola_install(install):
     def run(self):
-        copy_harlinked_for_windows()
+        copy_hardlinked_for_windows()
         install.run(self)
         install_manpages(self.root, self.prefix)
 


### PR DESCRIPTION
When cloning from a windows machine hardlinks are converted to text file, the text being the path to the real file.
There are at least three files that are hardlinked in the nikola repo and setup.py install will see those files with wrong content.
In particular nikola build for the demo site would fail.

I propose a small change in setup.py : copy the intended content over the git-hardlink-makers, see the diffs.

PD: while I modified and tested my local clone (all ok) , I was unable to push to the forked repo, so copy-pasted from the github web interface, just saying because indentation and gremlins... 
