### PR TITLE
Explicitly yeild tasks containing subtasks to add docs and remove ugly code

### DIFF
--- a/nikola/main.py
+++ b/nikola/main.py
@@ -145,8 +145,12 @@ class NikolaTaskLoader(TaskLoader):
                 'reporter': ExecutedOnlyReporter,
             }
         DOIT_CONFIG['default_tasks'] = ['render_site', 'post_render']
-        tasks = generate_tasks('render_site', self.nikola.gen_tasks('render_site', "Task"))
-        latetasks = generate_tasks('post_render', self.nikola.gen_tasks('post_render', "LateTask"))
+        tasks = generate_tasks('render_site',
+            self.nikola.gen_tasks('render_site', "Task",
+            'Group of tasks to render the site.'))
+        latetasks = generate_tasks('post_render',
+            self.nikola.gen_tasks('post_render', "LateTask",
+            'Group of tasks to be executes after site is rendered.'))
         return tasks + latetasks, DOIT_CONFIG
 
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -790,7 +790,7 @@ class Nikola(object):
             task['targets'] = [os.path.normpath(t) for t in targets]
         return task
 
-    def gen_tasks(self, name, plugin_category):
+    def gen_tasks(self, name, plugin_category, doc=''):
 
         def flatten(task):
             if isinstance(task, dict):
@@ -803,6 +803,7 @@ class Nikola(object):
         task_dep = []
         for pluginInfo in self.plugin_manager.getPluginsOfCategory(plugin_category):
             for task in flatten(pluginInfo.plugin_object.gen_tasks()):
+                assert 'basename' in task
                 task = self.clean_task_paths(task)
                 yield task
                 for multi in self.plugin_manager.getPluginsOfCategory("TaskMultiplier"):
@@ -815,7 +816,8 @@ class Nikola(object):
             if pluginInfo.plugin_object.is_default:
                 task_dep.append(pluginInfo.plugin_object.name)
         yield {
-            'name': name,
+            'basename': name,
+            'doc': doc,
             'actions': None,
             'clean': True,
             'task_dep': task_dep

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -39,7 +39,7 @@ __all__ = [
 from yapsy.IPlugin import IPlugin
 from doit.cmd_base import Command as DoitCommand
 
-from .utils import LOGGER
+from .utils import LOGGER, first_line
 
 
 class BasePlugin(IPlugin):
@@ -104,7 +104,7 @@ DoitCommand.help = help
 
 
 class BaseTask(BasePlugin):
-    """PLugins of this type are task generators."""
+    """Plugins of this type are task generators."""
 
     name = "dummy_task"
 
@@ -116,9 +116,17 @@ class BaseTask(BasePlugin):
         """Task generator."""
         raise NotImplementedError()
 
+    def group_task(self):
+        """dict for group task"""
+        return {
+            'basename': self.name,
+            'name': None,
+            'doc': first_line(self.__doc__),
+        }
+
 
 class Task(BaseTask):
-    """PLugins of this type are task generators."""
+    """Plugins of this type are task generators."""
 
 
 class LateTask(BaseTask):

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -46,6 +46,7 @@ class Archive(Task):
             "create_monthly_archive": self.site.config['CREATE_MONTHLY_ARCHIVE'],
         }
         self.site.scan_posts()
+        yield self.group_task()
         # TODO add next/prev links for years
         for lang in kw["translations"]:
             for year, posts in self.site.posts_per_year.items():

--- a/nikola/plugins/task/build_less.py
+++ b/nikola/plugins/task/build_less.py
@@ -36,7 +36,7 @@ from nikola import utils
 
 
 class BuildLess(Task):
-    """Bundle assets using WebAssets."""
+    """Generate CSS out of LESS sources."""
 
     name = "build_less"
     sources_folder = "less"
@@ -83,6 +83,8 @@ class BuildLess(Task):
             with open(dst, "wb+") as outf:
                 outf.write(compiled)
 
+        yield self.group_task()
+
         for target in targets:
             dst = os.path.join(dst_dir, target.replace(self.sources_ext, ".css"))
             yield {
@@ -94,6 +96,3 @@ class BuildLess(Task):
                 'uptodate': [utils.config_changed(kw)],
                 'clean': True
             }
-
-        if not targets:
-            yield {'basename': self.name, 'actions': []}

--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -78,7 +78,7 @@ class BuildBundles(LateTask):
                 with open(os.path.join(out_dir, os.path.basename(output)), 'wb+'):
                     pass  # Create empty file
 
-        flag = False
+        yield self.group_task()
         if (webassets is not None and self.site.config['USE_BUNDLES'] is not
                 False):
             for name, files in kw['theme_bundles'].items():
@@ -97,15 +97,7 @@ class BuildBundles(LateTask):
                     'uptodate': [utils.config_changed(kw)],
                     'clean': True,
                 }
