### PR TITLE
Fix documentation for `post-list`

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1496,7 +1496,7 @@ with the tag ``nikola``::
    Here are my 5 latest and greatest blog posts:
 
    .. post-list::
-      :start: -5
+      :stop: 5
 
    These are all my posts about Nikola:
 
@@ -1505,7 +1505,7 @@ with the tag ``nikola``::
 
 Note that you can give the ``tags`` option a comma-separated list of tags, in
 which case the list will show all posts that have at least one of those tags.
-Other interesting options include ``stop`` (set it to ``-1``, for example, to
+Other interesting options include ``start`` (set it to ``1``, for example, to
 show all but the last post); ``reverse`` (set to ``True`` to sort the list in
 chronological order, instead of the default latest-post-first); ``lang``
 (language to use for post titles and links); and ``slugs`` (allows you to filter


### PR DESCRIPTION
The handbook entry for the `post-list` directive doesn't match how it is currently implemented.
