### PR TITLE
fix #1354 -- copy .html source files as .src.html

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* sources for .html files are now copied as .src.html (Issue #1354)
 * Copy files/*.html verbatim (skip filters)
 * Don’t generate STORY_INDEX if there is a conflicting story
 * Added support for enclosures (via optional enclosure metadata tag) (Issue #1322)

--- a/nikola/plugins/task/sources.py
+++ b/nikola/plugins/task/sources.py
@@ -60,11 +60,8 @@ class Sources(Task):
                         continue
                     output_name = os.path.join(
                         kw['output_folder'], post.destination_path(
-                            lang, post.source_ext()))
+                            lang, post.source_ext(True)))
                     source = post.source_path
-                    dest_ext = self.site.get_compiler(post.source_path).extension()
-                    if dest_ext == post.source_ext():
-                        continue
                     if lang != kw["default_lang"]:
                         source_lang = utils.get_translation_candidate(self.site.config, source, lang)
                         if os.path.exists(source_lang):

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -546,9 +546,10 @@ class Post(object):
 
     def source_link(self, lang=None):
         """Return absolute link to the post's source."""
+        ext = self.source_ext(True)
         return "/" + self.destination_path(
             lang=lang,
-            extension=self.source_ext(),
+            extension=ext,
             sep='/')
 
     def destination_path(self, lang=None, extension='.html', sep=os.sep):
@@ -589,8 +590,20 @@ class Post(object):
         else:
             return link
 
-    def source_ext(self):
-        return os.path.splitext(self.source_path)[1]
+    def source_ext(self, prefix=False):
+        """
+        Return the source file extension.
+
+        If `prefix` is True, a `.src.` prefix will be added to the resulting extension
+        if it’s equal to the destination extension.
+        """
+
+        ext = os.path.splitext(self.source_path)[1]
+        if prefix and ext == self.compiler.extension():
+            # ext starts with a dot
+            return '.src' + ext
+        else:
+            return ext
 
 # Code that fetches metadata from different places
 


### PR DESCRIPTION
This is the first fix described in #1354.  `.html` source files are now copied as `.src.html`, verbatim.  This can be useful in some cases, eg. for debug purposes.

Signed-off-by: Chris “Kwpolska” Warrick kwpolska@gmail.com
