### PR TITLE
Fix "translated" posts without original in default lang

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -591,7 +591,7 @@ class Nikola(object):
             # Find the correct compiler for this files extension
             lang_exts_tab = list(self.config['COMPILERS'].items())
             langs = [lang for lang, exts in lang_exts_tab if ext in exts or
-                     len([ext for ext in exts if source_name.endswith(ext)]) > 0]
+                     len([ext_ for ext_ in exts if source_name.endswith(ext_)]) > 0]
             if len(langs) != 1:
                 if len(set(langs)) > 1:
                     exit("Your file extension->compiler definition is"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -231,7 +231,7 @@ class MissingDefaultLanguageTest(TranslatedBuildTest):
     def test_translated_titles(self):
         """Do not test titles as we just removed the translation"""
         pass
-    
+
 
 class TranslationsPatternTest2(TranslatedBuildTest):
     """Check that the path_lang.ext TRANSLATIONS_PATTERN works too"""


### PR DESCRIPTION
solved by creating extension aliases according to `TRANSLATION_PATTERN`
this might solve #931 
