### PR TITLE
Add method to render template to string to templating systems.

### DIFF
--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -157,6 +157,10 @@ class TemplateSystem(BasePlugin):
         """
         raise NotImplementedError()
 
+    def render_template_to_string(self, template, context):
+        """ Renders template to a string using context. """
+
+        raise NotImplementedError()
 
 class TaskMultiplier(BasePlugin):
     """Plugins that take a task and return *more* tasks."""

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -73,6 +73,11 @@ class JinjaTemplates(TemplateSystem):
                 output.write(output.encode('utf8'))
         return output
 
+    def render_template_to_string(self, template, context):
+        """ Render template to a string using context. """
+
+        return jinja2.Template(template).render(**context)
+
     def template_deps(self, template_name):
         # Cache the lists of dependencies for each template name.
         if self.dependency_cache.get(template_name) is None:

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -33,6 +33,7 @@ import tempfile
 
 from mako import util, lexer
 from mako.lookup import TemplateLookup
+from mako.template import Template
 from markupsafe import Markup  # It's ok, Mako requires it
 
 from nikola.plugin_categories import TemplateSystem
@@ -90,9 +91,14 @@ class MakoTemplates(TemplateSystem):
                 output.write(data)
         return data
 
+    def render_template_to_string(self, template, context):
+        """ Render template to a string using context. """
+
+        return Template(template).render(**context)
+
     def template_deps(self, template_name):
         """Returns filenames which are dependencies for a template."""
-        # We can cache here because depedencies should
+        # We can cache here because dependencies should
         # not change between runs
         if self.cache.get(template_name, None) is None:
             template = self.lookup.get_template(template_name)


### PR DESCRIPTION
It is not always convenient to have the template in a file, and the
output written to a file.  Rendering from and to a string is useful.
