### PR TITLE
Add EXTRA_PLUGINS_DIR config variable

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1559,6 +1559,10 @@ Similarly to themes, there is a nice, built-in command to install them —
 You can also share plugins you created with the community!  Visit the
 `GitHub repository <https://github.com/getnikola/plugins>`__ to find out more.
 
+You can use the plugins in this repository without installing them into your
+site, by cloning the repository and adding the path of the plugins directory to
+the EXTRA_PLUGINS_DIRS list in your configuration.
+
 License
 -------
 

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -611,6 +611,10 @@ CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
 # Plugins you don't want to use. Be careful :-)
 # DISABLED_PLUGINS = ["render_galleries"]
 
+# Add the absolute paths to directories containing plugins, to use them.
+# For example, a clone of the nikola plugins repository
+# EXTRA_PLUGINS_DIRS = []
+
 # Experimental plugins - use at your own risk.
 # They probably need some manual adjustments - please see their respective
 # readme.

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -143,6 +143,7 @@ class Nikola(object):
             'DEFAULT_LANG': "en",
             'DEPLOY_COMMANDS': [],
             'DISABLED_PLUGINS': (),
+            'EXTRA_PLUGINS_DIRS': [],
             'COMMENT_SYSTEM_ID': 'nikolademo',
             'ENABLED_EXTRAS': (),
             'EXTRA_HEAD_DATA': '',
@@ -341,16 +342,18 @@ class Nikola(object):
             "SignalHandler": SignalHandler,
         })
         self.plugin_manager.setPluginInfoExtension('plugin')
+        extra_plugins_dirs = self.config['EXTRA_PLUGINS_DIRS']
         if sys.version_info[0] == 3:
             places = [
                 os.path.join(os.path.dirname(__file__), 'plugins'),
                 os.path.join(os.getcwd(), 'plugins'),
-            ]
+            ] + [path for path in extra_plugins_dirs if path]
         else:
             places = [
                 os.path.join(os.path.dirname(__file__), utils.sys_encode('plugins')),
                 os.path.join(os.getcwd(), utils.sys_encode('plugins')),
-            ]
+            ] + [utils.sys_encode(path) for path in extra_plugins_dirs if path]
+
         self.plugin_manager.setPluginPlaces(places)
         self.plugin_manager.collectPlugins()
 


### PR DESCRIPTION
This can be used to point to any directory containing Nikola plugins.
This is more convenient than installing plugins in the site, for each
Nikola site that I maintain/use.
