### PR TITLE
Use py.test instead of nose.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
   - "if [[ $NMODE == 'flake8' ]]; then pip install flake8; fi"
 # We run tests and nikola (to see if the command is executable) OR flake8.
 script:
-  - "if [[ $NMODE == 'nikola' ]]; then nosetests --with-coverage --cover-package=nikola --with-doctest --doctest-options=+NORMALIZE_WHITESPACE --logging-filter=-yapsy; fi"
+  - "if [[ $NMODE == 'nikola' ]]; then py.test --doctest-modules nikola/; fi"
+  - "if [[ $NMODE == 'nikola' ]]; then py.test --cov nikola --cov-report term-missing tests/; fi"
   - "if [[ $NMODE == 'nikola' ]]; then nikola help; fi"
   - "if [[ $NMODE == 'flake8' ]]; then flake8 .; fi"
 after_success:

--- a/dodo.py
+++ b/dodo.py
@@ -56,19 +56,26 @@ def task_locale():
     return {'actions': [set_nikola_test_locales], 'verbosity': 2}
 
 
+def task_doctest():
+    """run doctests with py.test"""
+    yield {
+        'actions': ['py.test --doctest-modules nikola/'],
+    }
+
+
 def task_test():
-    """run unit-tests using nose"""
+    """run unit-tests using py.test"""
     return {
-        'task_dep': ['locale'],
-        'actions': ['nosetests --with-doctest --doctest-options=+NORMALIZE_WHITESPACE --logging-filter=-yapsy'],
+        'task_dep': ['locale', 'doctest'],
+        'actions': ['py.test tests/'],
     }
 
 
 def task_coverage():
     """run unit-tests using nose"""
     return {
-        'task_dep': ['locale'],
-        'actions': ['nosetests --with-coverage --cover-package=nikola --with-doctest --doctest-options=+NORMALIZE_WHITESPACE --logging-filter=-yapsy'],
+        'task_dep': ['locale', 'doctest'],
+        'actions': ['py.test --cov nikola --cov-report term-missing tests/'],
         'verbosity': 2,
     }
 

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -2,5 +2,7 @@
 mock>=1.0.0
 coverage
 nose
+pytest
+pytest-cov
 freezegun
 python-coveralls

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,6 +33,7 @@ class EmptyBuildTest(BaseTestCase):
     @classmethod
     def setUpClass(cls):
         """Setup a demo site."""
+        cls.startdir = os.getcwd()
         cls.tmpdir = tempfile.mkdtemp()
         cls.target_dir = os.path.join(cls.tmpdir, "target")
         cls.init_command = nikola.plugins.command.init.CommandInit()
@@ -69,6 +70,8 @@ class EmptyBuildTest(BaseTestCase):
     @classmethod
     def tearDownClass(self):
         """Remove the demo site."""
+        # Don't saw off the branch you're sitting on!
+        os.chdir(self.startdir)
         # ignore_errors=True for windows by issue #782
         shutil.rmtree(self.tmpdir, ignore_errors=(sys.platform == 'win32'))
         # Fixes Issue #438


### PR DESCRIPTION
Why?
- nose is doing bad stuff to stdout/stderr, including discarding
  or showing when not needed.
- our nose test outputs contain a lot of garbage.
- nose’s output is much harder to debug.
- nose is generally disliked, while py.test is the “state-of-the-art”
  solution in the Python world.

Note that there are some bugs that kinda break it for Nikola (and that’s
basically why we run it twice, once for doctests and once for the regular test
suite)

Signed-off-by: Chris “Kwpolska” Warrick kwpolska@gmail.com
