### PR TITLE
s/CommandBuild/CommandServe/

### DIFF
--- a/docs/extending.txt
+++ b/docs/extending.txt
@@ -106,7 +106,7 @@ For your own plugin, just change the values in a sensible way. The
     # You have to inherit Command for this to be a
     # command plugin:
 
-    class CommandBuild(Command):
+    class CommandServe(Command):
         """Start test server."""
 
         name = "serve"

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -37,7 +37,7 @@ from nikola.plugin_categories import Command
 from nikola.utils import get_logger
 
 
-class CommandBuild(Command):
+class CommandServe(Command):
     """Start test server."""
 
     name = "serve"


### PR DESCRIPTION
Nitpick: Mis-named Python class, in both code and custom plugins documentation example.
