### PR TITLE
Fix logger reference

### DIFF
--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -81,8 +81,8 @@ class ImageProcessor(object):
                 im.thumbnail(size, Image.ANTIALIAS)
                 im.save(dst)
             except Exception as e:
-                self.logger.warn("Can't thumbnail {0}, using original "
-                                 "image as thumbnail ({1})".format(src, e))
+                utils.LOGGER.warn("Can't thumbnail {0}, using original "
+                                  "image as thumbnail ({1})".format(src, e))
                 utils.copy_file(src, dst)
         else:  # Image is small
             utils.copy_file(src, dst)


### PR DESCRIPTION
This fixes the following exception:

PythonAction Error
Traceback (most recent call last):
  File "/home/rail/.virtualenvs/nikola/local/lib/python2.7/site-packages/doit/action.py", line 372, in execute
    returned_value = self.py_callable(*self.args, **kwargs)
  File "/home/rail/.virtualenvs/nikola/local/lib/python2.7/site-packages/nikola/plugins/task/scale_images.py", line 68, in process_image
    self.resize_image(src, '.thumbnail'.join(os.path.splitext(dst)), self.kw['thumbnail_size'])
  File "/home/rail/.virtualenvs/nikola/local/lib/python2.7/site-packages/nikola/image_processing.py", line 85, in resize_image
    self.logger.warn("Can't thumbnail {0}, using original "
AttributeError: 'ScaleImage' object has no attribute 'logger'
