### PR TITLE
Better Travis irc bot notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,5 @@ notifications:
       - "%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
       - "Change view: %{compare_url}"
       - "Build details: %{build_url}"
+    skip_join: true
+    use_notice: true


### PR DESCRIPTION
`use_notice` will make the bot use notices instead of regular messages,
`skip_join` will disable the bot's joining before sending messages, parting after sending.
`skip_join` will require the removal of the `NO_EXTERNAL_MSGS flag` (n) on the IRC channel.

Detailed info can be found here: http://docs.travis-ci.com/user/notifications/

I didn't open an issue because this is trivial and any discussion can take place here (no harm done if it's rejected).
