### PR TITLE
fix guess languaje from locale in py2

### DIFF
--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -118,6 +118,10 @@ class Functionary(defaultdict):
     def current_lang(self):
         """Guess the current language from locale or default."""
         lang = locale.getlocale()[0]
+        if lang is None:
+            # for python 2.x, see issues 12699 and 6203 in python bugtracker 
+            locale.setlocale(locale.LC_ALL, '')
+            lang = locale.getlocale()[0]        
         if lang:
             if lang in self.keys():
                 return lang


### PR DESCRIPTION
calling locale.get_locale() before setting any locale returns (None, None) in python 2.x , so the first call to utils.Functionary.current_lang always returned default_lang in python 2.x

See the python bugtracker issues 6203, 12699.

From the python docs for 2.6.5, setlocale, section 23.2.1
"""
The program must explicitly say that it wants the user’s preferred locale settings by calling setlocale(LC_ALL, '')
"""
so I set that locale if detecting a None.
