### PR TITLE
fix Mako template rendering in render_template_to_string()

### DIFF
--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -115,7 +115,7 @@ class MakoTemplates(TemplateSystem):
     def render_template_to_string(self, template, context):
         """ Render template to a string using context. """
 
-        context = context.update(self.filters)
+        context.update(self.filters)
 
         return Template(template).render(**context)
 


### PR DESCRIPTION
`context` is a `dict`, `dict.update` returns `None`, so `.render(**None)` explodes.

The problem was introduced in 5e3be31a. What suprised me was that render_template_to_string() is not used anywhere in Nikola and doesn't seem to have any automated tests since its introduction in 170577fc. 
