### PR TITLE
Don’t check cache/ in ``nikola check -l``

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,7 @@ Features
 Bugfixes
 --------
 
-* Don’t check cache/ in ``nikola check -l`` (Issue #1446)
+* Don’t check cache/ in ``nikola check -l`` (Issue #1447)
 * Fix new_post for pandoc format (Issue #1445)
 * Fix STORY_INDEX generation (Issue #1444)
 * Fix bootswatch creation version check (Issue #1441)

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -159,7 +159,7 @@ class CommandCheck(Command):
             if filename.startswith(self.site.config['CACHE_FOLDER']):
                 # Do not look at links in the cache, which are not parsed by
                 # anyone and may result in false positives.  Problems arise
-                # with galleries, for example.  Full rationale: (Issue #1446)
+                # with galleries, for example.  Full rationale: (Issue #1447)
                 self.logger.notice("Ignoring {0} (in cache, links may be incorrect)".format(filename))
                 return False
 


### PR DESCRIPTION
While trying to add `nikola check -l` into my workflow (hat tip @Aeyoun), I encountered this issue:

```
$ nikola check -l
Scanning posts.....done!
[2014-10-14T08:00:18Z] WARNING: check: Broken link in cache/galleries/speeker/index.html: /blog/2014/08/26/speeker/
[2014-10-14T08:00:18Z] WARNING: check: Broken link in cache/galleries/speeker/index.pl.html: /pl/blog/2014/08/26/speeker/
```

After a bit of debugging, I discovered that it’s caused by them being `cache/` files.  You see, `nikola check -l` takes only output from a few plugins (which means all third-party plugins and even some first-party ones are happily **ignored**…).  `render_posts` (the main thing that outputs into `cache/`) is not among them, but `render_galleries` is.  If you use `index.txt` files in your galleries to provide a description, `render_galleries` has to render that post to `cache/`.

Now, here’s what happened: my gallery links back to the post it’s illustrating.  The link is pointing to `/blog/2014/08/26/speeker/` — which is a perfectly reasonable and functional link.  In the final page under `output/`, the link is transformed to point to the correct file as a relative link (`../../blog/2014/08/26/speeker/`); however, the copy in `cache/` has the raw absolute link.  That points to a file under the root of my hard drive.  Which does not exist.

And as such, we must ignore things under the cache folder.  This introduces exactly that.

Comments?
