### PR TITLE
Sanitize default IMAGE_FOLDERS output

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ Features
 Bugfixes
 --------
 
+* Make ``images`` the default output directory for IMAGE_FOLDERS
+  (Issue #1663)
 * Don't default to any swatch in bootswatch_theme (Issue #1656)
 * Fix ``nikola check -l`` for absolute and full-path URL styles
   (Issue #1650)

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1251,9 +1251,11 @@ its settings, change the layout, etc.).
 
 Images to be used in normal posts can be placed in the ``images`` folder. These
 images will be processed and have thumbnails created just as for galleries, but will
-then be copied directly to the corresponding path in the ``output`` directory, so you
+then be copied directly to the corresponding path in the ``output/images`` directory, so you
 can reference it from whatever page you like, most easily using the ``thumbnail``
 reST extension. If you don't want thumbnails, just use the ``files`` folder instead.
+You can also adjust the output path, eg. to put your images alongside posts
+(helpful if using ``PRETTY_URLS``)
 
 The ``conf.py`` options affecting images and gallery pages are these::
 
@@ -1269,7 +1271,7 @@ The ``conf.py`` options affecting images and gallery pages are these::
     # destination folder. A thumbnail will also be created in the same folder with
     # ``.thumbnail`` inserted in the file name before the file extension
     # (e.g. ``tesla.thumbnail.jpg``).
-    IMAGE_FOLDERS = {'images': ''}
+    IMAGE_FOLDERS = {'images': 'images'}
     # More image/gallery options:
     THUMBNAIL_SIZE = 180
     IMAGE_THUMBNAIL_SIZE = 400

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -436,7 +436,7 @@ REDIRECTIONS = ${REDIRECTIONS}
 # to be visible on the site. The format is a dictionary of {source:
 # relative destination}.
 #
-# IMAGE_FOLDERS = {'images': ''}
+IMAGE_FOLDERS = {'images': 'images'}
 # IMAGE_THUMBNAIL_SIZE = 400
 
 # #############################################################################


### PR DESCRIPTION
Change the default (litter files in `/`) to something saner (`/images/`).