### PR TITLE
fix autorebuild

### DIFF
--- a/nikola/plugins/command/auto.py
+++ b/nikola/plugins/command/auto.py
@@ -67,7 +67,7 @@ class CommandAuto(Command):
         if self.site.configuration_filename != 'conf.py':
             arguments = ['--conf=' + self.site.configuration_filename] + arguments
 
-        command_line = 'nikola' + ' '.join(arguments)
+        command_line = 'nikola ' + ' '.join(arguments)
 
         # Run an initial build so we are up-to-date
         subprocess.call(["nikola"] + arguments)


### PR DESCRIPTION
When using `nikola auto` the first build is successful but it doesn't rebuild the website on changes, it gave the following errors:
``
ERROR:root:[Errno 2] Aucun fichier ou dossier de ce type: 'nikolabuild'
ERROR:root:maybe you haven't installed nikolabuild
``
The command is missing a space before the arguments.