### PR TITLE
Fix Guardfile generated by auto command 

### DIFF
--- a/nikola/plugins/command/auto.py
+++ b/nikola/plugins/command/auto.py
@@ -41,6 +41,7 @@ import json
 import subprocess
 
 def f():
+    import subprocess
     subprocess.call(("nikola", "build"))
 
 fdata = json.loads('''{0}''')


### PR DESCRIPTION
I was getting the error

```
ERROR:tornado.application:Error in periodic callback
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/tornado/ioloop.py", line 794, in _run
    self.callback()
  File "/usr/local/lib/python2.7/site-packages/livereload/server.py", line 54, in watch_tasks
    changes = Task.watch()
  File "/usr/local/lib/python2.7/site-packages/livereload/task.py", line 44, in watch
    func and func()
  File "Guardfile", line 8, in f
    subprocess.call(("nikola", "build"))
NameError: global name 'subprocess' is not defined
```

which happens because the callback is executed in a different context where `subprocess` is not defined. (See [livereload docs](http://livereload.readthedocs.org/en/latest/guardfile.html#define-a-function)). This fixes the problem by simply reimporting `subprocess` each time. Tested, and it works.
