### PR TITLE
Fix #1129 -- non-ASCII files/* are not copied when not needed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,8 @@ Features
 Bugfixes
 --------
 
+* Files with non-ASCII characters in filenames are copied only when needed, and
+  not every build (Issue #1129)
 * Logging configuration has been fixed.  The stderr handler can now
   only be set to DEBUG or INFO (any higher levels are corrected as INFO), and
   unwanted (i.e. DEBUG) messages are not shown, as intended. (Issue #1111)

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -517,12 +517,12 @@ def copy_tree(src, dst, link_cutoff=None):
                 continue
             dst_file = os.path.join(dst_dir, src_name)
             src_file = os.path.join(root, src_name)
-            if sys.version_info[0] == 2:
+            #if sys.version_info[0] == 2:
                 # Python2 prefers encoded str here
-                dst_file = sys_encode(dst_file)
-                src_file = sys_encode(src_file)
+                #dst_file = sys_encode(dst_file)
+                #src_file = sys_encode(src_file)
             yield {
-                'name': str(dst_file),
+                'name': dst_file,
                 'file_dep': [src_file],
                 'targets': [dst_file],
                 'actions': [(copy_file, (src_file, dst_file, link_cutoff))],


### PR DESCRIPTION
This is a fix for #1129.

This effectively undoes #1053.  @tibonihoo, could you please test if you can import your dump?

If not, would you mind providing:
- the full and exact dump used,
- your `locale` settings,
- anything else that might be useful for debugging and finding a proper solution?

Note that the tests all pass, **but** your dump is seemingly not included in those.  However, I managed to successfully import the dump with Python 2.7 and 3.3; with a proper UTF-8 locale.
