### PR TITLE
Fix ipynb to work with the new OrderedDict metadata

### DIFF
--- a/nikola/plugins/compile/ipynb/__init__.py
+++ b/nikola/plugins/compile/ipynb/__init__.py
@@ -79,7 +79,7 @@ class CompileIPynb(PageCompiler):
         with codecs.open(meta_path, "wb+", "utf8") as fd:
             if onefile:
                 for k, v in metadata.items():
-                    fd.write('.. {0}: {1}\n'.format(k, v))
+                    fd.write('{0}\n'.format(v))
         print("Your post's metadata is at: ", meta_path)
         with codecs.open(path, "wb+", "utf8") as fd:
             fd.write("""{


### PR DESCRIPTION
After introduction of OrderedDict, ipynb plugin was throwing Keyerror exceptions... so here is the fix to make it work again.
If nobody goes against it, I will merge it at the end of the day, because we have a not working plugin right now.

Cheers.
