### PR TITLE
Fix issue where plugin JSON wasn't being returned

### DIFF
--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -318,6 +318,5 @@ class CommandPlugin(Command):
             return
         if self.json is None:
             data = requests.get(url).text
-            data = json.loads(data)
-            self.json = data
+            self.json = json.loads(data)
         return self.json


### PR DESCRIPTION
When the plugin command's JSON-request caching feature was implemented, the resulting refactored method didn't return anything when no cached data was available.

This should fix that.
