### PR TITLE
Fix drafts being leaked in feeds.

### DIFF
--- a/nikola/plugins/task/rss.py
+++ b/nikola/plugins/task/rss.py
@@ -58,6 +58,11 @@ class GenerateRSS(Task):
             "feed_length": self.site.config['FEED_LENGTH'],
         }
         self.site.scan_posts()
+        # Check for any changes in the state of use_in_feeds for any post.
+        # Issue #934
+        kw['use_in_feeds_status'] = ''.join(
+            ['T' if x.use_in_feeds else 'F' for x in self.site.timeline]
+        )
         yield self.group_task()
         for lang in kw["translations"]:
             output_name = os.path.join(kw['output_folder'],


### PR DESCRIPTION
This commit is a simple fix to work around the way `doit` seems to
handle file dependencies - if a file was a dependency for a task prior
to this run, but is no longer a dependency, the task is not run,
again. Only, the file dependencies in this run are checked for
changes.

We simply check use_in_feeds status for all the posts, to discover any
changes and regenerate the feed.

Fixes #934
