### PR TITLE
fix #1464 -- don’t pull in github_deploy by default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,13 +20,14 @@ Features
 Bugfixes
 --------
 
+* Don’t pull by default in ``github_deploy`` (Issue #1464)
 * disabled hyphenation for paragraphs with inline math (Issue #1461)
 * Support filters for all tasks (Issue #1459)
 * Don’t check cache/ in ``nikola check -l`` (Issue #1447)
 * Fix new_post for pandoc format (Issue #1445)
 * Fix STORY_INDEX generation (Issue #1444)
 * Fix bootswatch creation version check (Issue #1441)
-* Never rebase while pulling in `github_deploy`
+* Never rebase while pulling in ``github_deploy``
 * Handle better ``new_post --format=pandoc`` when pandoc is not defined (Issue #1422)
 * Open Graph properly uses latest RDFa in HTML – fixes validation
 * Fix sitemap generation (Issue #1397 via #1032)

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -259,6 +259,10 @@ REDIRECTIONS = ${REDIRECTIONS}
 # The name of the remote where you wish to push to, using github_deploy.
 # GITHUB_REMOTE_NAME = 'origin'
 
+# If you really care about history in the GitHub Pages branch, you can
+# set this to True to `git pull` before changes are made.
+# GITHUB_PULL_BEFORE_COMMIT = False
+
 # Where the output site should be located
 # If you don't use an absolute path, it will be considered as relative
 # to the location of conf.py

--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -95,6 +95,9 @@ class CommandGitHubDeploy(Command):
         self._remote_name = self.site.config.get(
             'GITHUB_REMOTE_NAME', 'origin'
         )
+        self._pull_before_commit = self.site.config.get(
+            'GITHUB_PULL_BEFORE_COMMIT', False
+        )
 
         self._ensure_git_repo()
 
@@ -135,12 +138,14 @@ class CommandGitHubDeploy(Command):
         )
 
         commands = [
-            ['git', 'pull', '--rebase=false', remote, '%s:%s' % (deploy, deploy)],
             ['git', 'add', '-A'],
             ['git', 'commit', '-m', commit_message],
             ['git', 'push', '--force', remote, '%s:%s' % (deploy, deploy)],
             ['git', 'checkout', source],
         ]
+
+        if self._pull_before_commit:
+            commands.insert(0, ['git', 'pull', '--rebase=false', remote, '%s:%s' % (deploy, deploy)])
 
         for command in commands:
             self.logger.info("==> {0}".format(command))


### PR DESCRIPTION
This is #1464.
