### PR TITLE
Add a configuration entry where plugins can add a function to be called at template's context calculation time

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -743,3 +743,8 @@ LOGGING_HANDLERS = {
 # Put in global_context things you want available on all your templates.
 # It can be anything, data, functions, modules, etc.
 GLOBAL_CONTEXT = {}
+
+# Add functions here and they will be called with template
+# GLOBAL_CONTEXT as parameter when the template is about to be
+# rendered
+GLOBAL_CONTEXT_FILLER = []

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -268,6 +268,7 @@ class Nikola(object):
             'FORCE_ISO8601': False,
             'GALLERY_PATH': 'galleries',
             'GALLERY_SORT_BY_DATE': True,
+            'GLOBAL_CONTEXT_FILLER': [],
             'GZIP_COMMAND': None,
             'GZIP_FILES': False,
             'GZIP_EXTENSIONS': ('.txt', '.htm', '.html', '.css', '.js', '.json', '.xml'),
@@ -780,6 +781,9 @@ class Nikola(object):
         local_context["formatmsg"] = lambda s, *a: s % a
         for h in local_context['template_hooks'].values():
             h.context = context
+
+        for func in self.config['GLOBAL_CONTEXT_FILLER']:
+            func(local_context, template_name)
 
         data = self.template_system.render_template(
             template_name, None, local_context)


### PR DESCRIPTION
My plugin renders template data to json for later consuming on the client side. The plugin work in tandem with a modified bootstrap3-jinja theme which uses that same "static post data" to render. This is because fragments of the templates are shared with the JS code to render them as a single page app instead of reloading all the page. Currently a work in progress.

See https://github.com/azazel75/plugins/blob/master/v7/spa/spa.py
and  https://github.com/azazel75/nikola-themes/tree/master/v7/spa-jinja/templates
