### PR TITLE
Cannot render site without RSS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Added ``GENERATE_RSS`` setting to allow disabling RSS in Nikola (Issue #1236)
 * Link listings raw sources if COPY_SOURCES is True (Issue #1214)
 * Much more powerful ``nikola plugin`` command (Issue #1189)
 * More powerful console mode allows access to all nikola commands (Issue #830)

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -535,6 +535,10 @@ COMMENT_SYSTEM_ID = ${COMMENT_SYSTEM_ID}
 # Defaults to 10
 # INDEX_DISPLAY_POST_COUNT = 10
 
+# By default, Nikola generates RSS files for the website and for tags.
+# Set this to False to disable all that.
+# GENERATE_RSS = True
+
 # RSS_LINK is a HTML fragment to link the RSS or Atom feeds. If set to None,
 # the base.tmpl will use the feed Nikola generates. However, you may want to
 # change it for a feedburner feed or something else.

--- a/nikola/data/themes/base-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_helper.tmpl
@@ -81,7 +81,7 @@ lang="{{ lang }}">
 {% macro html_feedlinks() %}
     {% if rss_link %}
         {{ rss_link }}
-    {% else %}
+    {% elif generate_rss %}
         {% if translations|length > 1 %}
             {% for language in translations %}
                 <link rel="alternate" type="application/rss+xml" title="RSS ({{ language }})" href="{{ _link('rss', None, language) }}">

--- a/nikola/data/themes/base-jinja/templates/tag.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tag.tmpl
@@ -3,11 +3,11 @@
 
 {% block extra_head %}
     {{ super() }}
-    {% if translations|length > 1 %}
+    {% if translations|length > 1 and generate_rss %}
         {% for language in translations %}
             <link rel="alternate" type="application/rss+xml" type="application/rss+xml" title="RSS for {{ kind }} {{ tag }} ({{ language }})" href="{{ _link(kind + "_rss", tag, language) }}">
         {% endfor %}
-    {% else %}
+    {% elif generate_rss %}
         <link rel="alternate" type="application/rss+xml" type="application/rss+xml" title="RSS for {{ kind }} {{ tag }}" href="{{ _link(kind + "_rss", tag) }}">
     {% endif %}
 {% endblock %}
@@ -18,13 +18,13 @@
     <header>
         <h1>{{ title }}</h1>
         <div class="metadata">
-            {% if translations|length > 1 %}
+            {% if translations|length > 1 and generate_rss %}
                 {% for language in translations %}
                 <p class="feedlink">
                     <a href="{{ _link(kind + "_rss", tag, language) }}" hreflang="{{ language }}" type="application/rss+xml">{{ messages('RSS feed', language) }} ({{ language }})</a>&nbsp;
                 </p>
                 {% endfor %}
-            {% else %}
+            {% elif generate_rss %}
                 <p class="feedlink"><a href="{{ _link(kind + "_rss", tag) }}" type="application/rss+xml">{{ messages('RSS feed') }}</a></p>
             {% endif %}
         </div>

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -81,7 +81,7 @@ lang="${lang}">
 <%def name="html_feedlinks()">
     %if rss_link:
         ${rss_link}
-    %else:
+    %elif generate_rss:
         %if len(translations) > 1:
             %for language in translations:
                 <link rel="alternate" type="application/rss+xml" title="RSS (${language})" href="${_link('rss', None, language)}">

--- a/nikola/data/themes/base/templates/tag.tmpl
+++ b/nikola/data/themes/base/templates/tag.tmpl
@@ -3,11 +3,11 @@
 
 <%block name="extra_head">
     ${parent.extra_head()}
-    %if len(translations) > 1:
+    %if len(translations) > 1 and generate_rss:
         %for language in translations:
             <link rel="alternate" type="application/rss+xml" type="application/rss+xml" title="RSS for ${kind} ${tag} (${language})" href="${_link(kind + "_rss", tag, language)}">
         %endfor
-    %else:
+    %elif generate_rss:
         <link rel="alternate" type="application/rss+xml" type="application/rss+xml" title="RSS for ${kind} ${tag}" href="${_link(kind + "_rss", tag)}">
     %endif
 </%block>
@@ -18,13 +18,13 @@
     <header>
         <h1>${title}</h1>
         <div class="metadata">
-            %if len(translations) > 1:
+            %if len(translations) > 1 and generate_rss:
                 %for language in translations:
                 <p class="feedlink">
                     <a href="${_link(kind + "_rss", tag, language)}" hreflang="${language}" type="application/rss+xml">${messages('RSS feed', language)} (${language})</a>&nbsp;
                 </p>
                 %endfor
-            %else:
+            %elif generate_rss:
                 <p class="feedlink"><a href="${_link(kind + "_rss", tag)}" type="application/rss+xml">${messages('RSS feed')}</a></p>
             %endif
         </div>

--- a/nikola/data/themes/bootstrap-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap-jinja/templates/base_helper.tmpl
@@ -141,7 +141,7 @@ lang="{{ lang }}">
 {% macro html_feedlinks() %}
     {% if rss_link %}
         {{ rss_link }}
-    {% else %}
+    {% elif generate_rss %}
         {% if translations|length > 1 %}
             {% for language in translations %}
                 <link rel="alternate" type="application/rss+xml" title="RSS ({{ language }})" href="{{ _link('rss', None, language) }}">

--- a/nikola/data/themes/bootstrap/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap/templates/base_helper.tmpl
@@ -141,7 +141,7 @@ lang="${lang}">
 <%def name="html_feedlinks()">
     %if rss_link:
         ${rss_link}
-    %else:
+    %elif generate_rss:
         %if len(translations) > 1:
             %for language in translations:
                 <link rel="alternate" type="application/rss+xml" title="RSS (${language})" href="${_link('rss', None, language)}">

--- a/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
@@ -138,7 +138,7 @@ lang="{{ lang }}">
 {% macro html_feedlinks() %}
     {% if rss_link %}
         {{ rss_link }}
-    {% else %}
+    {% elif generate_rss %}
         {% if translations|length > 1 %}
             {% for language in translations %}
                 <link rel="alternate" type="application/rss+xml" title="RSS ({{ language }})" href="{{ _link('rss', None, language) }}">

--- a/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
@@ -138,7 +138,7 @@ lang="${lang}">
 <%def name="html_feedlinks()">
     %if rss_link:
         ${rss_link}
-    %else:
+    %elif generate_rss:
         %if len(translations) > 1:
             %for language in translations:
                 <link rel="alternate" type="application/rss+xml" title="RSS (${language})" href="${_link('rss', None, language)}">

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -243,7 +243,7 @@ class Nikola(object):
             'DATE_FORMAT': '%Y-%m-%d %H:%M',
             'DEFAULT_LANG': "en",
             'DEPLOY_COMMANDS': [],
-            'DISABLED_PLUGINS': (),
+            'DISABLED_PLUGINS': [],
             'EXTRA_PLUGINS_DIRS': [],
             'COMMENT_SYSTEM_ID': 'nikolademo',
             'EXTRA_HEAD_DATA': '',
@@ -288,6 +288,7 @@ class Nikola(object):
             'RSS_READ_MORE_LINK': DEFAULT_RSS_READ_MORE_LINK,
             'REDIRECTIONS': [],
             'ROBOTS_EXCLUSIONS': [],
+            'GENERATE_RSS': True,
             'RSS_LINK': None,
             'RSS_PATH': '',
             'RSS_PLAIN': False,
@@ -448,6 +449,14 @@ class Nikola(object):
             utils.LOGGER.warn('The moot comment system has been renamed to muut by the upstream.  Setting COMMENT_SYSTEM to "muut".')
             self.config['COMMENT_SYSTEM'] = 'muut'
 
+        # Disable RSS.  For a successful disable, we must have both the option
+        # false and the plugin disabled through the official means.
+        if 'generate_rss' in self.config['DISABLED_PLUGINS']:
+            self.config['GENERATE_RSS'] = False
+
+        if not self.config['GENERATE_RSS'] and 'generate_rss' not in self.config['DISABLED_PLUGINS']:
+            self.config['DISABLED_PLUGINS'].append('generate_rss')
+
         # PRETTY_URLS defaults to enabling STRIP_INDEXES unless explicitly disabled
         if self.config.get('PRETTY_URLS') and 'STRIP_INDEXES' not in config:
             self.config['STRIP_INDEXES'] = True
@@ -605,6 +614,7 @@ class Nikola(object):
         self._GLOBAL_CONTEXT['transition'] = self.config.get('THEME_REVEAL_CONFIG_TRANSITION')
         self._GLOBAL_CONTEXT['content_footer'] = self.config.get(
             'CONTENT_FOOTER')
+        self._GLOBAL_CONTEXT['generate_rss'] = self.config.get('GENERATE_RSS')
         self._GLOBAL_CONTEXT['rss_path'] = self.config.get('RSS_PATH')
         self._GLOBAL_CONTEXT['rss_link'] = self.config.get('RSS_LINK')
 

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -103,6 +103,7 @@ class Galleries(Task):
             'feed_length': self.site.config['FEED_LENGTH'],
             'tzinfo': self.site.tzinfo,
             'comments_in_galleries': self.site.config['COMMENTS_IN_GALLERIES'],
+            'generate_rss': self.site.config['GENERATE_RSS'],
         }
 
         for k, v in self.site.GLOBAL_CONTEXT['template_hooks'].items():
@@ -241,33 +242,34 @@ class Galleries(Task):
                 }, self.kw['filters'])
 
                 # RSS for the gallery
-                rss_dst = os.path.join(
-                    self.kw['output_folder'],
-                    self.site.path(
-                        "gallery_rss",
-                        os.path.relpath(gallery, self.kw['gallery_path']), lang))
-                rss_dst = os.path.normpath(rss_dst)
+                if self.kw["generate_rss"]:
+                    rss_dst = os.path.join(
+                        self.kw['output_folder'],
+                        self.site.path(
+                            "gallery_rss",
+                            os.path.relpath(gallery, self.kw['gallery_path']), lang))
+                    rss_dst = os.path.normpath(rss_dst)
 
-                yield utils.apply_filters({
-                    'basename': self.name,
-                    'name': rss_dst,
-                    'file_dep': file_dep,
-                    'targets': [rss_dst],
-                    'actions': [
-                        (self.gallery_rss, (
-                            image_list,
-                            img_titles,
-                            lang,
-                            self.site.link(
-                                "gallery_rss", os.path.basename(gallery), lang),
-                            rss_dst,
-                            context['title']
-                        ))],
-                    'clean': True,
-                    'uptodate': [utils.config_changed({
-                        1: self.kw,
-                    })],
-                }, self.kw['filters'])
+                    yield utils.apply_filters({
+                        'basename': self.name,
+                        'name': rss_dst,
+                        'file_dep': file_dep,
+                        'targets': [rss_dst],
+                        'actions': [
+                            (self.gallery_rss, (
+                                image_list,
+                                img_titles,
+                                lang,
+                                self.site.link(
+                                    "gallery_rss", os.path.basename(gallery), lang),
+                                rss_dst,
+                                context['title']
+                            ))],
+                        'clean': True,
+                        'uptodate': [utils.config_changed({
+                            1: self.kw,
+                        })],
+                    }, self.kw['filters'])
 
     def find_galleries(self):
         """Find all galleries to be processed according to conf.py"""

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -61,9 +61,9 @@ class RenderTags(Task):
             "output_folder": self.site.config['OUTPUT_FOLDER'],
             "filters": self.site.config['FILTERS'],
             "tag_pages_are_indexes": self.site.config['TAG_PAGES_ARE_INDEXES'],
-            "index_display_post_count":
-            self.site.config['INDEX_DISPLAY_POST_COUNT'],
+            "index_display_post_count": self.site.config['INDEX_DISPLAY_POST_COUNT'],
             "index_teasers": self.site.config['INDEX_TEASERS'],
+            "generate_rss": self.site.config['GENERATE_RSS'],
             "rss_teasers": self.site.config["RSS_TEASERS"],
             "rss_plain": self.site.config["RSS_PLAIN"],
             "show_untranslated_posts": self.site.config['SHOW_UNTRANSLATED_POSTS'],
@@ -90,7 +90,8 @@ class RenderTags(Task):
                     filtered_posts = post_list
                 else:
                     filtered_posts = [x for x in post_list if x.is_translation_available(lang)]
-                yield self.tag_rss(tag, lang, filtered_posts, kw, is_category)
+                if kw["generate_rss"]:
+                    yield self.tag_rss(tag, lang, filtered_posts, kw, is_category)
                 # Render HTML
                 if kw['tag_pages_are_indexes']:
                     yield self.tag_page_as_index(tag, lang, filtered_posts, kw, is_category)
@@ -205,12 +206,13 @@ class RenderTags(Task):
         num_pages = len(lists)
         for i, post_list in enumerate(lists):
             context = {}
-            # On a tag page, the feeds include the tag's feeds
-            rss_link = ("""<link rel="alternate" type="application/rss+xml" """
-                        """type="application/rss+xml" title="RSS for tag """
-                        """{0} ({1})" href="{2}">""".format(
-                            tag, lang, self.site.link(kind + "_rss", tag, lang)))
-            context['rss_link'] = rss_link
+            if kw["generate_rss"]:
+                # On a tag page, the feeds include the tag's feeds
+                rss_link = ("""<link rel="alternate" type="application/rss+xml" """
+                            """type="application/rss+xml" title="RSS for tag """
+                            """{0} ({1})" href="{2}">""".format(
+                                tag, lang, self.site.link(kind + "_rss", tag, lang)))
+                context['rss_link'] = rss_link
             output_name = os.path.join(kw['output_folder'],
                                        page_name(tag, i, lang))
             context["title"] = kw["messages"][lang][


### PR DESCRIPTION
I want to make a site purely based on pages, and not have RSS links. I also disable archive, indexes, etc.

The goal of this subsite is to provide performance data and to be run in Buildbot and deploy automatically static pages only, but matching/integrating with the Nikola site I already have.

Right now DISABLED_PLUGINS must not contain "generate_rss" or practically everything crashes with key errors for "rss" links.