-                flag = True
                 yield utils.apply_filters(task, kw['filters'])
-        if flag is False:  # No page rendered, yield a dummy task
-            yield {
-                'basename': self.name,
-                'uptodate': [True],
-                'name': 'None',
-                'actions': [],
-            }
 
 
 def get_theme_bundles(themes):

--- a/nikola/plugins/task/copy_assets.py
+++ b/nikola/plugins/task/copy_assets.py
@@ -49,10 +49,12 @@ class CopyAssets(Task):
             "filters": self.site.config['FILTERS'],
             "code_color_scheme": self.site.config['CODE_COLOR_SCHEME'],
         }
-        flag = True
         has_code_css = False
         tasks = {}
         code_css_path = os.path.join(kw['output_folder'], 'assets', 'css', 'code.css')
+
+        yield self.group_task()
+
         for theme_name in kw['themes']:
             src = os.path.join(utils.get_theme_path(theme_name), 'assets')
             dst = os.path.join(kw['output_folder'], 'assets')
@@ -64,16 +66,7 @@ class CopyAssets(Task):
                 tasks[task['name']] = task
                 task['uptodate'] = [utils.config_changed(kw)]
                 task['basename'] = self.name
-                flag = False
                 yield utils.apply_filters(task, kw['filters'])
-
-        if flag:
-            yield {
-                'basename': self.name,
-                'name': 'None',
-                'uptodate': [True],
-                'actions': [],
-            }
 
         if not has_code_css:  # Generate it
 

--- a/nikola/plugins/task/copy_files.py
+++ b/nikola/plugins/task/copy_files.py
@@ -44,18 +44,12 @@ class CopyFiles(Task):
             'filters': self.site.config['FILTERS'],
         }
 
-        flag = False
+        yield self.group_task()
         for src in kw['files_folders']:
             dst = kw['output_folder']
             filters = kw['filters']
             real_dst = os.path.join(dst, kw['files_folders'][src])
             for task in utils.copy_tree(src, real_dst, link_cutoff=dst):
-                flag = True
                 task['basename'] = self.name
                 task['uptodate'] = [utils.config_changed(kw)]
                 yield utils.apply_filters(task, filters)
-        if not flag:
-            yield {
-                'basename': self.name,
-                'actions': (),
-            }

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -49,7 +49,7 @@ from nikola import utils
 
 
 class Galleries(Task):
-    """Copy theme assets into output."""
+    """Render image galleries."""
 
     name = str("render_galleries")
     dates = {}
@@ -71,6 +71,7 @@ class Galleries(Task):
             'global_context': self.site.GLOBAL_CONTEXT,
         }
 
+        yield self.group_task()
         # FIXME: lots of work is done even when images don't change,
         # which should be moved into the task.
 
@@ -79,13 +80,6 @@ class Galleries(Task):
         gallery_list = []
         for root, dirs, files in os.walk(kw['gallery_path']):
             gallery_list.append(root)
