### PR TITLE
Don't force push to GitHub

### DIFF
--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -137,7 +137,7 @@ class CommandGitHubDeploy(Command):
         commands = [
             ['git', 'add', '-A'],
             ['git', 'commit', '-m', commit_message],
-            ['git', 'push', '-f', remote, '%s:%s' % (deploy, deploy)],
+            ['git', 'push', remote, '%s:%s' % (deploy, deploy)],
             ['git', 'checkout', source],
         ]
 


### PR DESCRIPTION
If a force push is necessary, it probably means something is wrong, so instead
of force pushing, it would be better to fail.
