### PR TITLE
Avoiding memory leaks

### DIFF
--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -93,9 +93,12 @@ class Command(BasePlugin, DoitCommand):
         BasePlugin.__init__(self, *args, **kwargs)
         DoitCommand.__init__(self)
 
-    def execute(self, options={}, args=[]):
+    def execute(self, options=None, args=None):
         """Check if the command can run in the current environment,
         fail if needed, or call _execute."""
+        options = options or {}
+        args = args or []
+
         if self.needs_config and not self.site.configured:
             LOGGER.error("This command needs to run inside an existing Nikola site.")
             return False

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -106,8 +106,11 @@ class CommandImportWordpress(Command, ImportMixin):
         },
     ]
 
-    def _execute(self, options={}, args=[]):
+    def _execute(self, options=None, args=None):
         """Import a WordPress blog from an export file into a Nikola site."""
+        options = options or {}
+        args = args or []
+
         if not args:
             print(self.help())
             return

--- a/nikola/plugins/task/listings.py
+++ b/nikola/plugins/task/listings.py
@@ -115,7 +115,10 @@ class Listings(Task):
         # Things to ignore in listings
         ignored_extensions = (".pyc", ".pyo")
 
-        def render_listing(in_name, out_name, input_folder, output_folder, folders=[], files=[]):
+        def render_listing(in_name, out_name, input_folder, output_folder, folders=None, files=None):
+            folders = folders or []
+            files = files or []
+
             if in_name:
                 with open(in_name, 'r') as fd:
                     try:


### PR DESCRIPTION
In python it is very common to use default values in method arguments. But you should not use list or dicts there.

The problem is that the argument is initialized with the list/dict address, so it can happen unexpected results:

``` python
>>> def f(a=[]):
        a.append(1)
        print(a)    

>>> f()
[1]

>>> f()
[1, 1]

>>> f()
[1, 1, 1]
```

Usually this problem generates a memory leak, because you can have a never-ending array; often, it slows down the program performance, processing items more than once. 

Even if this is the expected result, it is too difficult to the reader to identify it. So, please, avoid using them as arguments.
