### PR TITLE
fix #1492

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* New PANDOC_OPTIONS option (Issue #1492)
 * New tab-width option in code-block directive (Issue #1514)
 * New option TAG_PAGES_DESCRIPTIONS for optionally making individual
   tag pages more unique and interesting (Issue #1486)

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -169,7 +169,7 @@ PAGES = ${PAGES}
 # FILES_FOLDERS = {'files': ''}
 # Which means copy 'files' into 'output'
 
-# One or more folders containing listings to be processed and stored into 
+# One or more folders containing listings to be processed and stored into
 # the output. The format is a dictionary of {source: relative destination}.
 # Default is:
 # LISTINGS_FOLDERS = {'listings': 'listings'}
@@ -599,6 +599,11 @@ COMMENT_SYSTEM_ID = ${COMMENT_SYSTEM_ID}
 # Note: most Nikola-specific extensions are done via the Nikola plugin system,
 #       with the MarkdownExtension class and should not be added here.
 # MARKDOWN_EXTENSIONS = ['fenced_code', 'codehilite']
+
+# Extra options to pass to the pandoc comand.
+# by default, it's empty, is a list of strings, for example
+# ['-F', 'pandoc-citeproc', '--bibliography=/Users/foo/references.bib']
+# PANDOC_OPTIONS = []
 
 # Social buttons. This is sample code for AddThis (which was the default for a
 # long time). Insert anything you want here, or even make it empty.

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -345,6 +345,7 @@ class Nikola(object):
             'OUTPUT_FOLDER': 'output',
             'POSTS': (("posts/*.txt", "posts", "post.tmpl"),),
             'PAGES': (("stories/*.txt", "stories", "story.tmpl"),),
+            'PANDOC_OPTIONS': [],
             'PRETTY_URLS': False,
             'FUTURE_IS_NOW': False,
             'INDEX_READ_MORE_LINK': DEFAULT_INDEX_READ_MORE_LINK,

--- a/nikola/plugins/compile/pandoc.py
+++ b/nikola/plugins/compile/pandoc.py
@@ -48,7 +48,7 @@ class CompilePandoc(PageCompiler):
     def compile_html(self, source, dest, is_two_file=True):
         makedirs(os.path.dirname(dest))
         try:
-            subprocess.check_call(('pandoc', '-o', dest, source))
+            subprocess.check_call(['pandoc', '-o', dest, source] + self.site.config['PANDOC_OPTIONS'])
         except OSError as e:
             if e.strreror == 'No such file or directory':
                 req_missing(['pandoc'], 'build this site (compile with pandoc)', python=False)


### PR DESCRIPTION
Adds a PANDOC_OPTIONS option so users can use pandoc's extensions that need enabling via command line.
