### PR TITLE
Dependency injection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Plugins can manipulate task dependencies (Issue #1679)
 * Four new filters: html_tidy_nowrap, html_tidy_wrap, html_tidy_wrap_attr,
   and html_tidy_mini for prettification and minification. Requires tidy5.
 * Multilingual sitemaps (Issue #1610)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -287,7 +287,7 @@ class Nikola(object):
         self.configuration_filename = config.pop('__configuration_filename__', False)
         self.configured = bool(config)
         self.injected_deps = defaultdict(list)
-        
+
         self.rst_transforms = []
         self.template_hooks = {
             'extra_head': utils.TemplateHookRegistry('extra_head', self),

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1323,8 +1323,6 @@ class Nikola(object):
                 if 'task_dep' not in task:
                     task['task_dep'] = []
                 task['task_dep'].extend(self.injected_deps[task['basename']])
-                if task['task_dep']:
-                    print(task['basename'], task['task_dep'])
                 yield task
                 for multi in self.plugin_manager.getPluginsOfCategory("TaskMultiplier"):
                     flag = False

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -286,7 +286,8 @@ class Nikola(object):
         self.quiet = config.pop('__quiet__', False)
         self.configuration_filename = config.pop('__configuration_filename__', False)
         self.configured = bool(config)
-
+        self.injected_deps = defaultdict(list)
+        
         self.rst_transforms = []
         self.template_hooks = {
             'extra_head': utils.TemplateHookRegistry('extra_head', self),
@@ -1319,6 +1320,11 @@ class Nikola(object):
             for task in flatten(pluginInfo.plugin_object.gen_tasks()):
                 assert 'basename' in task
                 task = self.clean_task_paths(task)
+                if 'task_dep' not in task:
+                    task['task_dep'] = []
+                task['task_dep'].extend(self.injected_deps[task['basename']])
+                if task['task_dep']:
+                    print(task['basename'], task['task_dep'])
                 yield task
                 for multi in self.plugin_manager.getPluginsOfCategory("TaskMultiplier"):
                     flag = False

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -79,6 +79,7 @@ class BasePlugin(IPlugin):
         """Add 'dependency' to the target task's task_deps"""
         self.site.injected_deps[target].append(dependency)
 
+
 class Command(BasePlugin, DoitCommand):
     """These plugins are exposed via the command line.
     They implement the doit Command interface."""

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -75,6 +75,9 @@ class BasePlugin(IPlugin):
             # so let’s just ignore it and be done with it.
             pass
 
+    def inject_dependency(self, target, dependency):
+        """Add 'dependency' to the target task's task_deps"""
+        self.site.injected_deps[target].append(dependency)
 
 class Command(BasePlugin, DoitCommand):
     """These plugins are exposed via the command line.


### PR DESCRIPTION
Allow plugins to alter task dependencies.

This allows plugins to:

1) Set themselves as dependencies for other plugins
2) Set other plugins as dependencies for themselves
3) Set other plugins as dependencies for other plugins (IOW: eeeeeevil)