### PR TITLE
Fixing dependencies of gallery RSS generation.

### DIFF
--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -254,8 +254,11 @@ class Galleries(Task, ImageProcessor):
                     context['post'] = None
                 file_dep = self.site.template_system.template_deps(
                     template_name) + image_list + thumbs
+                file_dep_dest = self.site.template_system.template_deps(
+                    template_name) + dest_img_list + thumbs
                 if post:
                     file_dep += [post.translated_base_path(l) for l in self.kw['translations']]
+                    file_dep_dest += [post.translated_base_path(l) for l in self.kw['translations']]
 
                 yield utils.apply_filters({
                     'basename': self.name,
@@ -289,7 +292,7 @@ class Galleries(Task, ImageProcessor):
                     yield utils.apply_filters({
                         'basename': self.name,
                         'name': rss_dst,
-                        'file_dep': file_dep,
+                        'file_dep': file_dep_dest,
                         'targets': [rss_dst],
                         'actions': [
                             (self.gallery_rss, (


### PR DESCRIPTION
The current gallery RSS rendering task requires the input images and the generated thumbnails to be there, but not the generated output images. When the task is executed, it tries to retrieve the size of the output images (which are copied from the input images).
When running Nikola in parallel mode, this can yield errors when the RSS generator tries to access a file which hasn't been copied to the destination yet.
This PR fixes the dependencies of the RSS generator task to require the output images to be there.