### PR TITLE
Fixing order for other metadata.

### DIFF
--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -35,6 +35,7 @@ import hashlib
 import io
 import locale
 import logging
+import natsort
 import os
 import re
 import json
@@ -1241,8 +1242,8 @@ def write_metadata(data):
             pass
 
     # Leftover metadata (user-specified/non-default).
-    for k, v in data.items():
-        meta.append(f.format(k, v))
+    for k in natsort.natsorted(list(data.keys())):
+        meta.append(f.format(k, data[k]))
 
     meta.append('')
 

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1242,7 +1242,7 @@ def write_metadata(data):
             pass
 
     # Leftover metadata (user-specified/non-default).
-    for k in natsort.natsorted(list(data.keys())):
+    for k in natsort.natsorted(list(data.keys()), alg=natsort.ns.F | natsort.ns.IC):
         meta.append(f.format(k, data[k]))
 
     meta.append('')


### PR DESCRIPTION
This PR fixes the order of metadata written via ```utils.write_metadata()```. Currently, a 'random' order (induced by the dict used) is taken.

I'm currently working on a small tag management plugin, which needs to read and write metadata. I want to avoid that every time the tags are modified, other metadata ends up in a new random order.