### PR TITLE
fix #1263 -- monthly archive links should end in /index.html

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -77,8 +77,10 @@ Features
 Bugfixes
 --------
 
+* Links in monthly archives did not have ``/index.html`` if STRIP_INDEXES
+  was set to False (Issue #1263)
 * Fix lxml adding extra root tags being added by lxml by lxml.html.tostring
-* not having typogrify installed now produces a valid error (Issue #1262)
+* Not having typogrify installed now produces a valid error (Issue #1262)
 * Pages were not rebuilt when DEMOTE_HEADERS was changed (Issue #1261)
 * code.css was not rebuilt, even though there were changes in v6.4.0 to its
   format (via Issue #1050)

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -77,11 +77,11 @@ class Archive(Task):
                     post_list.reverse()
                     context["posts"] = post_list
                 else:  # Monthly archives, just list the months
-                    months = set([m.split('/')[1] for m in self.site.posts_per_month.keys() if m.startswith(str(year))])
+                    months = set([(m.split('/')[1], self.site.link("archive", m, lang)) for m in self.site.posts_per_month.keys() if m.startswith(str(year))])
                     months = sorted(list(months))
                     months.reverse()
                     template_name = "list.tmpl"
-                    context["items"] = [[nikola.utils.LocaleBorg().get_month_name(int(month), lang), month] for month in months]
+                    context["items"] = [[nikola.utils.LocaleBorg().get_month_name(int(month), lang), link] for month, link in months]
                     post_list = []
                 task = self.site.generic_post_list_renderer(
                     lang,


### PR DESCRIPTION
This is #1263.

(I’m not doing all this issue2pr hassle, it is ugly and hacky IMO)
