### PR TITLE
Improving/fixing check command

### DIFF
--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -33,6 +33,7 @@ try:
     from urlparse import urlparse, urljoin, urldefrag
 except ImportError:
     from urllib.parse import unquote, urlparse, urljoin, urldefrag  # NOQA
+import subprocess
 
 import lxml.html
 
@@ -40,12 +41,23 @@ from nikola.plugin_categories import Command
 from nikola.utils import get_logger
 
 
+def _call_nikola_list(site, arguments):
+    command = ["nikola"]
+    if site.config['__configuration_filename__'] != 'conf.py':
+        command.append('--conf=' + site.config['__configuration_filename__'])
+    command.extend(["list", "--all"])
+    result = []
+    for task in subprocess.Popen(command, shell=False, stdout=subprocess.PIPE).stdout.readlines():
+        result.append(task.decode('utf-8'))
+    return result
+
+
 def real_scan_files(site):
     task_fnames = set([])
     real_fnames = set([])
     output_folder = site.config['OUTPUT_FOLDER']
     # First check that all targets are generated in the right places
-    for task in os.popen('nikola list --all', 'r').readlines():
+    for task in _call_nikola_list(site, ["--all"]):
         task = task.strip()
         if output_folder in task and ':' in task:
             fname = task.split(':', 1)[-1]
@@ -163,7 +175,7 @@ class CommandCheck(Command):
                 self.logger.notice("Ignoring {0} (in cache, links may be incorrect)".format(filename))
                 return False
 
-            d = lxml.html.fromstring(open(filename).read())
+            d = lxml.html.fromstring(open(filename, 'rb').read())
             for l in d.iterlinks():
                 target = l[0].attrib[l[1]]
                 if target == "#":
@@ -209,7 +221,7 @@ class CommandCheck(Command):
                         self.logger.warn("Broken link in {0}: {1}".format(filename, target))
                         if find_sources:
                             self.logger.warn("Possible sources:")
-                            self.logger.warn(os.popen('nikola list --deps ' + task, 'r').read())
+                            self.logger.warn("\n".join(_call_nikola_list(self.site, ["--deps", task])))
                             self.logger.warn("===============================\n")
         except Exception as exc:
             self.logger.error("Error with: {0} {1}".format(filename, exc))
@@ -220,7 +232,7 @@ class CommandCheck(Command):
         self.logger.info("===============\n")
         self.logger.notice("{0} mode".format(self.site.config['URL_TYPE']))
         failure = False
-        for task in os.popen('nikola list --all', 'r').readlines():
+        for task in _call_nikola_list(self.site, ["--all"]):
             task = task.strip()
             if task.split(':')[0] in (
                     'render_tags', 'render_archive',


### PR DESCRIPTION
Hi!

While trying to run `nikola check` resp. `nikola orphans` with `--conf=xxx`, I noticed that the result was not as expected, because `nikola/plugins/command/check.py` is calling ``nikola` without passing the configuration file name (I guess I missed that back then when I added `--conf=xxx`).

While fixing that, I migrated the use of `os.popen` to `subprocess.Popen`.

I also noticed that on my machine (with Python 3), link checking didn't work because `lxml.html.fromstring()` didn't like the output of `open(filename).read()` (the result was unicode, but since the output contained an encoding specification, `fromstring()` bailed out); maybe that's a Python 3 problem, but anyway, when opening the file with mode `"rb"`, the problem disappeared.

Cheers,
Felix
