### PR TITLE
Dependency on mock causes crash on init

### DIFF
--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -379,12 +379,6 @@ class CommandInit(Command):
             try:
                 if not target:
                     target = st['target']
-                    try:
-                        from mock import MagicMock as mm
-                    except ImportError:
-                        mm = None  # NOQA
-                    if isinstance(target, mm):
-                        target = None
             except KeyError:
                 pass
 

--- a/tests/test_command_init.py
+++ b/tests/test_command_init.py
@@ -47,22 +47,26 @@ class CommandInitCallTest(unittest.TestCase):
         del self.create_empty_site
 
     def test_init_default(self):
-        for arguments in (dict(options={'demo': True, 'quiet': True}, args=['destination']),
-                          {}):
-            self.init_command.execute(**arguments)
-
-            if arguments:
-                self.assertFalse(self.ask_questions.called)
-            else:
-                self.assertTrue(self.ask_questions.called)
-            self.assertTrue(self.create_configuration.called)
-            self.assertTrue(self.copy_sample_site.called)
-            self.assertFalse(self.create_empty_site.called)
-
-    def test_init_called_without_target(self):
         self.init_command.execute()
 
         self.assertTrue(self.ask_questions.called)
+        self.assertTrue(self.create_configuration.called)
+        self.assertFalse(self.copy_sample_site.called)
+        self.assertTrue(self.create_empty_site.called)
+
+    def test_init_args(self):
+        arguments = dict(options={'demo': True, 'quiet': True}, args=['destination'])
+        self.init_command.execute(**arguments)
+
+        self.assertFalse(self.ask_questions.called)
+        self.assertTrue(self.create_configuration.called)
+        self.assertTrue(self.copy_sample_site.called)
+        self.assertFalse(self.create_empty_site.called)
+
+    def test_init_called_without_target_quiet(self):
+        self.init_command.execute(**dict(options={'quiet': True}))
+
+        self.assertFalse(self.ask_questions.called)
         self.assertFalse(self.create_configuration.called)
         self.assertFalse(self.copy_sample_site.called)
         self.assertFalse(self.create_empty_site.called)


### PR DESCRIPTION
Fixes the following crash when doing `nikola init` (with no target specified)
`Traceback (most recent call last):
  File "nikola/testnikola/env/lib/python2.7/site-packages/doit/doit_cmd.py", line 120, in run
    return command.parse_execute(args)
  File "nikola/testnikola/env/lib/python2.7/site-packages/doit/cmd_base.py", line 78, in parse_execute
    return self.execute(params, args)
  File "nikola/scripts/../nikola/plugin_categories.py", line 98, in execute
    self._execute(options, args)
  File "nikola/nikola/plugins/command/init.py", line 386, in _execute
    if isinstance(target, mm):
TypeError: isinstance() arg 2 must be a class, type, or tuple of classes and types`

This crash happens when the optional `requirements-tests.txt` depencies are not installed. Which they are not when doing `pip install nikola`.I removed the dependency on mock. 

The code in init.py sets the target to None during testing which doesn't make sense. `target` can not be None because `ask_questions` forces a value from the user. I changed the tests to reflect that.
