### PR TITLE
Wordpress Importer: Importing thumbnails

### DIFF
--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -27,6 +27,7 @@
 from __future__ import unicode_literals, print_function
 import os
 import re
+import sys
 from lxml import etree
 
 try:
@@ -39,6 +40,11 @@ try:
     import requests
 except ImportError:
     requests = None  # NOQA
+
+try:
+    import phpserialize
+except ImportError:
+    phpserialize = None  # NOQA
 
 from nikola.plugin_categories import Command
 from nikola import utils
@@ -79,12 +85,6 @@ class CommandImportWordpress(Command, ImportMixin):
 
     def _execute(self, options={}, args=[]):
         """Import a WordPress blog from an export file into a Nikola site."""
-        # Parse the data
-        if requests is None:
-            print('To use the import_wordpress command,'
-                  ' you have to install the "requests" package.')
-            return
-
         if not args:
             print(self.help())
             return
@@ -100,17 +100,38 @@ class CommandImportWordpress(Command, ImportMixin):
                   'putting these arguments before the filename if you '
                   'are running into problems.'.format(args))
 
+        self.import_into_existing_site = False
+        self.url_map = {}
+        self.timezone = None
+
         self.wordpress_export_file = options['filename']
         self.squash_newlines = options.get('squash_newlines', False)
-        self.no_downloads = options.get('no_downloads', False)
         self.output_folder = options.get('output_folder', 'new_site')
-        self.import_into_existing_site = False
+
         self.exclude_drafts = options.get('exclude_drafts', False)
-        self.url_map = {}
+        self.no_downloads = options.get('no_downloads', False)
+
+        if not self.no_downloads:
+            def show_info_about_mising_module(modulename):
+                print(
+                    'To use the "{commandname}" command, you have to install '
+                    'the "{package}" package or supply the "--no-downloads" '
+                    'option.'.format(
+                        commandname=self.name,
+                        package=modulename)
+                )
+
+            if requests is None:
+                show_info_about_mising_module('requests')
+                return
+
+            if phpserialize is None:
+                show_info_about_mising_module('phpserialize')
+                return
+
         channel = self.get_channel_from_file(self.wordpress_export_file)
         self.context = self.populate_context(channel)
         conf_template = self.generate_base_site()
-        self.timezone = None
 
         self.import_posts(channel)
 
@@ -236,6 +257,61 @@ class CommandImportWordpress(Command, ImportMixin):
         dst_url = '/'.join(dst_path.split(os.sep)[2:])
         links[link] = '/' + dst_url
         links[url] = '/' + dst_url
+
+        self.download_additional_image_sizes(
+            item,
+            wordpress_namespace,
+            os.path.dirname(url)
+        )
+
+    def download_additional_image_sizes(self, item, wordpress_namespace, source_path):
+        if phpserialize is None:
+            return
+
+        additional_metadata = item.findall('{{{0}}}postmeta'.format(wordpress_namespace))
+
+        if additional_metadata is None:
+            return
+
+        for element in additional_metadata:
+            meta_key = element.find('{{{0}}}meta_key'.format(wordpress_namespace))
+            if meta_key is not None and meta_key.text == '_wp_attachment_metadata':
+                meta_value = element.find('{{{0}}}meta_value'.format(wordpress_namespace))
+
+                if meta_value is None:
+                    continue
+
+                # Someone from Wordpress thought it was a good idea
+                # serialize PHP objects into that metadata field. Given
+                # that the export should give you the power to insert
+                # your blogging into another site or system its not.
+                # Why don't they just use JSON?
+                if sys.version_info[0] == 2:
+                    metadata = phpserialize.loads(meta_value.text)
+                    size_key = 'sizes'
+                    file_key = 'file'
+                else:
+                    metadata = phpserialize.loads(meta_value.text.encode('UTF-8'))
+                    size_key = b'sizes'
+                    file_key = b'file'
+
+                if not size_key in metadata:
+                    continue
+
+                for filename in [metadata[size_key][size][file_key] for size in metadata[size_key]]:
+                    url = '/'.join([source_path, filename.decode('utf-8')])
+
+                    path = urlparse(url).path
+                    dst_path = os.path.join(*([self.output_folder, 'files']
+                                              + list(path.split('/'))))
+                    dst_dir = os.path.dirname(dst_path)
+                    if not os.path.isdir(dst_dir):
+                        os.makedirs(dst_dir)
+                    print("Downloading {0} => {1}".format(url, dst_path))
+                    self.download_url_content_to_file(url, dst_path)
+                    dst_url = '/'.join(dst_path.split(os.sep)[2:])
+                    links[url] = '/' + dst_url
+                    links[url] = '/' + dst_url
 
     @staticmethod
     def transform_sourcecode(content):

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -19,3 +19,4 @@ python-dateutil
 micawber
 pygal
 typogrify
