### PR TITLE
Removing empty line that produces an invalid '-->' output when importing md

### DIFF
--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -76,7 +76,7 @@ class CompileMarkdown(PageCompiler):
             with io.open(source, "r", encoding="utf8") as in_file:
                 data = in_file.read()
             if not is_two_file:
-                data = re.split('(\n\n|\r\n\r\n)', data, maxsplit=1)[-1]
+                data = re.split('(\-\->)', data, maxsplit=1)[-1]
             output = markdown(data, self.extensions)
             out_file.write(output)
 


### PR DESCRIPTION
When importing markdown, this line produces metadata like these:

```
<!--
.. title: foo
.. slug: bar
.. date: 2001/01/01

-->
```

That is processed genarating the line:

```
<p>--&gt;</p>
```

What is invalid.

This fix will generate metadata like:
```
<!--
.. title: foo
.. slug: bar
.. date: 2001/01/01
-->
```

What is processed as expected.