### PR TITLE
Avoid running bundle tasks twice (Issue #1032)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ Features
 Bugfixes
 --------
 
+* Avoid running bundle tasks twice (Issue #1032)
 * Fix post links in RSS feeds (Issue #986)
 * Only run sitemap once (Issue #1032)
 * Fix a bug with some multilingual pages

--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -87,8 +87,8 @@ class BuildBundles(LateTask):
                 output_path = os.path.join(kw['output_folder'], name)
                 dname = os.path.dirname(name)
                 file_dep = [os.path.join(kw['output_folder'], dname, fname)
-                            for fname in files]
-                file_dep = filter(os.path.isfile, file_dep)  # removes missing files
+                            for fname in files if
+                            utils.get_asset_path(fname, self.site.THEMES, self.site.config['FILES_FOLDERS'])]
                 task = {
                     'file_dep': list(file_dep),
                     'task_dep': ['copy_assets'],


### PR DESCRIPTION
This fixes another piece of #1032
