### PR TITLE
fix demo and install problems with symlinks in windows

### DIFF
--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -34,7 +34,7 @@ from mako.template import Template
 import nikola
 from nikola.plugin_categories import Command
 from nikola.utils import LOGGER, makedirs
-
+from nikola.winutils import fix_git_symlinked
 
 class CommandInit(Command):
     """Create a new site."""
@@ -93,6 +93,8 @@ class CommandInit(Command):
         lib_path = cls.get_path_to_nikola_modules()
         src = os.path.join(lib_path, 'data', 'samplesite')
         shutil.copytree(src, target)
+        fix_git_symlinked(src, target)
+            
 
     @classmethod
     def create_configuration(cls, target):

--- a/nikola/winutils.py
+++ b/nikola/winutils.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2012-2013 Roberto Alsina and others.
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""windows utilities to workaround problems with symlinks in a git clone"""
+
+import os
+import shutil
+import sys
+# don't add imports outside stdlib, will be imported in setup.py
+
+
+def should_fix_git_symlinked():
+    """True if git symlinls markers should be filled with the real content"""
+    if sys.platform == 'win32':
+        path = (os.path.dirname(__file__) +
+                 r'\data\samplesite\stories\theming.rst')
+        try:
+            if os.path.getsize(path) < 200:
+                return True
+        except Exception:
+            pass
+    return False
+
+
+def fix_git_symlinked(src, dst):
+    """fix git symlinked files in windows that had been copied from src to dst
+
+    Most (all?) of git implementations in windows store a symlink pointing
+    into the repo as a text file, the text being the relative path to the
+    file with the real content.
+    
+    So, in a clone of nikola in windows the symlinked files will have the
+    wrong content.
+    
+    The linux usage pattern for those files is 'copy to some dir, then use',
+    so we inspect after the copy and rewrite the wrong contents.
+
+    The goals are:
+       support running nikola from a clone without installing and without
+       making dirty the WC.
+       
+       support install from the WC.
+
+       if possible and needed, support running the test suite without making
+       dirty the WC. 
+    """
+    # if running from WC there should be a 'doc' dir sibling to nikola package
+    if not should_fix_git_symlinked():
+        return
+    # probabbly in a WC, so symlinks should be fixed
+    for root, dirs, files in os.walk(dst):
+        for name in files:
+            filename = os.path.join(root, name)
+
+            # detect if symlinked
+            try:
+                if not (2 < os.path.getsize(filename) < 500):
+                    continue
+                # which encoding uses a git symlink marker ? betting on default
+                with open(filename, 'r') as f:
+                    text = f.read()
+                if text[0]!='.':
+                    # de facto hint to skip binary files and exclude.meta
+                    continue
+            except Exception:
+                # probably encoding: content binary or encoding not defalt,
+                # also in py2.6 it can be path encoding
+                continue
+            dst_dir_relpath = os.path.dirname(os.path.relpath(filename, dst))
+            path = os.path.normpath(os.path.join(src, dst_dir_relpath, text))            
+            if not os.path.exists(path):
+                continue
+            # most probably it is a git symlinked file
+
+            # copy original content to filename
+            shutil.copy(path, filename)

--- a/setup.py
+++ b/setup.py
@@ -76,27 +76,41 @@ def copy_messages():
         shutil.copytree(original_messages_directory, theme_messages_directory)
 
 
-def copy_hardlinked_for_windows():
+def copy_symlinked_for_windows():
     """replaces the hardlinked files with a copy of the original content.
 
     In windows (msysgit), a symlink is converted to a text file with a
     path to the file it points to. If not corrected, installing from a git
-    clone will end with some files with bad content"""
+    clone will end with some files with bad content
 
-    if sys.platform != 'win32':
-        return
-    # .txt in src, .rst in dst
-    stories_hardlinked = ['manual', 'creating-a-theme', 'theming']
+    After install the WC will be dirty (symlink markers rewroted with real
+    content)
+    """
+
+    # essentially nikola.utils.should_fix_git_symlinked inlined, to not
+    # fiddle with sys.path / import unless really needed
+    if sys.platform == 'win32':
+        path = ( os.path.dirname(__file__) +
+                 r'nikola\data\samplesite\stories\theming.rst')
+        try:
+            if os.path.getsize(path) < 200:
+                pass
+            else:
+                return
+        except Exception:
+            return
+    
+    # apply the fix
     localdir = os.path.dirname(__file__)
-    stories_directory = os.path.join(
-        localdir, 'nikola', 'data', 'samplesite', 'stories')
-    docs_directory = os.path.join(localdir, 'docs')
-
-    for name in stories_hardlinked:
-        shutil.copy(
-            os.path.join(docs_directory, name + '.txt'),
-            os.path.join(stories_directory, name + '.rst'))
-
+    dst = os.path.join(localdir, 'nikola', 'data', 'samplesite')
+    src = dst
+    oldpath = sys.path[:]
+    sys.path.insert(0, os.path.join(localdir, 'nikola'))
+    winutils = __import__('winutils')
+    winutils.fix_git_symlinked(src, dst)
+    sys.path = oldpath
+    del sys.modules['winutils']
+    print('WARNING: your working copy is now dirty by changes in samplesite')     
 
 def install_manpages(root, prefix):
     try:
@@ -127,7 +141,7 @@ def install_manpages(root, prefix):
 
 class nikola_install(install):
     def run(self):
-        copy_hardlinked_for_windows()
+        copy_symlinked_for_windows()
         install.run(self)
         install_manpages(self.root, self.prefix)
 


### PR DESCRIPTION
Fixes problems in windows from the use of symlinks into nikola package
 It uses theming.rst to determine if adaptation is needed, if yes then autodetects \ corrects all symlinks in the appropriate directory. 

The goals are
 [x] support running nikola from a clone without installing and without making dirty the WC.

[x] support install from the WC. (at present the WC ends dirty)

As a side effect allows to install from a zip obtained from github
