### PR TITLE
Fix #1225 -- stop `nikola init` from crashing if invalid locales are specified.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -64,6 +64,8 @@ Features
 Bugfixes
 --------
 
+* If an invalid language is specified, Nikola now shows a helpful error message
+  instead of a traceback (via Issue #1225)
 * Ensure the locale is set correctly when compiling posts (Issue #1219)
 * Fix site-dependent commands (they tried to run anyways) (Issue #1223)
 * Follow symlinks when walking trees (Issue #1206)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -616,7 +616,7 @@ class Nikola(object):
             try:
                 self._THEMES = utils.get_theme_chain(self.config['THEME'])
             except Exception:
-                utils.LOGGER.warn('''Can't load theme "{0}", using 'bootstrap' instead.'''.format(self.config['THEME']))
+                utils.LOGGER.warn('''Cannot load theme "{0}", using 'bootstrap' instead.'''.format(self.config['THEME']))
                 self.config['THEME'] = 'bootstrap'
                 return self._get_themes()
             # Check consistency of USE_CDN and the current THEME (Issue #386)
@@ -631,9 +631,13 @@ class Nikola(object):
     THEMES = property(_get_themes)
 
     def _get_messages(self):
-        return utils.load_messages(self.THEMES,
-                                   self.translations,
-                                   self.default_lang)
+        try:
+            return utils.load_messages(self.THEMES,
+                                       self.translations,
+                                       self.default_lang)
+        except utils.LanguageNotFoundError as e:
+            utils.LOGGER.error('''Cannot load language "{0}".  Please make sure it is supported by Nikola itself, or that you have the appropriate messages files in your themes.'''.format(e.lang))
+            sys.exit(1)
 
     MESSAGES = property(_get_messages)
 
@@ -955,7 +959,7 @@ class Nikola(object):
         """slug path handler"""
         results = [p for p in self.timeline if p.meta('slug') == name]
         if not results:
-            utils.LOGGER.warning("Can't resolve path request for slug: {0}".format(name))
+            utils.LOGGER.warning("Cannot resolve path request for slug: {0}".format(name))
         else:
             if len(results) > 1:
                 utils.LOGGER.warning('Ambiguous path request for slug: {0}'.format(name))
@@ -965,7 +969,7 @@ class Nikola(object):
         """filename path handler"""
         results = [p for p in self.timeline if p.source_path == name]
         if not results:
-            utils.LOGGER.warning("Can't resolve path request for filename: {0}".format(name))
+            utils.LOGGER.warning("Cannot resolve path request for filename: {0}".format(name))
         else:
             if len(results) > 1:
                 utils.LOGGER.error("Ambiguous path request for filename: {0}".format(name))

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -303,7 +303,6 @@ class CommandInit(Command):
                 print("Type '?' (a question mark, sans quotes) to list available languages.")
                 lhandler(default, toconf, show_header=False)
 
-
         def chandler(default, toconf):
             print("You can configure comments now.  Type '?' (a question mark, sans quotes) to list available comment systems.  If you do not want any comments, just leave the field blank.")
             answer = ask('Comment system', '')

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -465,6 +465,7 @@ def get_theme_chain(theme):
 
 warned = []
 
+
 class LanguageNotFoundError(Exception):
     def __init__(self, lang, orig):
         self.lang = lang
@@ -472,6 +473,7 @@ class LanguageNotFoundError(Exception):
 
     def __str__(self):
         return 'cannot find language {0}'.format(self.lang)
+
 
 def load_messages(themes, translations, default_lang):
     """ Load theme's messages into context.


### PR DESCRIPTION
This is #1225.
