### PR TITLE
Added possibility to config the IPython.nbconvert inside Nikola.

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -396,6 +396,12 @@ CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
 #</script>
 #"""
 
+# Do you want to customize the nbconversion of your IPython notebook?
+# IPYNB_CONFIG = {}
+# With the following example configuracion you can use a custom jinja template
+# called `toggle.tpl` which has to be located in your site/blog main folder:
+# IPYNB_CONFIG = {'Exporter':{'template_file': 'toggle'}}
+
 # What MarkDown extensions to enable?
 # You will also get gist, nikola and podcast because those are
 # done in the code, hope you don't mind ;-)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -156,6 +156,7 @@ class Nikola(object):
             'INDEXES_TITLE': "",
             'INDEXES_PAGES': "",
             'INDEX_PATH': '',
+            'IPYNB_CONFIG': {},
             'LICENSE': '',
             'LINK_CHECK_WHITELIST': [],
             'LISTINGS_FOLDER': 'listings',

--- a/nikola/plugins/compile/ipynb/__init__.py
+++ b/nikola/plugins/compile/ipynb/__init__.py
@@ -33,6 +33,7 @@ import os
 try:
     from IPython.nbconvert.exporters import HTMLExporter
     from IPython.nbformat import current as nbformat
+    from IPython.config import Config
     flag = True
 except ImportError:
     flag = None
@@ -52,7 +53,8 @@ class CompileIPynb(PageCompiler):
                             'to install IPython 1.0.')
         makedirs(os.path.dirname(dest))
         HTMLExporter.default_template = 'basic'
-        exportHtml = HTMLExporter()
+        c = Config(self.site.config['IPYNB_CONFIG'])
+        exportHtml = HTMLExporter(config=c)
         with codecs.open(dest, "w+", "utf8") as out_file:
             with codecs.open(source, "r", "utf8") as in_file:
                 nb = in_file.read()


### PR DESCRIPTION
This simple PR makes the support from ipynb so "much" powerful because we have access to the IPython config system... so we can config a **LOT** of useful things.
One use case is the change of the template that `IPython.nbconvert` uses to render the ipynb to html... and there is a lot of more uses cases such as changing filters, preprocessor, etc... 
I will be great if we have this possibility in Nikola...

Working example of utility: visit this [post](http://www.damian.oquanta.info/posts/blogging-with-nikola-and-ipython.html) and click in any IPython input cell and... surprise ;-)

Cheers.

Damián
