### PR TITLE
Can import a exists ipynb file

### DIFF
--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -206,6 +206,14 @@ class CommandNewPost(Command):
             'default': False,
             'help': 'Schedule the post based on recurrence rule'
         },
+        {
+            'name': 'file',
+            'short': 'i',
+            'long': 'file',
+            'type': str,
+            'default': '',
+            'help': 'Can import existing file'
+        },
 
     ]
 
@@ -233,6 +241,7 @@ class CommandNewPost(Command):
         tags = options['tags']
         onefile = options['onefile']
         twofile = options['twofile']
+        exist_file = options['file'] or None
 
         if is_page:
             LOGGER = PAGELOGGER
@@ -263,7 +272,11 @@ class CommandNewPost(Command):
                                   self.site.config['COMPILERS'],
                                   self.site.config['post_pages'])
 
-        print("Creating New {0}".format(content_type.title()))
+        if exist_file is not None:
+            # Current it only affect `ipynb` format
+            print("Import Existed {0}".format(content_type.title()))
+        else:
+            print("Creating New {0}".format(content_type.title()))
         print("-----------------\n")
         if title is not None:
             print("Title:", title)
@@ -330,7 +343,8 @@ class CommandNewPost(Command):
         content = "Write your {0} here.".format('page' if is_page else 'post')
         compiler_plugin.create_post(
             txt_path, content=content, onefile=onefile, title=title,
-            slug=slug, date=date, tags=tags, is_page=is_page, **metadata)
+            slug=slug, date=date, tags=tags, is_page=is_page,
+            exist_file=exist_file, **metadata)
 
         event = dict(path=txt_path)
 

--- a/nikola/plugins/compile/ipynb/__init__.py
+++ b/nikola/plugins/compile/ipynb/__init__.py
@@ -68,12 +68,18 @@ class CompileIPynb(PageCompiler):
         kw.pop('content', None)
         onefile = kw.pop('onefile', False)
         kw.pop('is_page', False)
+        exist_file = kw.pop('exist_file')
 
         makedirs(os.path.dirname(path))
         if onefile:
             raise Exception('The one-file format is not supported by this compiler.')
-        with io.open(path, "w+", encoding="utf8") as fd:
-            fd.write("""{
+        if exist_file is not None and os.path.exists(exist_file):
+            with io.open(exist_file) as efd:
+                with io.open(path, "w+", encoding="utf8") as fd:
+                    fd.writelines(efd.readlines())
+        else:
+            with io.open(path, "w+", encoding="utf8") as fd:
+                fd.write("""{
  "metadata": {
   "name": ""
  },


### PR DESCRIPTION
The `ipynb` is not a editable format. It doesn't like the markdown that what you see is what you get. when i create a new post with ipynb format. Actually my flow like this:
1. Open ipython notebook server and create a notebook named A.ipynb
2. edit it, add the contents of the I want to express 
3. use `nikola new_post -f ipynb` create one ipynb file  named B.ipynb
4. find the A.ipynb file and replace B.ipynb

I think i only need import a exists ipynb file directly when create a post is better.
