### PR TITLE
Add an explicit exception if PIL/pillow is missing.

### DIFF
--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -51,6 +51,7 @@ import PyRSS2Gen as rss
 from nikola.plugin_categories import Task
 from nikola import utils
 from nikola.post import Post
+from nikola.utils import req_missing
 
 
 class Galleries(Task):
@@ -76,6 +77,9 @@ class Galleries(Task):
 
     def gen_tasks(self):
         """Render image galleries."""
+
+        if Image is None:
+            req_missing(['pillow'], 'render galleries')
 
         self.logger = utils.get_logger('render_galleries', self.site.loghandlers)
         self.image_ext_list = ['.jpg', '.png', '.jpeg', '.gif', '.svg', '.bmp', '.tiff']


### PR DESCRIPTION
I'm not sure if this really needs a fix, since pillow is a requirement.  But an explicit error message is
better than having error messages like `AttributeError: 'NoneType' object has no attribute 'open'`

https://groups.google.com/d/msg/nikola-discuss/MYysrF1-Anc/5jm_KU9ZchYJ
