### PR TITLE
Avoid rebuild of tag/category pages/feeds when tag/category is added/removed.

### DIFF
--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -84,7 +84,7 @@ class RenderTags(Task):
         self.site.scan_posts()
         yield self.group_task()
 
-        yield self.list_tags_page(kw)  # this also adds category and tag list to kw
+        yield self.list_tags_page(kw)
 
         if not self.site.posts_per_tag and not self.site.posts_per_category:
             return
@@ -169,6 +169,7 @@ class RenderTags(Task):
         has_tags = (tags != ['']) and include_tags
         has_categories = (categories != ['']) and include_categories
         template_name = "tags.tmpl"
+        kw = kw.copy()
         if include_tags:
             kw['tags'] = tags
         if include_categories:


### PR DESCRIPTION
This patch avoids rebuilding of tag and category pages and RSS feeds if a tag or category was added or removed; this was caused because every tag and category page and RSS feed had a list of all tags and categories incorporated into its ```uptodate``` list (via ```kw```).

Fixes #1410.