### PR TITLE
fix #1229 -- replace __file__ with resource_filename()

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -28,6 +28,7 @@ from __future__ import print_function, unicode_literals
 import codecs
 from collections import defaultdict
 from copy import copy
+from pkg_resources import resource_filename
 import datetime
 import glob
 import locale
@@ -458,12 +459,12 @@ class Nikola(object):
         extra_plugins_dirs = self.config['EXTRA_PLUGINS_DIRS']
         if sys.version_info[0] == 3:
             places = [
-                os.path.join(os.path.dirname(__file__), 'plugins'),
+                resource_filename('nikola', 'plugins'),
                 os.path.join(os.getcwd(), 'plugins'),
             ] + [path for path in extra_plugins_dirs if path]
         else:
             places = [
-                os.path.join(os.path.dirname(__file__), utils.sys_encode('plugins')),
+                resource_filename('nikola', utils.sys_encode('plugins')),
                 os.path.join(os.getcwd(), utils.sys_encode('plugins')),
             ] + [utils.sys_encode(path) for path in extra_plugins_dirs if path]
 

--- a/nikola/plugins/basic_import.py
+++ b/nikola/plugins/basic_import.py
@@ -29,6 +29,7 @@ import codecs
 import csv
 import datetime
 import os
+from pkg_resources import resource_filename
 
 try:
     from urlparse import urlparse
@@ -95,7 +96,7 @@ class ImportMixin(object):
             utils.LOGGER.notice('The folder {0} already exists - assuming that this is a '
                                 'already existing Nikola site.'.format(self.output_folder))
 
-        filename = os.path.join(os.path.dirname(utils.__file__), 'conf.py.in')
+        filename = resource_filename('nikola', 'conf.py.in')
         # The 'strict_undefined=True' will give the missing symbol name if any,
         # (ex: NameError: 'THEME' is not defined )
         # for other errors from mako/runtime.py, you can add format_extensions=True ,

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -33,6 +33,7 @@ import json
 import textwrap
 
 from mako.template import Template
+from pkg_resources import resource_filename
 
 import nikola
 from nikola.nikola import DEFAULT_TRANSLATIONS_PATTERN, DEFAULT_READ_MORE_LINK, LEGAL_VALUES
@@ -228,15 +229,13 @@ class CommandInit(Command):
 
     @classmethod
     def copy_sample_site(cls, target):
-        lib_path = cls.get_path_to_nikola_modules()
-        src = os.path.join(lib_path, 'data', 'samplesite')
+        src = resource_filename('nikola', os.path.join('data', 'samplesite'))
         shutil.copytree(src, target)
         fix_git_symlinked(src, target)
 
     @classmethod
     def create_configuration(cls, target):
-        lib_path = cls.get_path_to_nikola_modules()
-        template_path = os.path.join(lib_path, 'conf.py.in')
+        template_path = resource_filename('nikola', 'conf.py.in')
         conf_template = Template(filename=template_path)
         conf_path = os.path.join(target, 'conf.py')
         with codecs.open(conf_path, 'w+', 'utf8') as fd:
@@ -246,10 +245,6 @@ class CommandInit(Command):
     def create_empty_site(cls, target):
         for folder in ('files', 'galleries', 'listings', 'posts', 'stories'):
             makedirs(os.path.join(target, folder))
-
-    @staticmethod
-    def get_path_to_nikola_modules():
-        return os.path.dirname(nikola.__file__)
 
     @staticmethod
     def ask_questions(target):

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -136,6 +136,7 @@ else:
 
 from doit import tools
 from unidecode import unidecode
+from pkg_resources import resource_filename
 
 import PyRSS2Gen as rss
 
@@ -425,8 +426,7 @@ def get_theme_path(theme):
     dir_name = os.path.join('themes', theme)
     if os.path.isdir(dir_name):
         return dir_name
-    dir_name = os.path.join(os.path.dirname(__file__),
-                            'data', 'themes', theme)
+    dir_name = resource_filename('nikola', os.path.join('data', 'themes', theme))
     if os.path.isdir(dir_name):
         return dir_name
     raise Exception("Can't find theme '{0}'".format(theme))


### PR DESCRIPTION
While we don’t use eggs, this is still good practice we can happily implement, right?
