### PR TITLE
Local search task should run when any new page is created.

### DIFF
--- a/nikola/plugins/task/localsearch/__init__.py
+++ b/nikola/plugins/task/localsearch/__init__.py
@@ -29,6 +29,8 @@ import codecs
 import json
 import os
 
+from doit.tools import result_dep
+
 from nikola.plugin_categories import LateTask
 from nikola.utils import config_changed, copy_tree, makedirs
 
@@ -86,13 +88,19 @@ class Tipue(LateTask):
             with codecs.open(dst_path, "wb+", "utf8") as fd:
                 fd.write(output)
 
+
         yield {
             "basename": str(self.name),
             "name": dst_path,
             "targets": [dst_path],
             "actions": [(save_data, [])],
-            'uptodate': [config_changed(kw)]
+            'uptodate': [config_changed(kw), result_dep('sitemap')]
         }
+        # Note: The task should run everytime a new file is added or a
+        # file is changed.  We cheat, and depend on the sitemap task,
+        # to run everytime a new file is added.
+
+
 
         # Copy all the assets to the right places
         asset_folder = os.path.join(os.path.dirname(__file__), "files")

--- a/nikola/plugins/task/sitemap/__init__.py
+++ b/nikola/plugins/task/sitemap/__init__.py
@@ -139,7 +139,9 @@ class Sitemap(LateTask):
                 for k in sorted(locs.keys()):
                     outf.write(locs[k])
                 outf.write("</urlset>")
-            return True
+            # Other tasks can depend on this output, instead of having
+            # to scan locations.
+            return {'locations': locs.keys()}
 
         scan_locs()
         task = {


### PR DESCRIPTION
Add dependency to the locations in the sitemap, to rerun the local
search task.
