### PR TITLE
Fixed command line parsing when --conf=xxx is given

### DIFF
--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -88,7 +88,7 @@ def main(args=None):
         quiet = True
     global config
 
-    if conf_filename_changed and not quiet:
+    if conf_filename_changed:
         LOGGER.info("Using config file '{0}'".format(conf_filename))
 
     # Those commands do not require a `conf.py`.  (Issue #1132)


### PR DESCRIPTION
Hi,
there was some command line processing early in **main**.py which interprets the quiet flag, which wasn't aware that `--conf=xxx` can appear inbetween. Should be fixed with this.
Cheers,
Felix