+phpserialize

--- a/tests/test_command_import_wordpress.py
+++ b/tests/test_command_import_wordpress.py
@@ -11,7 +11,8 @@ import nikola.plugins.command.import_wordpress
 
 class BasicCommandImportWordpress(unittest.TestCase):
     def setUp(self):
-        self.import_command = nikola.plugins.command.import_wordpress.CommandImportWordpress()
+        self.module = nikola.plugins.command.import_wordpress
+        self.import_command = self.module.CommandImportWordpress()
         self.import_filename = os.path.abspath(os.path.join(
             os.path.dirname(__file__), 'wordpress_export_example.xml'))
 
@@ -135,10 +136,13 @@ class CommandImportWordpressTest(BasicCommandImportWordpress):
             self.import_filename)
         self.import_command.context = self.import_command.populate_context(
             channel)
-        self.import_command.url_map = {}  # For testing we use an empty one.
         self.import_command.output_folder = 'new_site'
         self.import_command.squash_newlines = True
         self.import_command.no_downloads = False
+
+        # Ensuring clean results
+        self.import_command.url_map = {}
+        self.module.links = {}
 
         write_metadata = mock.MagicMock()
         write_content = mock.MagicMock()
@@ -210,6 +214,27 @@ Diese Daten sind f\xfcr mich nicht bestimmten Personen zuordenbar. Eine Zusammen
         self.assertEqual(
             self.import_command.url_map['http://some.blog/kontakt/'],
             'http://some.blog/stories/kontakt.html')
+
+        image_thumbnails = [
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-64x64.png',
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-300x175.png',
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-36x36.png',
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-24x24.png',
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-96x96.png',
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-96x96.png',
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-48x48.png',
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-96x96.png',
+            'http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-150x150.png'
+        ]
+
+        for link in image_thumbnails:
+            self.assertTrue(
+                link in self.module.links,
+                'No link to "{0}" found in {map}.'.format(
+                    link,
+                    map=self.module.links
+                )
+            )
 
     def test_transforming_content(self):
         """Applying markup conversions to content."""

--- a/tests/wordpress_export_example.xml
+++ b/tests/wordpress_export_example.xml
@@ -230,5 +230,62 @@ A listing with another listing inside.
         </wp:postmeta>
     </item>
 
