### PR TITLE
Catch keyboard exit while serving so traceback does not show.

### DIFF
--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -89,7 +89,10 @@ class CommandServe(Command):
                 server_url = "http://{0}:{1}/".format(options['address'], options['port'])
                 self.logger.info("Opening {0} in the default web browser ...".format(server_url))
                 webbrowser.open(server_url)
-            httpd.serve_forever()
+            try:
+                httpd.serve_forever()
+            except KeyboardInterrupt:
+                exit(0)
 
 
 class OurHTTPRequestHandler(SimpleHTTPRequestHandler):


### PR DESCRIPTION
Merely aesthetic.
