### PR TITLE
Fix #1671

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,7 @@ Features
 Bugfixes
 --------
 
+* Support using post.text() in post_list_directive.tmpl (Issue #1671)
 * Avoid recursive dep when using post-list in a post (Issue #1671)
 * Encode IDNs to Punycode in ``nikola init`` and in links;
   show an error if the site URL is not Punycode (Issue #1644)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,7 @@ Features
 Bugfixes
 --------
 
+* Posts/Pages that use post-list will never be up to date (Issue #1671)
 * Support using post.text() in post_list_directive.tmpl (Issue #1671)
 * Avoid recursive dep when using post-list in a post (Issue #1671)
 * Encode IDNs to Punycode in ``nikola init`` and in links;

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,7 @@ Features
 Bugfixes
 --------
 
+* Avoid recursive dep when using post-list in a post (Issue #1671)
 * Encode IDNs to Punycode in ``nikola init`` and in links;
   show an error if the site URL is not Punycode (Issue #1644)
 * Make ``images`` the default output directory for IMAGE_FOLDERS

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1635,6 +1635,13 @@ and it will produce:
 Post List
 ~~~~~~~~~
 
+.. WARNING:: 
+
+   Any post or page that uses this directive will **never** be considered up-to-date,
+   meaning that every time you build the site, that post/page and everything that
+   depends on it (tag pages, RSS feeds, sitemap, etc.) will be rebuilt.
+
+
 This directive can be used to generate a list of posts. You could use it, for
 example, to make a list of the latest 5 blog posts, or a list of all blog posts
 with the tag ``nikola``::

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -104,7 +104,7 @@ class CompileRest(PageCompiler):
                 out_file.write(output)
             deps_path = dest + '.dep'
             if deps.list:
-                deps.list = [p for p in deps.list if p != dest]  #Don't depend on yourself (#1671)
+                deps.list = [p for p in deps.list if p != dest]  # Don't depend on yourself (#1671)
                 with io.open(deps_path, "w+", encoding="utf8") as deps_file:
                     deps_file.write('\n'.join(deps.list))
             else:

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -104,6 +104,7 @@ class CompileRest(PageCompiler):
                 out_file.write(output)
             deps_path = dest + '.dep'
             if deps.list:
+                deps.list = [p for p in deps.list if p != dest]  #Don't depend on yourself (#1671)
                 with io.open(deps_path, "w+", encoding="utf8") as deps_file:
                     deps_file.write('\n'.join(deps.list))
             else:

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -180,6 +180,7 @@ class PostList(Directive):
 
         if not posts:
             return []
+        self.state.document.settings.record_dependencies.add("####MAGIC####TIMELINE")
 
         template_data = {
             'lang': lang,

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -526,8 +526,16 @@ class Post(object):
         if lang is None:
             lang = nikola.utils.LocaleBorg().current_lang
         file_name = self._translated_file_path(lang)
+
+        # Yes, we compile it and screw it.
+        # This may be controversial, but the user (or someone) is asking for the post text
+        # and the post should not just refuse to give it.
+        if not os.path.isfile(file_name):
+            self.compile(lang)
+
         with io.open(file_name, "r", encoding="utf8") as post_file:
             data = post_file.read().strip()
+
         if self.compiler.extension() == '.php':
             return data
         try:


### PR DESCRIPTION
Fix for #1671:

1) Avoid circular dependencies when using post-list in a post
2) Make post.text() work anytime. It goes a bit against design principles, but I feel it's worth it because it makes the Post object more predictable.
3) This adds a "magic dependency marker" that rst directives can use which marks the document as basically unstable, making it never be uptodate. That means it will always be rebuilt.

As a refinement, this could be improved so the rebuild is only triggered, in this case, when the timeline changes.