### PR TITLE
Make all imports appear at top of file.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -41,35 +41,20 @@ try:
 except ImportError:
     from urllib.parse import urlparse, urlsplit, urljoin  # NOQA
 
-from blinker import signal
 try:
     import pyphen
 except ImportError:
     pyphen = None
+
 import dateutil.tz
-
 import logging
-from . import DEBUG
-
-if DEBUG:
-    logging.basicConfig(level=logging.DEBUG)
-else:
-    logging.basicConfig(level=logging.ERROR)
-
 import PyRSS2Gen as rss
-
 import lxml.html
 from yapsy.PluginManager import PluginManager
-
-# Default "Read more..." link
-DEFAULT_INDEX_READ_MORE_LINK = '<p class="more"><a href="{link}">{read_more}…</a></p>'
-DEFAULT_RSS_READ_MORE_LINK = '<p><a href="{link}">{read_more}…</a> ({min_remaining_read})</p>'
-
-# Default pattern for translation files' names
-DEFAULT_TRANSLATIONS_PATTERN = '{path}.{lang}.{ext}'
+from blinker import signal
 
 from .post import Post
-from . import utils
+from . import DEBUG, utils
 from .plugin_categories import (
     Command,
     LateTask,
@@ -82,6 +67,18 @@ from .plugin_categories import (
     SignalHandler,
     ConfigPlugin,
 )
+
+if DEBUG:
+    logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig(level=logging.ERROR)
+
+# Default "Read more..." link
+DEFAULT_INDEX_READ_MORE_LINK = '<p class="more"><a href="{link}">{read_more}…</a></p>'
+DEFAULT_RSS_READ_MORE_LINK = '<p><a href="{link}">{read_more}…</a> ({min_remaining_read})</p>'
+
+# Default pattern for translation files' names
+DEFAULT_TRANSLATIONS_PATTERN = '{path}.{lang}.{ext}'
 
 
 config_changed = utils.config_changed

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -28,6 +28,11 @@ from __future__ import absolute_import
 import sys
 import os
 
+from yapsy.IPlugin import IPlugin
+from doit.cmd_base import Command as DoitCommand
+
+from .utils import LOGGER, first_line
+
 __all__ = [
     'Command',
     'LateTask',
@@ -39,11 +44,6 @@ __all__ = [
     'TemplateSystem',
     'SignalHandler'
 ]
-
-from yapsy.IPlugin import IPlugin
-from doit.cmd_base import Command as DoitCommand
-
-from .utils import LOGGER, first_line
 
 
 class BasePlugin(IPlugin):

--- a/nikola/plugins/compile/rest/listing.py
+++ b/nikola/plugins/compile/rest/listing.py
@@ -37,6 +37,8 @@ try:
 except ImportError:
     from urllib.parse import urlunsplit  # NOQA
 
+import docutils.parsers.rst.directives.body
+import docutils.parsers.rst.directives.misc
 from docutils import core
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -48,6 +50,7 @@ import pygments
 import pygments.util
 
 from nikola import utils
+from nikola.plugin_categories import RestExtension
 
 
 # A sanitized version of docutils.parsers.rst.directives.body.CodeBlock.
@@ -115,12 +118,8 @@ class CodeBlock(Directive):
         return [node]
 
 # Monkey-patch: replace insane docutils CodeBlock with our implementation.
-import docutils.parsers.rst.directives.body
-import docutils.parsers.rst.directives.misc
 docutils.parsers.rst.directives.body.CodeBlock = CodeBlock
 docutils.parsers.rst.directives.misc.CodeBlock = CodeBlock
-
-from nikola.plugin_categories import RestExtension
 
 
 class Plugin(RestExtension):

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -38,7 +38,6 @@ except ImportError:
     from urllib.parse import urljoin  # NOQA
 
 import natsort
-Image = None
 try:
     from PIL import Image  # NOQA
 except ImportError:
@@ -46,7 +45,7 @@ except ImportError:
         import Image as _Image
         Image = _Image
     except ImportError:
-        pass
+        Image = None
 
 import PyRSS2Gen as rss
 

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -27,7 +27,6 @@
 """Utility functions."""
 
 from __future__ import print_function, unicode_literals, absolute_import
-from collections import defaultdict, Callable
 import calendar
 import datetime
 import dateutil.tz
@@ -42,19 +41,49 @@ import json
 import shutil
 import subprocess
 import sys
-from zipfile import ZipFile as zipf
-try:
-    from imp import reload
-except ImportError:
-    pass
-
 import dateutil.parser
 import dateutil.tz
 import logbook
+import warnings
+import PyRSS2Gen as rss
+from collections import defaultdict, Callable
 from logbook.more import ExceptionHandler, ColorizedStderrHandler
 from pygments.formatters import HtmlFormatter
+from zipfile import ZipFile as zipf
+from doit import tools
+from unidecode import unidecode
+from pkg_resources import resource_filename
+from doit.cmdparse import CmdParse
 
 from nikola import DEBUG
+
+__all__ = ['get_theme_path', 'get_theme_chain', 'load_messages', 'copy_tree',
+           'copy_file', 'slugify', 'unslugify', 'to_datetime', 'apply_filters',
+           'config_changed', 'get_crumbs', 'get_tzname', 'get_asset_path',
+           '_reload', 'unicode_str', 'bytes_str', 'unichr', 'Functionary',
+           'TranslatableSetting', 'TemplateHookRegistry', 'LocaleBorg',
+           'sys_encode', 'sys_decode', 'makedirs', 'get_parent_theme_name',
+           'demote_headers', 'get_translation_candidate', 'write_metadata',
+           'ask', 'ask_yesno', 'options2docstring', 'os_path_split',
+           'get_displayed_page_number', 'adjust_name_for_index_path_list',
+           'adjust_name_for_index_path', 'adjust_name_for_index_link',
+           'NikolaPygmentsHTML', 'create_redirect']
+
+# Are you looking for 'generic_rss_renderer'?
+# It's defined in nikola.nikola.Nikola (the site object).
+
+if sys.version_info[0] == 3:
+    # Python 3
+    bytes_str = bytes
+    unicode_str = str
+    unichr = chr
+    raw_input = input
+    from imp import reload as _reload
+else:
+    bytes_str = str
+    unicode_str = unicode  # NOQA
+    _reload = reload  # NOQA
+    unichr = unichr
 
 
 class ApplicationWarning(Exception):
@@ -98,9 +127,6 @@ if DEBUG:
     logging.basicConfig(level=logging.DEBUG)
 else:
     logging.basicConfig(level=logging.INFO)
-
-
-import warnings
 
 
 def showwarning(message, category, filename, lineno, file=None, line=None):
@@ -159,42 +185,8 @@ def req_missing(names, purpose, python=True, optional=False):
 
     return msg
 
-if sys.version_info[0] == 3:
-    # Python 3
-    bytes_str = bytes
-    unicode_str = str
-    unichr = chr
-    raw_input = input
-    from imp import reload as _reload
-else:
-    bytes_str = str
-    unicode_str = unicode  # NOQA
-    _reload = reload  # NOQA
-    unichr = unichr
 
-from doit import tools
-from unidecode import unidecode
-from pkg_resources import resource_filename
-from nikola import filters as task_filters
-
-import PyRSS2Gen as rss
-
-__all__ = ['get_theme_path', 'get_theme_chain', 'load_messages', 'copy_tree',
-           'copy_file', 'slugify', 'unslugify', 'to_datetime', 'apply_filters',
-           'config_changed', 'get_crumbs', 'get_tzname', 'get_asset_path',
-           '_reload', 'unicode_str', 'bytes_str', 'unichr', 'Functionary',
-           'TranslatableSetting', 'TemplateHookRegistry', 'LocaleBorg',
-           'sys_encode', 'sys_decode', 'makedirs', 'get_parent_theme_name',
-           'demote_headers', 'get_translation_candidate', 'write_metadata',
-           'ask', 'ask_yesno', 'options2docstring', 'os_path_split',
-           'get_displayed_page_number', 'adjust_name_for_index_path_list',
-           'adjust_name_for_index_path', 'adjust_name_for_index_link',
-           'NikolaPygmentsHTML', 'create_redirect']
-
-# Are you looking for 'generic_rss_renderer'?
-# It's defined in nikola.nikola.Nikola (the site object).
-
-
+from nikola import filters as task_filters  # NOQA
 ENCODING = sys.getfilesystemencoding() or sys.stdin.encoding
 
 
@@ -1287,10 +1279,6 @@ def ask_yesno(query, default=None):
         return ask_yesno(query, default)
 
 
-from nikola.plugin_categories import Command
-from doit.cmdparse import CmdParse
-
-
 class CommandWrapper(object):
     """Converts commands into functions."""
 
@@ -1341,6 +1329,8 @@ class Commands(object):
         self.main.run(cmd_args)
 
     def _run_with_kw(self, cmd, *a, **kw):
+        # cyclic import hack
+        from nikola.plugin_categories import Command
         cmd = self.main.sub_cmds[cmd]
         options, _ = CmdParse(cmd.options).parse([])
         options.update(kw)

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -615,7 +615,7 @@ def load_messages(themes, translations, default_lang):
             try:
                 translation = __import__('messages_' + lang)
                 # If we don't do the reload, the module is cached
-                reload(translation)
+                _reload(translation)
                 if sorted(translation.MESSAGES.keys()) !=\
                         sorted(english.MESSAGES.keys()) and \
                         lang not in warned:


### PR DESCRIPTION
PEP8 requires this, flake8 complains, and I figured it’d be easier to
refactor it as much as possible (instead of just blindly ignoring the warning).

Comments and sanity checks welcome.

Signed-off-by: Chris Warrick <kwpolska@gmail.com>