### PR TITLE
Emit "initialized" event when config is ready and commands too

### DIFF
--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -226,6 +226,8 @@ class NikolaTaskLoader(TaskLoader):
         latetasks = generate_tasks(
             'post_render',
             self.nikola.gen_tasks('post_render', "LateTask", 'Group of tasks to be executes after site is rendered.'))
+        from blinker import signal
+        signal('initialized').send(self.nikola)
         return tasks + latetasks, DOIT_CONFIG
 
 


### PR DESCRIPTION
I needed a way to put tags data in every page. I cannot use conf.py for that because as i understand Nikola.scan_posts() should be runnable in order to have the data. So i made a SignalHandler plugin hoping to use the "initialized" signal as stated in the docs ( here: http://getnikola.com/extending.html#signalhandler-plugins , but I discovered with a grep that an "initialized" event is never emitted by actual code. So here is a simple patch that emits it when Nikola and the commands are ready to go.  I'm not an expert on Nikola's code so feel free to relocate is as long as Nikola.scan_posts() still works when called by a listening SignalHandler's code
