### PR TITLE
Wordpress code blocks (fixes #1186)

### DIFF
--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -363,33 +363,16 @@ class CommandImportWordpress(Command, ImportMixin):
         # lang="x"] -> ```x translation, and remove quoted html entities (<,
         # >, &, and ").
 
-        # Workaround from https://gist.github.com/gromgull/3922244, because
-        # re.sub doesn't work if there is no lang. An alternative would be to
-        # use the regex module, instead of re.
-        def re_sub(pattern, replacement, string):
-            def _r(m):
-                # Now this is ugly.
-                # Python has a "feature" where unmatched groups return None
-                # then re.sub chokes on this.
-                # see http://bugs.python.org/issue1519638
+        def replacement(m):
+            language = m.group(1) or ''
+            code = m.group(2)
+            code = code.replace('&amp;', '&')
+            code = code.replace('&gt;', '>')
+            code = code.replace('&lt;', '<')
+            code = code.replace('&quot;', '"')
+            return '```{language}\n{code}\n```'.format(language=language, code=code)
 
-                # this works around and hooks into the internal of the re module...
-
-                # the match object is replaced with a wrapper that
-                # returns "" instead of None for unmatched groups
-
-                class _m():
-                    def __init__(self, m):
-                        self.m=m
-                        self.string=m.string
-                    def group(self, n):
-                        return m.group(n) or ""
-
-                return re._expand(pattern, _m(m), replacement)
-
-            return re.sub(pattern, _r, string)
-
-        return re_sub(self.code_re, r'```\1\n\2\n```', content)
+        return self.code_re.sub(replacement, content)
 
     @staticmethod
     def transform_caption(content):

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -348,22 +348,13 @@ class CommandImportWordpress(Command, ImportMixin):
                     links[url] = '/' + dst_url
                     links[url] = '/' + dst_url
 
-    @staticmethod
-    def transform_sourcecode(content):
-        new_content = re.sub('\[sourcecode language="([^"]+)"\]',
-                             "\n~~~~~~~~~~~~{.\\1}\n", content)
-        new_content = new_content.replace('[/sourcecode]',
-                                          "\n~~~~~~~~~~~~\n")
-        return new_content
-
-    code_re = re.compile(r'\[code(?: lang(?:uage)?="(.*?)")?\](.*?)\[/code\]', re.DOTALL)
+    code_re = re.compile(r'\[(?:source)?code(?: lang(?:uage)?="(.*?)")?\](.*?)\[/code\]', re.DOTALL)
 
     def transform_code(self, content):
         # http://en.support.wordpress.com/code/posting-source-code/. There are
         # a ton of things not supported here. We only do a basic [code
         # lang="x"] -> ```x translation, and remove quoted html entities (<,
         # >, &, and ").
-
         def replacement(m):
             language = m.group(1) or ''
             code = m.group(2)
@@ -390,11 +381,10 @@ class CommandImportWordpress(Command, ImportMixin):
             return content
 
     def transform_content(self, content):
-        new_content = self.transform_sourcecode(content)
-        new_content = self.transform_code(content)
-        new_content = self.transform_caption(new_content)
-        new_content = self.transform_multiple_newlines(new_content)
-        return new_content
+        content = self.transform_code(content)
+        content = self.transform_caption(content)
+        content = self.transform_multiple_newlines(content)
+        return content
 
     def import_item(self, item, wordpress_namespace, out_folder=None):
         """Takes an item from the feed and creates a post file."""

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -356,6 +356,41 @@ class CommandImportWordpress(Command, ImportMixin):
                                           "\n~~~~~~~~~~~~\n")
         return new_content
 
+    code_re = re.compile(r'\[code(?: lang(?:uage)?="(.*?)")?\](.*?)\[/code\]', re.DOTALL)
+    def transform_code(self, content):
+        # http://en.support.wordpress.com/code/posting-source-code/. There are
+        # a ton of things not supported here. We only do a basic [code
+        # lang="x"] -> ```x translation, and remove quoted html entities (<,
+        # >, &, and ").
+
+        # Workaround from https://gist.github.com/gromgull/3922244, because
+        # re.sub doesn't work if there is no lang. An alternative would be to
+        # use the regex module, instead of re.
+        def re_sub(pattern, replacement, string):
+            def _r(m):
+                # Now this is ugly.
+                # Python has a "feature" where unmatched groups return None
+                # then re.sub chokes on this.
+                # see http://bugs.python.org/issue1519638
+
+                # this works around and hooks into the internal of the re module...
+
+                # the match object is replaced with a wrapper that
+                # returns "" instead of None for unmatched groups
+
+                class _m():
+                    def __init__(self, m):
+                        self.m=m
+                        self.string=m.string
+                    def group(self, n):
+                        return m.group(n) or ""
+
+                return re._expand(pattern, _m(m), replacement)
+
+            return re.sub(pattern, _r, string)
+
+        return re_sub(self.code_re, r'```\1\n\2\n```', content)
+
     @staticmethod
     def transform_caption(content):
         new_caption = re.sub(r'\[/caption\]', '', content)
@@ -372,6 +407,7 @@ class CommandImportWordpress(Command, ImportMixin):
 
     def transform_content(self, content):
         new_content = self.transform_sourcecode(content)
+        new_content = self.transform_code(content)
         new_content = self.transform_caption(new_content)
         new_content = self.transform_multiple_newlines(new_content)
         return new_content

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -357,6 +357,7 @@ class CommandImportWordpress(Command, ImportMixin):
         return new_content
 
     code_re = re.compile(r'\[code(?: lang(?:uage)?="(.*?)")?\](.*?)\[/code\]', re.DOTALL)
+
     def transform_code(self, content):
         # http://en.support.wordpress.com/code/posting-source-code/. There are
         # a ton of things not supported here. We only do a basic [code


### PR DESCRIPTION
This is a basic fix for https://github.com/getnikola/nikola/issues/1186.  If you guys have tests I haven't modified them yet.

All it does is replace

```
[code language="stuff"]
code here
[/code]
```

with 

\`\`\`stuff
code here
\`\`\`

(no idea how to render \`\`\` inside of a code block on GitHub) in the Wordpress importer.