### PR TITLE
Fix #1273 -- make non-ASCII-titled sites build

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1313,7 +1313,7 @@ class Nikola(object):
         return utils.apply_filters(task, filters)
 
     def __repr__(self):
-        return '<Nikola Site: {0}>'.format(self.config['BLOG_TITLE']())
+        return '<Nikola Site: {0!r}>'.format(self.config['BLOG_TITLE']())
 
 
 def sanitized_locales(locale_fallback, locale_default, locales, translations):

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -332,14 +332,7 @@ class TranslatableSetting(object):
 
     def __repr__(self):
         """Provide a representation for programmers."""
-        header = '<TranslatableSetting> '
-
-        if not self.translated:
-            values = [repr(self())]
-        else:
-            values = ['{0}={1!r}'.format(k, v) for k, v in self.values.items()]
-
-        return header + ', '.join(values)
+        return '<TranslatableSetting: {0!r}>'.format(self.name)
 
     def format(self, *args, **kwargs):
         """Format ALL the values in the setting the same way."""


### PR DESCRIPTION
`__repr__()` goes crazy when it has too much to do with Unicode.

Signed-off-by: Chris “Kwpolska” Warrick kwpolska@gmail.com
