### PR TITLE
Fix #1195 -- evaluate TranslatableSettings into multiple languages in init.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -295,6 +295,8 @@ class Nikola(object):
             self.config['NAVIGATION_LINKS'] = {self.config['DEFAULT_LANG']: ()}
 
         # Translatability configuration.
+        self.config['TRANSLATIONS'] = self.config.get('TRANSLATIONS',
+                                                      {self.config['DEFAULT_LANG']: ''})
         utils.TranslatableSetting.default_lang = self.config['DEFAULT_LANG']
 
         self.TRANSLATABLE_SETTINGS = ('BLOG_AUTHOR',
@@ -323,7 +325,7 @@ class Nikola(object):
 
         for i in self.TRANSLATABLE_SETTINGS:
             try:
-                self.config[i] = utils.TranslatableSetting(i, self.config[i])
+                self.config[i] = utils.TranslatableSetting(i, self.config[i], self.config['TRANSLATIONS'])
             except KeyError:
                 pass
 
@@ -379,9 +381,6 @@ class Nikola(object):
 
         if not self.config.get('COPY_SOURCES'):
             self.config['SHOW_SOURCELINK'] = False
-
-        self.config['TRANSLATIONS'] = self.config.get('TRANSLATIONS',
-                                                      {self.config['DEFAULT_LANG']: ''})
 
         self.default_lang = self.config['DEFAULT_LANG']
         self.translations = self.config['TRANSLATIONS']

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -228,7 +228,7 @@ class TranslatableSetting(object):
     def __dir__(self):
         return list(set(self.__dict__).union(set(dir(str))))
 
-    def __init__(self, name, inp):
+    def __init__(self, name, inp, translations):
         """Initialize a translated setting.
 
         Valid inputs include:
@@ -240,6 +240,7 @@ class TranslatableSetting(object):
         """
         self.name = name
         self._inp = inp
+        self.translations = translations
         self.overriden_default = False
         self.values = defaultdict()
 
@@ -250,6 +251,9 @@ class TranslatableSetting(object):
                 self.default_lang = list(self.values.keys())[0]
                 self.overridden_default = True
             self.values.default_factory = lambda: self.values[self.default_lang]
+            for k in translations.keys():
+                if k not in self.values.keys():
+                    self.values[k] = inp[self.default_lang]
         else:
             self.translated = False
             self.values[self.default_lang] = inp

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -240,7 +240,7 @@ class TranslatableSettingsTest(unittest.TestCase):
     def test_string_input(self):
         """Tests for string input."""
         inp = 'Fancy Blog'
-        S = TranslatableSetting('S', inp)
+        S = TranslatableSetting('S', inp, {'xx': ''})
         S.default_lang = 'xx'
         S.lang = 'xx'
 
@@ -265,7 +265,7 @@ class TranslatableSettingsTest(unittest.TestCase):
         inp = {'xx': 'Fancy Blog',
                'zz': 'Schmancy Blog'}
 
-        S = TranslatableSetting('S', inp)
+        S = TranslatableSetting('S', inp, {'xx': '', 'zz': ''})
         S.default_lang = 'xx'
         S.lang = 'xx'
 
@@ -290,7 +290,7 @@ class TranslatableSettingsTest(unittest.TestCase):
         inp = {'xx': 'Fancy Blog',
                'zz': 'Schmancy Blog'}
 
-        S = TranslatableSetting('S', inp)
+        S = TranslatableSetting('S', inp, {'xx': '', 'zz': ''})
         S.default_lang = 'xx'
         S.lang = 'xx'
 
@@ -320,82 +320,6 @@ class TranslatableSettingsTest(unittest.TestCase):
 
         self.assertEqual(inp['zz'], u)
         self.assertEqual(inp['zz'], cn)
-
-    def test_dict_input_default_lang(self):
-        """Test dict input, with a default language change along the way."""
-        inp = {'xx': 'Fancy Blog',
-               'zz': 'Schmancy Blog'}
-
-        S = TranslatableSetting('S', inp)
-        S.default_lang = 'xx'
-        S.lang = 'xx'
-
-        try:
-            u = unicode(S)
-        except NameError:  # Python 3
-            u = str(S)
-
-        cn = S()
-
-        self.assertEqual(inp['xx'], u)
-        self.assertEqual(inp['xx'], cn)
-
-        # Change the default language.
-        # WARNING: DO NOT set default_lang locally in real code!
-        #          Set it globally instead!
-        S.default_lang = 'zz'
-
-        try:
-            u = unicode(S)
-        except NameError:  # Python 3
-            u = str(S)
-
-        cn = S()
-        cf = S('ff')
-
-        self.assertEqual(inp['xx'], u)
-        self.assertEqual(inp['xx'], cn)
-        self.assertEqual(inp['zz'], cf)
-
-    def test_dict_input_both_langs(self):
-        """Test dict input, with both languages changed along the way."""
-        inp = {'xx': 'Fancy Blog',
-               'yy': 'Dancy Blog',
-               'zz': 'Schmancy Blog'}
-
-        S = TranslatableSetting('S', inp)
-        S.default_lang = 'xx'
-        S.lang = 'xx'
-
-        try:
-            u = unicode(S)
-        except NameError:  # Python 3
-            u = str(S)
-
-        cn = S()
-
-        self.assertEqual(inp['xx'], u)
-        self.assertEqual(inp['xx'], cn)
-
-        # Change the default language.
-        # WARNING: DO NOT set those locally in real code!
-        #          Set it globally instead!
-        # WARNING: TranslatableSetting.lang is used to override the current
-        #          locale settings returned by LocaleBorg!  Use with care!
-        S.default_lang = 'zz'
-        S.lang = 'yy'
-
-        try:
-            u = unicode(S)
-        except NameError:  # Python 3
-            u = str(S)
-
-        cn = S()
-        cf = S('ff')
-
-        self.assertEqual(inp['yy'], u)
-        self.assertEqual(inp['yy'], cn)
-        self.assertEqual(inp['zz'], cf)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Note that we do not support default language changes along the way. We did not need it anyway.