-        if not gallery_list:
-            yield {
-                'basename': str('render_galleries'),
-                'actions': [],
-            }
-            return
-
         # gallery_path is "gallery/name"
         for gallery_path in gallery_list:
             # gallery_name is "name"

--- a/nikola/plugins/task/indexes.py
+++ b/nikola/plugins/task/indexes.py
@@ -40,6 +40,7 @@ class Indexes(Task):
 
     def gen_tasks(self):
         self.site.scan_posts()
+        yield self.group_task()
 
         kw = {
             "translations": self.site.config['TRANSLATIONS'],

--- a/nikola/plugins/task/listings.py
+++ b/nikola/plugins/task/listings.py
@@ -83,10 +83,11 @@ class Listings(Task):
             }
             self.site.render_template('listing.tmpl', out_name,
                                       context)
-        flag = True
+
+        yield self.group_task()
+
         template_deps = self.site.template_system.template_deps('listing.tmpl')
         for root, dirs, files in os.walk(kw['listings_folder']):
-            flag = False
             # Render all files
             out_name = os.path.join(
                 kw['output_folder'],
@@ -125,8 +126,3 @@ class Listings(Task):
                         self.site.GLOBAL_CONTEXT)],
                     'clean': True,
                 }
-        if flag:
-            yield {
-                'basename': self.name,
-                'actions': [],
-            }

--- a/nikola/plugins/task/pages.py
+++ b/nikola/plugins/task/pages.py
@@ -43,7 +43,7 @@ class RenderPages(Task):
             "hide_untranslated_posts": self.site.config['HIDE_UNTRANSLATED_POSTS'],
         }
         self.site.scan_posts()
-        flag = False
+        yield self.group_task()
         for lang in kw["translations"]:
             for post in self.site.timeline:
                 if kw["hide_untranslated_posts"] and not post.is_translation_available(lang):
@@ -55,12 +55,4 @@ class RenderPages(Task):
                         2: kw})]
                     task['basename'] = self.name
                     task['task_dep'] = ['render_posts']
-                    flag = True
                     yield task
-        if flag is False:  # No page rendered, yield a dummy task
-            yield {
-                'basename': self.name,
-                'name': 'None',
-                'uptodate': [True],
-                'actions': [],
-            }

--- a/nikola/plugins/task/posts.py
+++ b/nikola/plugins/task/posts.py
@@ -58,8 +58,8 @@ class RenderPosts(Task):
         }
 
         nikola.post.READ_MORE_LINK = self.site.config['READ_MORE_LINK']
+        yield self.group_task()
 
-        flag = False
         for lang in kw["translations"]:
             deps_dict = copy(kw)
             deps_dict.pop('timeline')
@@ -72,7 +72,6 @@ class RenderPosts(Task):
                     source = post.translated_source_path(lang)
                     if lang != post.default_lang:
                         dest = dest + '.' + lang
