### PR TITLE
Fix issue with livereload

### DIFF
--- a/nikola/plugins/command/auto.py
+++ b/nikola/plugins/command/auto.py
@@ -84,4 +84,4 @@ class CommandAuto(Command):
         else:
             browser = False
 
-            server.serve(port, None, out_folder, True, browser)
+            server.serve(port, None, out_folder, browser)


### PR DESCRIPTION
The auto command was not working for me.  While reading this code along with LiveReload API, I think this is the proper fix.

Ref:
http://livereload.readthedocs.org/en/latest/#module-livereload

Traceback fixed:
File "/usr/lib/python3.4/site-packages/nikola/plugins/command/auto.py", line 87, in _execute
    server.serve(port, None, out_folder, True, browser)
TypeError: serve() takes from 1 to 5 positional arguments but 6 were given
