### PR TITLE
Fix #1581

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -79,3 +79,4 @@ Carsten Grohmann <https://github.com/CarstenGrohmann>
 Aurelien Naldi <https://github.com/aurelien-naldi>
 Andreas Linz <https://github.com/KLINGTdotNET>
 小明 <https://github.com/dongweiming>
+Michael McNeil Forbes <https://github.com/mforbes>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,14 @@
+New in master
+=============
+
+Features
+--------
+
+Bugfixes
+--------
+
+* Fixed compatibility with IPython 3.x (Issue #1581)
+
 New in v7.3.0
 =============
 

--- a/nikola/plugins/compile/ipynb/__init__.py
+++ b/nikola/plugins/compile/ipynb/__init__.py
@@ -31,15 +31,14 @@ import io
 import os
 
 try:
+    import IPython
     from IPython.nbconvert.exporters import HTMLExporter
-    import IPython.nbformat
     if IPython.version_info[0] >= 3:     # API changed with 3.0.0
-        def nbformat_reads(s):
-            # Update to the current format so that the export works.
-            return IPython.nbformat.reads(
-                s, IPython.nbformat.current_nbformat)
+        from IPython import nbformat
+        current_nbformat = nbformat.current_nbformat
     else:
-        nbformat_reads = IPython.nbformat.current.reads_json
+        import IPython.nbformat.current as nbformat
+        current_nbformat = 'json'
 
     from IPython.config import Config
     flag = True
@@ -66,8 +65,7 @@ class CompileIPynb(PageCompiler):
         exportHtml = HTMLExporter(config=c)
         with io.open(dest, "w+", encoding="utf8") as out_file:
             with io.open(source, "r", encoding="utf8") as in_file:
-                nb = in_file.read()
-                nb_json = nbformat_reads(nb)
+                nb_json = nbformat.read(in_file, current_nbformat)
             (body, resources) = exportHtml.from_notebook_node(nb_json)
             out_file.write(body)
 

--- a/nikola/plugins/compile/ipynb/__init__.py
+++ b/nikola/plugins/compile/ipynb/__init__.py
@@ -32,7 +32,15 @@ import os
 
 try:
     from IPython.nbconvert.exporters import HTMLExporter
-    from IPython.nbformat import current as nbformat
+    import IPython.nbformat
+    if IPython.version_info[0] >= 3:     # API changed with 3.0.0
+        def nbformat_reads(s):
+            # Update to the current format so that the export works.
+            return IPython.nbformat.reads(
+                s, IPython.nbformat.current_nbformat)
+    else:
+        nbformat_reads = IPython.nbformat.current.reads_json
+
     from IPython.config import Config
     flag = True
 except ImportError:
@@ -59,7 +67,7 @@ class CompileIPynb(PageCompiler):
         with io.open(dest, "w+", encoding="utf8") as out_file:
             with io.open(source, "r", encoding="utf8") as in_file:
                 nb = in_file.read()
-                nb_json = nbformat.reads_json(nb)
+                nb_json = nbformat_reads(nb)
             (body, resources) = exportHtml.from_notebook_node(nb_json)
             out_file.write(body)
 


### PR DESCRIPTION
This adds a bit of code to deal with the API changes in the latest development version of IPython 3.0.0.  Note: I read the notebook into the current format (as opposed to ``nbformat.NO_CONVERT``) so that the ``HTMLExporter`` can properly output the data.  If the conversion is not done, then this will fail if there are ``cells`` in the notebook as shown in the issue.

There is probably more that could be cleaned up (the generated notebook for an initial post should probably use the current format rather than a hard-coded nbformat 3 template for example), but I wanted to keep this a minimal change to preserve backward compatibility.