### PR TITLE
RSS2 expects lastBuildDate to be GMT.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1021,7 +1021,7 @@ class Nikola(object):
             title=title,
             link=link,
             description=description,
-            lastBuildDate=datetime.datetime.now(),
+            lastBuildDate=datetime.datetime.utcnow(),
             generator='http://getnikola.com/',
             language=lang
         )

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -575,7 +575,7 @@ class Galleries(Task, ImageProcessor):
             title=title,
             link=make_url(permalink),
             description='',
-            lastBuildDate=datetime.datetime.now(),
+            lastBuildDate=datetime.datetime.utcnow(),
             items=items,
             generator='http://getnikola.com/',
             language=lang


### PR DESCRIPTION
PyRSS2Gen expects the lastBuildDate to be in GMT, and ignores any
timezone information when generating the RSS.