### PR TITLE
SCHEDULE_FORCE_TODAY is redundant?

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,6 +73,7 @@ Features
 Bugfixes
 --------
 
+* Removed SCHEDULE_FORCE_TODAY option (Issue #984)
 * Give better error for unknown subcommands (Issue #1233)
 * Handle conf.py for import plugins more generically (Issue #1235)
 * Remove RSS files from the sitemap (Issue #804)

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -755,15 +755,6 @@ All these posts get queued up according to your schedule, but note
 that you will anyway need to build and deploy your site for the posts
 to appear online.  You can have a cron job that does this regularly.
 
-An additional setting (``SCHEDULE_FORCE_TODAY = True``) lets you tell
-Nikola to make the post today, if you run the ``new_post --schedule``
-after the scheduled hour has passed, and there is no other post
-at/after the scheduled hour.  Concretely, say, you run the ``nikola
-new_post -s`` command at 10am on a Monday (with the schedule rule set
-to the same as above), with no other post on Monday, at/after 7am,
-setting ``SCHEDULE_FORCE_TODAY = True`` will have your post scheduled
-to Monday, instead of being scheduled to Wednesday 7am.
-
 Post Types
 ~~~~~~~~~~
 

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -472,8 +472,6 @@ COMMENT_SYSTEM_ID = ${COMMENT_SYSTEM_ID}
 # SCHEDULE_RULE = ''
 # If True, use the scheduling rule to all posts by default
 # SCHEDULE_ALL = False
-# If True, schedules post to today if possible, even if scheduled hour is over
-# SCHEDULE_FORCE_TODAY = False
 
 # Do you want a add a Mathjax config file?
 # MATHJAX_CONFIG = ""

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -321,7 +321,6 @@ class Nikola(object):
             'DEPLOY_FUTURE': False,
             'SCHEDULE_ALL': False,
             'SCHEDULE_RULE': '',
-            'SCHEDULE_FORCE_TODAY': False,
             'LOGGING_HANDLERS': {'stderr': {'loglevel': 'WARNING', 'bubble': True}},
             'DEMOTE_HEADERS': 1,
         }

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -84,7 +84,7 @@ def get_default_compiler(is_post, compilers, post_pages):
     return 'rest'
 
 
-def get_date(schedule=False, rule=None, last_date=None, force_today=False, tz=None, iso8601=False):
+def get_date(schedule=False, rule=None, last_date=None, tz=None, iso8601=False):
     """Returns a date stamp, given a recurrence rule.
 
     schedule - bool:
@@ -95,10 +95,6 @@ def get_date(schedule=False, rule=None, last_date=None, force_today=False, tz=No
 
     last_date - datetime:
         timestamp of the last post
-
-    force_today - bool:
-        tries to schedule a post to today, if possible, even if the scheduled
-        time has already passed in the day.
 
     tz - tzinfo:
         the timezone used for getting the current time.
@@ -124,9 +120,6 @@ def get_date(schedule=False, rule=None, last_date=None, force_today=False, tz=No
         except Exception:
             LOGGER.error('Unable to parse rule string, using current time.')
         else:
-            # Try to post today, instead of tomorrow, if no other post today.
-            if force_today:
-                now = now.replace(hour=0, minute=0, second=0, microsecond=0)
             date = rule_.after(max(now, last_date or now), last_date is None)
 
     offset = tz.utcoffset(now)
@@ -289,11 +282,10 @@ class CommandNewPost(Command):
         # Calculate the date to use for the content
         schedule = options['schedule'] or self.site.config['SCHEDULE_ALL']
         rule = self.site.config['SCHEDULE_RULE']
-        force_today = self.site.config['SCHEDULE_FORCE_TODAY']
         self.site.scan_posts()
         timeline = self.site.timeline
         last_date = None if not timeline else timeline[0].date
-        date = get_date(schedule, rule, last_date, force_today, self.site.tzinfo, self.site.config['FORCE_ISO8601'])
+        date = get_date(schedule, rule, last_date, self.site.tzinfo, self.site.config['FORCE_ISO8601'])
         data = {
             'title': title,
             'slug': slug,


### PR DESCRIPTION
Hi,

further reading of the handbook has brought me to **SCHEDULE_FORCE_TODAY** setting, and by following the example from the handbook, it seems to be that instead of having **SCHEDULE_FORCE_TODAY** setting, the same thing could be accomplished by just using:

```
nikola new_post
```

without 

```
--schedule
```

option, which would mean one setting less to take care of in Nikola?
