### PR TITLE
Allow plugins to provide metadata

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -9,6 +9,7 @@ Aurelien Naldi <https://github.com/aurelien-naldi>
 Ben Mather <https://github.com/bwhmather>
 Boris Kaul <https://github.com/localvoid>
 Brandon W. Maister <https://github.com/quodlibetor>
+Bussonnier Matthias <https://gtihub.com/carreau>
 Carsten Grohmann <https://github.com/CarstenGrohmann>
 Casey M. Bessette <https://github.com/caseybessette>
 Chris Lee <https://github.com/clee>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,7 @@ New in v7.3.0
 Features
 --------
 
+* Added possibility for plugins to define how to read metadata from files
 * Added ``-a``, ``--author`` option to set post author field
 * Added option INDEXES_PRETTY_PAGE_URL to make URLs for indexes
   pages more pretty. (Issue #1548)

--- a/docs/extending.txt
+++ b/docs/extending.txt
@@ -374,6 +374,10 @@ They must provide:
 If the compiler produces something other than HTML files, it should also implement ``extension`` which
 returns the preferred extension for the output file.
 
+These plugin can also be used to extract metadata from file. To do so, the
+plugin may implement ``read_metadata`` that will return a dict containing some
+metadata contained in the file.
+
 RestExtension Plugins
 ---------------------
 

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -245,6 +245,12 @@ class PageCompiler(BasePlugin):
         """The preferred extension for the output of this compiler."""
         return ".html"
 
+    def read_metadata(self, post, file_metadata_regexp=None, unslugify_titles=False, lang=None):
+        """
+        Read the metadata from a post, and return a metadata dict
+        """
+        return {}
+
 
 class RestExtension(BasePlugin):
     name = "dummy_rest_extension"

--- a/nikola/plugins/compile/ipynb/__init__.py
+++ b/nikola/plugins/compile/ipynb/__init__.py
@@ -69,6 +69,19 @@ class CompileIPynb(PageCompiler):
             (body, resources) = exportHtml.from_notebook_node(nb_json)
             out_file.write(body)
 
+    def read_metadata(self, post, file_metadata_regexp=None, unslugify_titles=False, lang=None):
+        """read metadata directly from ipynb file.
+
+        As ipynb file support arbitrary metadata as json, the metadata used by Nikola
+        will be assume to be in the 'nikola' subfield.
+        """
+        source = post.source_path
+        with io.open(source, "r", encoding="utf8") as in_file:
+            nb_json = nbformat.read(in_file, current_nbformat)
+        # metadata shoudl always exist, but we never know
+        # if Someone craft an ipynb by hand.
+        return nb_json.get('metadata', {}).get('nikola', {})
+
     def create_post(self, path, **kw):
         content = kw.pop('content', None)
         onefile = kw.pop('onefile', False)

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -917,8 +917,6 @@ def get_meta(post, file_metadata_regexp=None, unslugify_titles=False, lang=None)
     """
     meta = defaultdict(lambda: '')
 
-    newstylemeta = True
-
     try:
         config = post.config
     except AttributeError:
@@ -927,9 +925,8 @@ def get_meta(post, file_metadata_regexp=None, unslugify_titles=False, lang=None)
     _, newstylemeta = get_metadata_from_meta_file(post.metadata_path, config, lang)
     meta.update(_)
 
-    if meta:
-        return meta, newstylemeta
-    post.is_two_file = False
+    if not meta:
+        post.is_two_file = False
 
     if file_metadata_regexp is not None:
         meta.update(_get_metadata_from_filename_by_regex(post.source_path,
@@ -937,6 +934,10 @@ def get_meta(post, file_metadata_regexp=None, unslugify_titles=False, lang=None)
                                                          unslugify_titles))
 
     meta.update(get_metadata_from_file(post.source_path, config, lang))
+
+    if getattr(post, 'compiler', None):
+        compiler_meta = post.compiler.read_metadata(post, file_metadata_regexp, unslugify_titles, lang)
+        meta.update(compiler_meta)
 
     if lang is None:
         # Only perform these checks for the default language

--- a/tests/test_rss_feeds.py
+++ b/tests/test_rss_feeds.py
@@ -34,6 +34,9 @@ class FakeCompiler(object):
     compile_html = None
     extension = lambda self: '.html'
 
+    def read_metadata(*args, **kwargs):
+        return {}
+
     def register_extra_dependencies(self, post):
         pass
 


### PR DESCRIPTION
This allow plugins to provide a way to extract metadata from file the way
they wish to.

Metadata will be search first from the default value of as before this
PR. Metadata extracted by the plugin will then be merged into the
metadata dict, which in turn will be extended by the value in the
`.meta` file if present.

--- 

See start of discussion from #1602 

I tried to get the api to extract metadata by way of plugins, as close as possible as other `get_meta` calls. 
I also implement this for 1 plugin (`.ipynb`) the one I'm interested in.

This should not change current behavior for reading metadata from other places. 