### PR TITLE
Get rid of EXTRA_PLUGINS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -68,6 +68,7 @@ Features
 Bugfixes
 --------
 
+* Removed EXTRA_PLUGINS and ENABLED_EXTRAS options (Issue #1247)
 * ``nikola COMMAND -h/--help`` now outputs command help and not Nikola
   help (showing the command help is standard behavior) (Issue #1245)
 * Redirect pages should have a body linking to the new location

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1476,14 +1476,6 @@ and the authors Twitter user ID is found below.
     }
 
 
-Extra Plugins
--------------
-
-These are plugins that may not be widely used or that are a bit too radical or
-experimental for the general public.
-
-To enable them for your site please look for `ENABLED_EXTRAS` in your ``conf.py``.
-
 Custom Plugins
 --------------
 

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -647,14 +647,6 @@ COMMENT_SYSTEM_ID = ${COMMENT_SYSTEM_ID}
 # repository.
 # EXTRA_PLUGINS_DIRS = []
 
-# Experimental plugins - use at your own risk.
-# They probably need some manual adjustments - please see their respective
-# readme.
-# ENABLED_EXTRAS = [
-#     'planetoid',
-#     'ipynb',
-# ]
-
 # List of regular expressions, links matching them will always be considered
 # valid by "nikola check -l"
 # LINK_CHECK_WHITELIST = []

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -170,9 +170,6 @@ class Nikola(object):
 
     Takes a site config as argument on creation.
     """
-    EXTRA_PLUGINS = [
-        'ipynb',
-    ]
 
     def __init__(self, **config):
         """Setup proper environment for running tasks."""
@@ -255,7 +252,6 @@ class Nikola(object):
             'DISABLED_PLUGINS': (),
             'EXTRA_PLUGINS_DIRS': [],
             'COMMENT_SYSTEM_ID': 'nikolademo',
-            'ENABLED_EXTRAS': (),
             'EXTRA_HEAD_DATA': '',
             'FAVICONS': {},
             'FEED_LENGTH': 10,
@@ -516,9 +512,7 @@ class Nikola(object):
         self.commands = {}
         # Activate all command plugins
         for plugin_info in self.plugin_manager.getPluginsOfCategory("Command"):
-            if (plugin_info.name in self.config['DISABLED_PLUGINS']
-                or (plugin_info.name in self.EXTRA_PLUGINS and
-                    plugin_info.name not in self.config['ENABLED_EXTRAS'])):
+            if plugin_info.name in self.config['DISABLED_PLUGINS']:
                 self.plugin_manager.removePluginFromCategory(plugin_info, "Command")
                 continue
 
@@ -530,9 +524,7 @@ class Nikola(object):
         # Activate all task plugins
         for task_type in ["Task", "LateTask"]:
             for plugin_info in self.plugin_manager.getPluginsOfCategory(task_type):
-                if (plugin_info.name in self.config['DISABLED_PLUGINS']
-                    or (plugin_info.name in self.EXTRA_PLUGINS and
-                        plugin_info.name not in self.config['ENABLED_EXTRAS'])):
+                if plugin_info.name in self.config['DISABLED_PLUGINS']:
                     self.plugin_manager.removePluginFromCategory(plugin_info, task_type)
                     continue
                 self.plugin_manager.activatePluginByName(plugin_info.name)
@@ -540,9 +532,7 @@ class Nikola(object):
 
         # Activate all multiplier plugins
         for plugin_info in self.plugin_manager.getPluginsOfCategory("TaskMultiplier"):
-            if (plugin_info.name in self.config['DISABLED_PLUGINS']
-                or (plugin_info.name in self.EXTRA_PLUGINS and
-                    plugin_info.name not in self.config['ENABLED_EXTRAS'])):
+            if plugin_info.name in self.config['DISABLED_PLUGINS']:
                 self.plugin_manager.removePluginFromCategory(plugin_info, task_type)
                 continue
             self.plugin_manager.activatePluginByName(plugin_info.name)

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -54,9 +54,7 @@ class CompileMarkdown(PageCompiler):
 
     def set_site(self, site):
         for plugin_info in site.plugin_manager.getPluginsOfCategory("MarkdownExtension"):
-            if (plugin_info.name in site.config['DISABLED_PLUGINS']
-                or (plugin_info.name in site.EXTRA_PLUGINS and
-                    plugin_info.name not in site.config['ENABLED_EXTRAS'])):
+            if plugin_info.name in site.config['DISABLED_PLUGINS']:
                 site.plugin_manager.removePluginFromCategory(plugin_info, "MarkdownExtension")
                 continue
 

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -115,9 +115,7 @@ class CompileRest(PageCompiler):
 
     def set_site(self, site):
         for plugin_info in site.plugin_manager.getPluginsOfCategory("RestExtension"):
-            if (plugin_info.name in site.config['DISABLED_PLUGINS']
-                or (plugin_info.name in site.EXTRA_PLUGINS and
-                    plugin_info.name not in site.config['ENABLED_EXTRAS'])):
+            if plugin_info.name in site.config['DISABLED_PLUGINS']:
                 site.plugin_manager.removePluginFromCategory(plugin_info, "RestExtension")
                 continue
 


### PR DESCRIPTION
It used to contain planetoid, mustache, whatever and ipython notebook support.

Some plugins are now out of core, notebooks are mature, so let's kill it.
