### PR TITLE
Fix #1219

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -64,6 +64,7 @@ Features
 Bugfixes
 --------
 
+* Ensure the locale is set correctly when compiling posts (Issue #1219)
 * Fix site-dependent commands (they tried to run anyways) (Issue #1223)
 * Follow symlinks when walking trees (Issue #1206)
 * bootswatch_theme works again and does not try using server hostname=swatch (Issue #1202)

--- a/nikola/plugins/compile/rest/doc.py
+++ b/nikola/plugins/compile/rest/doc.py
@@ -48,7 +48,6 @@ def doc_role(name, rawtext, text, lineno, inliner,
 
     # split link's text and post's slug in role content
     has_explicit_title, title, slug = split_explicit_title(text)
-
     # check if the slug given is part of our blog posts/pages
     twin_slugs = False
     post = None
@@ -73,7 +72,6 @@ def doc_role(name, rawtext, text, lineno, inliner,
     if not has_explicit_title:
         # use post's title as link's text
         title = post.title()
-
     permalink = post.permalink()
     if twin_slugs:
         msg = inliner.reporter.warning(

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -54,6 +54,7 @@ from .utils import (
     current_time,
     Functionary,
     LOGGER,
+    LocaleBorg,
     slugify,
     to_datetime,
     unicode_str,
@@ -332,11 +333,12 @@ class Post(object):
         dest = self.translated_base_path(lang)
         if not self.is_translation_available(lang) and not self.config['SHOW_UNTRANSLATED_POSTS']:
             return
-        else:
-            self.compile_html(
-                self.translated_source_path(lang),
-                dest,
-                self.is_two_file),
+        # Set the language to the right thing
+        LocaleBorg().set_locale(lang)
+        self.compile_html(
+            self.translated_source_path(lang),
+            dest,
+            self.is_two_file),
         if self.meta('password'):
             wrap_encrypt(dest, self.meta('password'))
         if self.publish_later:


### PR DESCRIPTION
We were not setting the locale when compiling posts. That means that everything that's locale-dependent was wrong.

This was detected in the `:doc:` role but is probably also true of things like the title used in the `.. contents::` directive.
