### PR TITLE
Add two parameters to post-list directive to allow for sorting posts

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -22,6 +22,7 @@ Daniel Devine <https://github.com/DDevine>
 Daniel F. Moisset <https://github.com/dmoisset>
 David Beath <https://github.com/DBeath>
 Dhruv Baldawa <https://github.com/dhruvbaldawa>
+Dirk Engling <https://github.com/erdgeist>
 Dmitry Verkhoturov <https://github.com/paskal>
 Duncan Lock <https://github.com/dflock>
 Edinei Cavalcanti <https://github.com/neiesc>

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Add a ``sort`` parameter to the post-list directive. Uses natsort to sort posts in list.
+
 Bugfixes
 --------
 

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1659,6 +1659,14 @@ The following options are recognized:
       Reverse the order of the post-list.
       Defaults is to not reverse the order of posts.
 
+* ``sort``: string
+      Sort post list alphabetically by one of its attribute, usually ``title``.
+      Defaults to None.
+
+* ``sortnum`: string
+      Sort post list numerically by one of its numeric attribute, usually ``prio``.
+      Defaults to None.
+
 * ``tags`` : string [, string...]
       Filter posts to show only posts having at least one of the ``tags``.
 

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1660,11 +1660,7 @@ The following options are recognized:
       Defaults is to not reverse the order of posts.
 
 * ``sort``: string
-      Sort post list alphabetically by one of its attribute, usually ``title``.
-      Defaults to None.
-
-* ``sortnum`: string
-      Sort post list numerically by one of its numeric attribute, usually ``prio``.
+      Sort post list by one of each post's attributes, usually ``title`` or a custom ``prio``.
       Defaults to None.
 
 * ``tags`` : string [, string...]

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -166,7 +166,7 @@ class PostList(Directive):
             filtered_timeline.sort(key=lambda post: post.meta[lang][sort])
 
         if sortnum:
-            filtered_timeline.sort(key=lambda post: int(post.meta[lang].get(sortnum,0)))
+            filtered_timeline.sort(key=lambda post: int(post.meta[lang].get(sortnum, 0)))
 
         for post in filtered_timeline[start:stop:step]:
             if slugs:

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -30,6 +30,8 @@ import uuid
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 
+from natsort import natsorted
+
 from nikola import utils
 from nikola.plugin_categories import RestExtension
 
@@ -52,7 +54,7 @@ class PostList(Directive):
     Post List
     =========
     :Directive Arguments: None.
-    :Directive Options: lang, start, stop, reverse, sort, sortnum, tags, template, id
+    :Directive Options: lang, start, stop, reverse, sort, tags, template, id
     :Directive Content: None.
 
     Provides a reStructuredText directive to create a list of posts.
@@ -78,11 +80,7 @@ class PostList(Directive):
         Defaults is to not reverse the order of posts.
 
     ``sort``: string
-        Sort post list by one of its attribute, usually ``title``.
-        Defaults to None.
-
-    ``sortnum``: string
-        Sort post list by one of its numeric attribute, usually ``prio``.
+        Sort post list by one of each post's attributes, usually ``title`` or a custom ``prio``.
         Defaults to None.
 
     ``tags`` : string [, string...]
@@ -114,7 +112,6 @@ class PostList(Directive):
         'stop': int,
         'reverse': directives.flag,
         'sort': directives.unchanged,
-        'sortnum': directives.unchanged,
         'tags': directives.unchanged,
         'slugs': directives.unchanged,
         'all': directives.flag,
@@ -135,7 +132,6 @@ class PostList(Directive):
         lang = self.options.get('lang', utils.LocaleBorg().current_lang)
         template = self.options.get('template', 'post_list_directive.tmpl')
         sort = self.options.get('sort')
-        sortnum = self.options.get('sortnum')
         if self.site.invariant:  # for testing purposes
             post_list_id = self.options.get('id', 'post_list_' + 'fixedvaluethatisnotauuid')
         else:
@@ -163,10 +159,7 @@ class PostList(Directive):
             filtered_timeline.append(post)
 
         if sort:
-            filtered_timeline.sort(key=lambda post: post.meta[lang][sort])
-
-        if sortnum:
-            filtered_timeline.sort(key=lambda post: int(post.meta[lang].get(sortnum, 0)))
+            filtered_timeline = natsorted(filtered_timeline, key=lambda post: post.meta[lang][sort])
 
         for post in filtered_timeline[start:stop:step]:
             if slugs:

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -166,7 +166,7 @@ class PostList(Directive):
             filtered_timeline.sort(key=lambda post: post.meta[lang][sort])
 
         if sortnum:
-            filtered_timeline.sort(key=lambda post: int(post.meta[lang][sortnum]) if post.meta[lang][sortnum] else 0)
+            filtered_timeline.sort(key=lambda post: int(post.meta[lang].get(sortnum,0)))
 
         for post in filtered_timeline[start:stop:step]:
             if slugs:

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -52,7 +52,7 @@ class PostList(Directive):
     Post List
     =========
     :Directive Arguments: None.
-    :Directive Options: lang, start, stop, reverse, tags, template, id
+    :Directive Options: lang, start, stop, reverse, sort, sortnum, tags, template, id
     :Directive Content: None.
 
     Provides a reStructuredText directive to create a list of posts.
@@ -76,6 +76,14 @@ class PostList(Directive):
     ``reverse`` : flag
         Reverse the order of the post-list.
         Defaults is to not reverse the order of posts.
+
+    ``sort``: string
+        Sort post list by one of its attribute, usually ``title``.
+        Defaults to None.
+
+    ``sortnum``: string
+        Sort post list by one of its numeric attribute, usually ``prio``.
+        Defaults to None.
 
     ``tags`` : string [, string...]
         Filter posts to show only posts having at least one of the ``tags``.
@@ -105,6 +113,8 @@ class PostList(Directive):
         'start': int,
         'stop': int,
         'reverse': directives.flag,
+        'sort': directives.unchanged,
+        'sortnum': directives.unchanged,
         'tags': directives.unchanged,
         'slugs': directives.unchanged,
         'all': directives.flag,
@@ -124,6 +134,8 @@ class PostList(Directive):
         show_all = self.options.get('all', False)
         lang = self.options.get('lang', utils.LocaleBorg().current_lang)
         template = self.options.get('template', 'post_list_directive.tmpl')
+        sort = self.options.get('sort')
+        sortnum = self.options.get('sortnum')
         if self.site.invariant:  # for testing purposes
             post_list_id = self.options.get('id', 'post_list_' + 'fixedvaluethatisnotauuid')
         else:
@@ -149,6 +161,12 @@ class PostList(Directive):
                     continue
 
             filtered_timeline.append(post)
+
+        if sort:
+            filtered_timeline.sort(key=lambda post: post.meta[lang][sort])
+
+        if sortnum:
+            filtered_timeline.sort(key=lambda post: int(post.meta[lang][sortnum]) if post.meta[lang][sortnum] else 0)
 
         for post in filtered_timeline[start:stop:step]:
             if slugs:


### PR DESCRIPTION
I have added the ``sort`` and ``sortnum``parameters to the post-list directive, so the order of posts can be changed from their default. ``sort`` sorts alphabetically, ``sortnum`` numerically, so I can either sort all posts by their title or manually put priorities to posts to set their order.