### PR TITLE
Thumbnail updates

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Features
 
 * Added ``root`` path handler (via Issues #1008, #1573)
 * Added RSS feeds to gallery HEAD (part of Issue #786)
+* Don't create larger thumbnails for panorama images in scale_images
+  plugin
 
 Bugfixes
 --------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,8 +6,9 @@ Features
 
 * Added ``root`` path handler (via Issues #1008, #1573)
 * Added RSS feeds to gallery HEAD (part of Issue #786)
-* Don't create larger thumbnails for panorama images in scale_images
-  plugin
+* Separate new option IMAGE_THUMBNAIL_SIZE for setting size of
+  thumbnails created by scale_images plugin. Also don't create larger
+  thumbnails for panorama images in scale_images.
 
 Bugfixes
 --------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-New in v7.3.0
+New in master
 =============
 
 Features

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1251,6 +1251,7 @@ The ``conf.py`` options affecting images and gallery pages are these::
     IMAGE_FOLDERS = {'images': ''}
     # More image/gallery options:
     THUMBNAIL_SIZE = 180
+    IMAGE_THUMBNAIL_SIZE = 400
     MAX_IMAGE_SIZE = 1280
     USE_FILENAME_AS_TITLE = True
     EXTRA_IMAGE_EXTENSIONS = []

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -420,12 +420,13 @@ REDIRECTIONS = ${REDIRECTIONS}
 # GALLERY_SORT_BY_DATE = True
 #
 # Folders containing images to be used in normal posts or
-# pages. Images will be scaled down according to THUMBNAIL_SIZE and
-# MAX_IMAGE_SIZE options, but will have to be referenced manually to
-# be visible on the site. The format is a dictionary of {source:
+# pages. Images will be scaled down according to IMAGE_THUMBNAIL_SIZE
+# and MAX_IMAGE_SIZE options, but will have to be referenced manually
+# to be visible on the site. The format is a dictionary of {source:
 # relative destination}.
 #
 # IMAGE_FOLDERS = {'images': ''}
+# IMAGE_THUMBNAIL_SIZE = 400
 
 # #############################################################################
 # HTML fragments and diverse things that are used by the templates

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -47,7 +47,7 @@ class ImageProcessor(object):
 
     image_ext_list_builtin = ['.jpg', '.png', '.jpeg', '.gif', '.svg', '.bmp', '.tiff']
 
-    def resize_image(self, src, dst, max_size):
+    def resize_image(self, src, dst, max_size, bigger_panoramas=True):
         """Make a copy of the image in the requested size."""
         if not Image:
             utils.copy_file(src, dst)
@@ -58,7 +58,7 @@ class ImageProcessor(object):
             size = max_size, max_size
 
             # Panoramas get larger thumbnails because they look *awful*
-            if w > 2 * h:
+            if bigger_panoramas and w > 2 * h:
                 size = min(w, max_size * 4), min(w, max_size * 4)
 
             try:

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -335,6 +335,7 @@ class Nikola(object):
             'INDEX_DISPLAY_POST_COUNT': 10,
             'INDEX_FILE': 'index.html',
             'INDEX_TEASERS': False,
+            'IMAGE_THUMBNAIL_SIZE': 400,
             'INDEXES_TITLE': "",
             'INDEXES_PAGES': "",
             'INDEXES_PAGES_MAIN': False,

--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -68,8 +68,8 @@ class ScaleImage(Task, ImageProcessor):
                 }
 
     def process_image(self, src, dst):
-        self.resize_image(src, dst, self.kw['max_image_size'])
-        self.resize_image(src, '.thumbnail'.join(os.path.splitext(dst)), self.kw['thumbnail_size'])
+        self.resize_image(src, dst, self.kw['max_image_size'], False)
+        self.resize_image(src, '.thumbnail'.join(os.path.splitext(dst)), self.kw['thumbnail_size'], False)
 
     def gen_tasks(self):
         """Copy static files into the output folder."""

--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -69,13 +69,13 @@ class ScaleImage(Task, ImageProcessor):
 
     def process_image(self, src, dst):
         self.resize_image(src, dst, self.kw['max_image_size'], False)
-        self.resize_image(src, '.thumbnail'.join(os.path.splitext(dst)), self.kw['thumbnail_size'], False)
+        self.resize_image(src, '.thumbnail'.join(os.path.splitext(dst)), self.kw['image_thumbnail_size'], False)
 
     def gen_tasks(self):
         """Copy static files into the output folder."""
 
         self.kw = {
-            'thumbnail_size': self.site.config['THUMBNAIL_SIZE'],
+            'image_thumbnail_size': self.site.config['IMAGE_THUMBNAIL_SIZE'],
             'max_image_size': self.site.config['MAX_IMAGE_SIZE'],
             'image_folders': self.site.config['IMAGE_FOLDERS'],
             'output_folder': self.site.config['OUTPUT_FOLDER'],


### PR DESCRIPTION
Some improvements for my scale_images plugin:

* Thumbnail images in a post would normally be larger than the thumbnails in a gallery, so thumbnail size is now controlled with a separate setting.
* The special treatment of panorama images in galleries plugin has been turned off in scale_images since it would produce very wide thumbnails that messed up page layout.
