### PR TITLE
copy files/*.html verbatim (skip filters)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Copy files/*.html verbatim (skip filters)
 * Don’t generate STORY_INDEX if there is a conflicting story
 * Added support for enclosures (via optional enclosure metadata tag) (Issue #1322)
 

--- a/nikola/plugins/task/copy_files.py
+++ b/nikola/plugins/task/copy_files.py
@@ -52,4 +52,4 @@ class CopyFiles(Task):
             for task in utils.copy_tree(src, real_dst, link_cutoff=dst):
                 task['basename'] = self.name
                 task['uptodate'] = [utils.config_changed(kw)]
-                yield utils.apply_filters(task, filters)
+                yield utils.apply_filters(task, filters, skip_ext=['.html'])

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -769,7 +769,7 @@ def current_time(tzinfo=None):
     return dt
 
 
-def apply_filters(task, filters):
+def apply_filters(task, filters, skip_ext=None):
     """
     Given a task, checks its targets.
     If any of the targets has a filter that matches,
@@ -790,6 +790,8 @@ def apply_filters(task, filters):
 
     for target in task.get('targets', []):
         ext = os.path.splitext(target)[-1].lower()
+        if skip_ext and ext in skip_ext:
+            continue
         filter_ = filter_matches(ext)
         if filter_:
             for action in filter_:


### PR DESCRIPTION
Use case: Google site verification.

And besides, verbatim copying is generally what a person putting .html files in there would want (why not make them stories if that’s not the case?)

Signed-off-by: Chris “Kwpolska” Warrick kwpolska@gmail.com