-                flag = True
                 task = {
                     'basename': self.name,
                     'name': dest,
@@ -89,13 +88,6 @@ class RenderPosts(Task):
                 if post.meta('password'):
                     task['actions'].append((wrap_encrypt, (dest, post.meta('password'))))
                 yield task
-        if flag is False:  # Return a dummy task
-            yield {
-                'basename': self.name,
-                'name': 'None',
-                'uptodate': [True],
-                'actions': [],
-            }
 
 
 CRYPT = string.Template("""\

--- a/nikola/plugins/task/redirect.py
+++ b/nikola/plugins/task/redirect.py
@@ -32,7 +32,7 @@ from nikola import utils
 
 
 class Redirect(Task):
-    """Copy theme assets into output."""
+    """Generate redirections"""
 
     name = "redirect"
 
@@ -44,17 +44,8 @@ class Redirect(Task):
             'output_folder': self.site.config['OUTPUT_FOLDER'],
         }
 
-        if not kw['redirections']:
-            # If there are no redirections, still needs to create a
-            # dummy action so dependencies don't fail
-            yield {
-                'basename': self.name,
-                'name': 'None',
-                'uptodate': [True],
-                'actions': [],
-            }
-
-        else:
+        yield self.group_task()
+        if kw['redirections']:
             for src, dst in kw["redirections"]:
                 src_path = os.path.join(kw["output_folder"], src)
                 yield {

--- a/nikola/plugins/task/rss.py
+++ b/nikola/plugins/task/rss.py
@@ -54,6 +54,7 @@ class RenderRSS(Task):
             "feed_length": self.site.config['FEED_LENGTH'],
         }
         self.site.scan_posts()
+        yield self.group_task()
         for lang in kw["translations"]:
             output_name = os.path.join(kw['output_folder'],
                                        self.site.path("rss", None, lang))

--- a/nikola/plugins/task/sitemap/__init__.py
+++ b/nikola/plugins/task/sitemap/__init__.py
@@ -144,6 +144,7 @@ class Sitemap(LateTask):
             return {'locations': list(locs.keys())}
 
         scan_locs()
+        yield self.group_task()
         task = {
             "basename": "sitemap",
             "name": sitemap_path,

--- a/nikola/plugins/task/sources.py
+++ b/nikola/plugins/task/sources.py
@@ -52,7 +52,7 @@ class Sources(Task):
         }
 
         self.site.scan_posts()
-        flag = False
+        yield self.group_task()
         if self.site.config['COPY_SOURCES']:
             for lang in kw["translations"]:
                 for post in self.site.timeline:
@@ -79,10 +79,3 @@ class Sources(Task):
                             'clean': True,
                             'uptodate': [utils.config_changed(kw)],
                         }
-        if flag is False:  # No page rendered, yield a dummy task
-            yield {
-                'basename': 'render_sources',
-                'name': 'None',
-                'uptodate': [True],
-                'actions': [],
-            }

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -63,11 +63,11 @@ class RenderTags(Task):
         }
 
         self.site.scan_posts()
+        yield self.group_task()
 
         yield self.list_tags_page(kw)
 
         if not self.site.posts_per_tag and not self.site.posts_per_category:
-            yield {'basename': str(self.name), 'actions': []}
             return
 
         tag_list = list(self.site.posts_per_tag.items())
@@ -164,6 +164,7 @@ class RenderTags(Task):
             )
             task_cfg = {1: task['uptodate'][0].config, 2: kw}
             task['uptodate'] = [utils.config_changed(task_cfg)]
+            task['basename'] = str(self.name)
             yield task
 
     def tag_page_as_index(self, tag, lang, post_list, kw, is_category):

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -637,3 +637,13 @@ def split_explicit_title(text):
     if match:
         return True, match.group(1), match.group(2)
     return False, text, text
+
+
+def first_line(doc):
+    """extract first non-blank line from text, to extract docstring title"""
+    if doc is not None:
+        for line in doc.splitlines():
+            striped = line.strip()
+            if striped:
+                return striped
+    return ''

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -1,4 +1,4 @@
-doit>=0.20.0
+doit>=0.23.0
 pygments
 pillow>=2.0.0
 docutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-doit>=0.20.0
+doit>=0.23.0
 pygments
 pillow>=2.0.0
 docutils


### PR DESCRIPTION
Note: this patch requires doit >= 0.23

Before doit 0.23 it was not possible to set the "doc" attribute of a task containing sub-tasks.
Now it is possible by yielding a task with "name" equal to None.

This also allows nikola to get rid of some ugly code that created a dummy task to make sure
all named tasks were present.

minor notes:
- I found a problem that "render_tags" was a creating a sub-task in "render_site". 
  Fixed that and added an assert to make sure other Tasks wont misbehave.
- made render_site and post_render to be simple tasks instead of creating a single sub-task

Off topic: the name "post_render" is confusing. I was thinking it was related to a "post" in the blog. what about "after_render"?
