### PR TITLE
don’t generate STORY_INDEX if a conflicting story exists

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Don’t generate STORY_INDEX if there is a conflicting story
 * Added support for enclosures (via optional enclosure metadata tag) (Issue #1322)
 
 Bugfixes

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -439,6 +439,9 @@ COMMENT_SYSTEM_ID = ${COMMENT_SYSTEM_ID}
 # ANNOTATIONS = False
 
 # Create index.html for story folders?
+# WARNING: if a story would conflict with the index file (usually
+#          caused by setting slug to `index`), the STORY_INDEX
+#          will not be generated for that directory.
 # STORY_INDEX = False
 # Enable comments on story pages?
 # COMMENTS_IN_STORIES = False


### PR DESCRIPTION
This is a fix for the dreaded

```
ERROR: Two different tasks can't have a common target.
'output/index.html' is a target for render_pages:output/index.html and
render_indexes:output/index.html`.
```

This works by checking pages that would appear in the index, and if one of them has a matching destination (i.e. slug == index), the story index is not generated.  Most users are likely to want it to work this way.

Signed-off-by: Chris “Kwpolska” Warrick kwpolska@gmail.com

P.S. happy Nikola Tesla day!
