### PR TITLE
Fix #1695

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Features
 Bugfixes
 --------
 
+* Handle strange URLs, like ed2k:// (Issue #1695)
 * Fix very old metadata format support (Issue #1689)
 
 New in v7.4.0

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -992,12 +992,16 @@ class Nikola(object):
         if url_type is None:
             url_type = self.config.get('URL_TYPE')
 
+        if dst_url.scheme and dst_url.scheme not in ['http', 'https', 'link']:
+            return dst
+
         # Refuse to replace links that are full URLs.
         if dst_url.netloc:
             if dst_url.scheme == 'link':  # Magic link
                 dst = self.link(dst_url.netloc, dst_url.path.lstrip('/'), lang)
+            # Assuming the site is served over one of these, and
+            # since those are the only URLs we want to rewrite...
             else:
-                print(dst)
                 if '%' in dst_url.netloc:
                     # convert lxml percent-encoded garbage to punycode
                     nl = unquote(dst_url.netloc)
@@ -1006,7 +1010,6 @@ class Nikola(object):
                     except AttributeError:
                         # python 3: already unicode
                         pass
-
                     nl = nl.encode('idna')
 
                     dst = urlunsplit((dst_url.scheme,
@@ -1014,7 +1017,6 @@ class Nikola(object):
                                       dst_url.path,
                                       dst_url.query,
                                       dst_url.fragment))
-                    print(dst)
                 return dst
         elif dst_url.scheme == 'link':  # Magic absolute path link:
             dst = dst_url.path


### PR DESCRIPTION
This avoids the unicode/bytes error under python3, BUT it still keeps the ed2k URL url-encoded llike this

```
<p>Here is an <a class="reference external" href="ed2k://%7Cfile%7CAudioBook-OrsonWelles-WarOfTheWorlds,Original,Uncut.mp3%7C54878208%7CB7E6517C258F0062832629718E91FFBC%7C/">eD2k link</a></p>
```

I have no idea if those are valid or not. @chaghi can you check?