### PR TITLE
fix #1162

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,7 @@ Features
 Bugfixes
 --------
 
+* Fix links with full path in RSS for files outside root (Issue #1162)
 * ``nikola new_post`` now always outputs a newline at the end of file (Issue #1169)
 * Gallery code cleanup (Issue #1121)
 * USE_FILENAME_AS_TITLE works again (Issue #1073)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -783,14 +783,16 @@ class Nikola(object):
         items = []
 
         for post in timeline[:feed_length]:
-            data = post.text(lang, teaser_only=rss_teasers, really_absolute=True, strip_html=rss_plain)
+            old_url_type = self.config['URL_TYPE']
+            self.config['URL_TYPE'] = 'absolute'
+            data = post.text(lang, teaser_only=rss_teasers, strip_html=rss_plain)
             if feed_url is not None and data:
                 # Massage the post's HTML (unless plain)
                 if not rss_plain:
                     # FIXME: this is duplicated with code in Post.text()
                     try:
                         doc = lxml.html.document_fromstring(data)
-                        doc.rewrite_links(lambda dst: self.url_replacer(feed_url, dst, lang))
+                        doc.rewrite_links(lambda dst: self.url_replacer(post.permalink(), dst, lang))
                         try:
                             body = doc.body
                             data = (body.text or '') + ''.join(
@@ -803,7 +805,7 @@ class Nikola(object):
                             data = ""
                         else:  # let other errors raise
                             raise(e)
-
+            self.config['URL_TYPE'] = old_url_type
             args = {
                 'title': post.title(lang),
                 'link': post.permalink(lang, absolute=True),

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -402,7 +402,7 @@ class Post(object):
         else:
             return get_translation_candidate(self.config, self.base_path, sorted(self.translated_to)[0])
 
-    def text(self, lang=None, teaser_only=False, strip_html=False, really_absolute=False):
+    def text(self, lang=None, teaser_only=False, strip_html=False):
         """Read the post file for that language and return its contents.
 
         teaser_only=True breaks at the teaser marker and returns only the teaser.
@@ -426,7 +426,7 @@ class Post(object):
                 return ""
             # let other errors raise
             raise(e)
-        base_url = self.permalink(lang=lang, absolute=really_absolute)
+        base_url = self.permalink(lang=lang)
         document.make_links_absolute(base_url)
 
         if self.hyphenate:
@@ -449,11 +449,11 @@ class Post(object):
                 if not strip_html:
                     if TEASER_REGEXP.search(data).groups()[-1]:
                         teaser += '<p class="more"><a href="{0}">{1}</a></p>'.format(
-                            self.permalink(lang, absolute=really_absolute),
+                            self.permalink(lang),
                             TEASER_REGEXP.search(data).groups()[-1])
                     else:
                         teaser += READ_MORE_LINK.format(
-                            link=self.permalink(lang, absolute=really_absolute),
+                            link=self.permalink(lang),
                             read_more=self.messages[lang]["Read more"])
                 # This closes all open tags and sanitizes the broken HTML
                 document = lxml.html.fromstring(teaser)


### PR DESCRIPTION
Fixes #1162 and also makes things slightly simpler in post.text() by removing the `absolute` parameter, since that's better handled by the URL rewriter.