-</channel>
+    <item>
+        <title>Screenshot - 2012-12-19</title>
+        <link>http://some.blog/2012/12/wintermodus/2012-12-19-1355925145_1024x600_scrot/</link>
+        <pubDate>Wed, 19 Dec 2012 13:53:19 +0000</pubDate>
+        <dc:creator>Niko</dc:creator>
+        <guid isPermaLink="false">http://some.blog/wp-content/uploads/2012/12/2012-12-19-355925145_1024x600_scrot.png</guid>
+        <description></description>
+        <content:encoded><![CDATA[]]></content:encoded>
+        <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+        <wp:post_id>2271</wp:post_id>
+        <wp:post_date>2012-12-19 14:53:19</wp:post_date>
+        <wp:post_date_gmt>2012-12-19 13:53:19</wp:post_date_gmt>
+        <wp:comment_status>open</wp:comment_status>
+        <wp:ping_status>open</wp:ping_status>
+        <wp:post_name>2012-12-19-1355925145_1024x600_scrot</wp:post_name>
+        <wp:status>inherit</wp:status>
+        <wp:post_parent>2270</wp:post_parent>
+        <wp:menu_order>0</wp:menu_order>
+        <wp:post_type>attachment</wp:post_type>
+        <wp:post_password></wp:post_password>
+        <wp:is_sticky>0</wp:is_sticky>
+        <wp:attachment_url>http://some.blog/wp-content/uploads/2012/12/2012-12-19-355925145_1024x600_scrot.png</wp:attachment_url>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attached_file</wp:meta_key>
+            <wp:meta_value><![CDATA[2012/12/2012-12-19-1355925145_1024x600_scrot.png]]></wp:meta_value>
+        </wp:postmeta>
+        <wp:postmeta>
+            <wp:meta_key>_wp_attachment_metadata</wp:meta_key>
+             <wp:meta_value><![CDATA[a:5:{s:5:"width";i:1024;s:6:"height";i:600;s:4:"file";s:48:"2012/12/2012-12-19-1355925145_1024x600_scrot.png";s:5:"sizes";a:9:{s:9:"thumbnail";a:4:{s:4:"file";s:48:"2012-12-19-1355925145_1024x600_scrot-150x150.png";s:5:"width";i:150;s:6:"height";i:150;s:9:"mime-type";s:9:"image/png";}s:6:"medium";a:4:{s:4:"file";s:48:"2012-12-19-1355925145_1024x600_scrot-300x175.png";s:5:"width";i:300;s:6:"height";i:175;s:9:"mime-type";s:9:"image/png";}s:12:"mosaic-thumb";a:4:{s:4:"file";s:46:"2012-12-19-1355925145_1024x600_scrot-96x96.png";s:5:"width";i:96;s:6:"height";i:96;s:9:"mime-type";s:9:"image/png";}s:13:"gallery-thumb";a:4:{s:4:"file";s:46:"2012-12-19-1355925145_1024x600_scrot-96x96.png";s:5:"width";i:96;s:6:"height";i:96;s:9:"mime-type";s:9:"image/png";}s:9:"widget-24";a:4:{s:4:"file";s:46:"2012-12-19-1355925145_1024x600_scrot-24x24.png";s:5:"width";i:24;s:6:"height";i:24;s:9:"mime-type";s:9:"image/png";}s:9:"widget-32";a:4:{s:4:"file";s:46:"2012-12-19-1355925145_1024x600_scrot-36x36.png";s:5:"width";i:36;s:6:"height";i:36;s:9:"mime-type";s:9:"image/png";}s:9:"widget-48";a:4:{s:4:"file";s:46:"2012-12-19-1355925145_1024x600_scrot-48x48.png";s:5:"width";i:48;s:6:"height";i:48;s:9:"mime-type";s:9:"image/png";}s:9:"widget-64";a:4:{s:4:"file";s:46:"2012-12-19-1355925145_1024x600_scrot-64x64.png";s:5:"width";i:64;s:6:"height";i:64;s:9:"mime-type";s:9:"image/png";}s:9:"widget-96";a:4:{s:4:"file";s:46:"2012-12-19-1355925145_1024x600_scrot-96x96.png";s:5:"width";i:96;s:6:"height";i:96;s:9:"mime-type";s:9:"image/png";}}s:10:"image_meta";a:10:{s:8:"aperture";i:0;s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";i:0;s:9:"copyright";s:0:"";s:12:"focal_length";i:0;s:3:"iso";i:0;s:13:"shutter_speed";i:0;s:5:"title";s:0:"";}}]]></wp:meta_value>
+        </wp:postmeta>
+    </item>
+
+        <item>
+            <title>Image Link Rewriting</title>
+            <link>http://some.blog/2012/12/wintermodus/</link>
+            <pubDate>Wed, 19 Dec 2012 13:55:10 +0000</pubDate>
+            <dc:creator>Niko</dc:creator>
+            <guid isPermaLink="false">http://some.blog/?p=2270</guid>
+            <description></description>
+            <content:encoded><![CDATA[Some image upload. The links to this and the src of the img-tag  should be rewritten correctly.
+
+    <a href="http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot.png"><img class="aligncenter size-medium wp-image-2271" alt="Netbook Screenshot - 2012-12-19" src="http://some.blog/wp-content/uploads/2012/12/2012-12-19-1355925145_1024x600_scrot-300x175.ng" width="300" height="175" /></a>]]></content:encoded>
+            <excerpt:encoded><![CDATA[]]></excerpt:encoded>
+            <wp:post_id>2270</wp:post_id>
+            <wp:post_date>2012-12-19 14:55:10</wp:post_date>
+            <wp:post_date_gmt>2012-12-19 13:55:10</wp:post_date_gmt>
+            <wp:comment_status>open</wp:comment_status>
+            <wp:ping_status>open</wp:ping_status>
+            <wp:post_name>image-link-rewriting</wp:post_name>
+            <wp:status>publish</wp:status>
+            <wp:post_parent>0</wp:post_parent>
+            <wp:menu_order>0</wp:menu_order>
+            <wp:post_type>post</wp:post_type>
+            <wp:post_password></wp:post_password>
+            <wp:is_sticky>0</wp:is_sticky>
+            <category domain="category" nicename="linux"><![CDATA[Linux]]></category>
+        </item>
+    </channel>
 </rss>


### PR DESCRIPTION
This improves the importing of Wordpress exports by also importing thumbnails.

Not only leads this to a more complete import it also tackles a part of #369 by increasing the amount of links we can rewrite to our new site.
