### PR TITLE
Fix #1132 -- don’t CWD to dir-with-conf.py if not needed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,10 @@ Features
 Bugfixes
 --------
 
+* The ``init`` command and the importers now always output to the CWD.
+  Previously, if you had a ``conf.py`` file higher in the directory structure,
+  Nikola would put the output of those commands in the directory that contained
+  the file. (Issue #1132)
 * Logging configuration has been fixed.  The stderr handler can now
   only be set to DEBUG or INFO (any higher levels are corrected as INFO), and
   unwanted (i.e. DEBUG) messages are not shown, as intended. (Issue #1111)

--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -70,9 +70,16 @@ def main(args):
             if os.name == 'nt':
                 colorful = False
 
-    root = get_root_dir()
-    if root:
-        os.chdir(root)
+    # Those commands do not require a `conf.py`.  (Issue #1132)
+    # Moreover, actually having one somewhere in the tree can be bad, putting
+    # the output of that command (the new site) in an unknown directory that is
+    # not the current working directory.  (does not apply to `version`)
+    argname = args[0] if len(args) > 0 else None
+    if argname not in ['init', 'import_wordpress', 'import_feed',
+                       'import_blogger', 'version']:
+        root = get_root_dir()
+        if root:
+            os.chdir(root)
 
     sys.path.append('')
     try:


### PR DESCRIPTION
This is #1132.
