### PR TITLE
Update pandoc.py

### DIFF
--- a/nikola/plugins/compile/pandoc.py
+++ b/nikola/plugins/compile/pandoc.py
@@ -46,7 +46,7 @@ class CompilePandoc(PageCompiler):
     name = "pandoc"
 
     def set_site(self, site):
-        self.config_dependencies = [str(self.site.config['PANDOC_OPTIONS'])]
+        self.config_dependencies = [str(site.config['PANDOC_OPTIONS'])]
 
     def compile_html(self, source, dest, is_two_file=True):
         makedirs(os.path.dirname(dest))


### PR DESCRIPTION
Class `CompilePandoc` does not have an attribute `site`; it is part of the configuration.