### PR TITLE
Fix #1157 -- include code.css in bundles.

### DIFF
--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -98,7 +98,7 @@ class BuildBundles(LateTask):
                 # generation will happen before this task.
                 task = {
                     'file_dep': list(file_dep),
-                    'task_dep': ['copy_assets'],
+                    'task_dep': ['copy_assets', 'copy_files'],
                     'basename': str(self.name),
                     'name': str(output_path),
                     'actions': [(build_bundle, (name, file_dep))],


### PR DESCRIPTION
This is #1157.

We can do this, because:
- create_bundles depends on copy_assets
- code.css is guaranteed to be created (in one of the three ways)
