### PR TITLE
Fixed link checker

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Features
 Bugfixes
 --------
 
+* Fix ``nikola check -l`` for absolute and full-path URL styles
+  (Issue #1650)
 * Really add missing trailing slashes in ``BASE_URL`` (Issue #1651)
 * Check if files exists before adding them as post-list dependencies
   (Issue #1646)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,8 +14,6 @@ Features
 Bugfixes
 --------
 
-* Fix ``nikola check -l`` for absolute and full-path URL styles
-  (Issue #1650)
 * Check if files exists before adding them as post-list dependencies
   (Issue #1646)
 * Fix build command in ``nikola auto`` (Issue #1641)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Features
 Bugfixes
 --------
 
+* Fix ``nikola check -l`` for absolute and full-path URL styles
+  (Issue #1650)
 * Check if files exists before adding them as post-list dependencies
   (Issue #1646)
 * Fix build command in ``nikola auto`` (Issue #1641)

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -171,8 +171,8 @@ class CommandCheck(Command):
         self.existing_targets.add(self.site.config['SITE_URL'])
         self.existing_targets.add(self.site.config['BASE_URL'])
         url_type = self.site.config['URL_TYPE']
-        if url_type == 'absolute':
-            url_netloc_to_root = urlparse(self.site.config['SITE_URL']).path
+        if url_type in ('absolute', 'full_path'):
+            url_netloc_to_root = urlparse(self.site.config['BASE_URL']).path
         try:
             filename = task.split(":")[-1]
 
@@ -210,9 +210,10 @@ class CommandCheck(Command):
                 elif url_type in ('full_path', 'absolute'):
                     if url_type == 'absolute':
                         # convert to 'full_path' case, ie url relative to root
-                        url_rel_path = target.path[len(url_netloc_to_root):]
+                        url_rel_path = parsed.path[len(url_netloc_to_root):]
                     else:
-                        url_rel_path = target.path
+                        # convert to relative to base path
+                        url_rel_path = target[len(url_netloc_to_root):]
                     if url_rel_path == '' or url_rel_path.endswith('/'):
                         url_rel_path = urljoin(url_rel_path, self.site.config['INDEX_FILE'])
                     fs_rel_path = fs_relpath_from_url_path(url_rel_path)

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -88,7 +88,7 @@ def fs_relpath_from_url_path(url_path):
     url_path = unquote(url_path)
     # in windows relative paths don't begin with os.sep
     if sys.platform == 'win32' and len(url_path):
-        url_path = url_path[1:].replace('/', '\\')
+        url_path = url_path.replace('/', '\\')
     return url_path
 
 


### PR DESCRIPTION
This patch fixes the behaviour of `nikola check -l` for the cases where `URL_TYPE` is set to `full_path` or `absolute` (issue #1650). It also fixes the use of `SITE_URL` instead of `BASE_URL` when determining the relative portion of the path in the `absolute` case, which leads to bogus broken link reports when both variables are set in the configuration file and have different values.