### PR TITLE
Allowing category hierarchies.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ New in v7.4.1
 Features
 --------
 
+* Allowing category hierarchies via new option CATEGORY_ALLOW_HIERARCHIES
+  (Issue #1520)
 * Better handling of missing/unconfigured compilers (Issue #1704)
 * New -r option for the link checker to check remote links (Issue #1684)
 * Use static navbars in bootstrap3 and bootstrap themes

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -250,6 +250,16 @@ HIDDEN_TAGS = ['mathjax']
 # CATEGORY_PATH = "categories"
 # CATEGORY_PREFIX = "cat_"
 
+# If CATEGORY_ALLOW_HIERARCHIES is set to True, categories can be organized in
+# hierarchies. For a post, the whole path in the hierarchy must be specified,
+# using a forward slash ('/') to separate paths. Use a backslash ('\') to escape
+# a forward slash or a backslash (i.e. '\//\\' is a path specifying the
+# subcategory called '\' of the top-level category called '/').
+# CATEGORY_ALLOW_HIERARCHIES = False
+# If CATEGORY_OUTPUT_FLAT_HIERARCHY is set to True, the output written to output
+# contains only the name of the leaf category and not the whole path.
+# CATEGORY_OUTPUT_FLAT_HIERARCHY = False
+
 # If CATEGORY_PAGES_ARE_INDEXES is set to True, each category's page will contain
 # the posts themselves. If set to False, it will be just a list of links.
 # CATEGORY_PAGES_ARE_INDEXES = False

--- a/nikola/data/themes/base-jinja/templates/index.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index.tmpl
@@ -11,14 +11,7 @@
 {% endblock %}
 
 {% block content %}
-{% if subcategories %}
-{{ messages('Subcategories:') }}
-<ul>
-    {% for name, link in subcategories %}
-    <li><a href="{{ link }}">{{ name }}</a></li>
-    {% endfor %}
-</ul>
-{% endif %}
+{% block content_header %}{% endblock %}
 <div class="postindex">
 {% for post in posts %}
     <article class="h-entry post-{{ post.meta('type') }}">

--- a/nikola/data/themes/base-jinja/templates/index.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index.tmpl
@@ -11,6 +11,14 @@
 {% endblock %}
 
 {% block content %}
+{% if subcategories: %}
+{{ messages('Subcategories:') }}
+<ul>
+    {% for name, link in subcategories: %}
+    <li><a href="{{ link }}">{{ name }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
 <div class="postindex">
 {% for post in posts %}
     <article class="h-entry post-{{ post.meta('type') }}">

--- a/nikola/data/themes/base-jinja/templates/index.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index.tmpl
@@ -11,10 +11,10 @@
 {% endblock %}
 
 {% block content %}
-{% if subcategories: %}
+{% if subcategories %}
 {{ messages('Subcategories:') }}
 <ul>
-    {% for name, link in subcategories: %}
+    {% for name, link in subcategories %}
     <li><a href="{{ link }}">{{ name }}</a></li>
     {% endfor %}
 </ul>

--- a/nikola/data/themes/base-jinja/templates/tag.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tag.tmpl
@@ -20,6 +20,14 @@
         {% if description %}
         <p>{{ description }}</p>
         {% endif %}
+        {% if subcategories: %}
+        {{ messages('Subcategories:') }}
+        <ul>
+            {% for name, link in subcategories: %}
+            <li><a href="{{ link }}">{{ name }}</a></li>
+            {% endfor %}
+        </ul>
+        {% endif %}
         <div class="metadata">
             {% if translations|length > 1 and generate_rss %}
                 {% for language in translations %}

--- a/nikola/data/themes/base-jinja/templates/tag.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tag.tmpl
@@ -20,10 +20,10 @@
         {% if description %}
         <p>{{ description }}</p>
         {% endif %}
-        {% if subcategories: %}
+        {% if subcategories %}
         {{ messages('Subcategories:') }}
         <ul>
-            {% for name, link in subcategories: %}
+            {% for name, link in subcategories %}
             <li><a href="{{ link }}">{{ name }}</a></li>
             {% endfor %}
         </ul>

--- a/nikola/data/themes/base-jinja/templates/tagindex.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tagindex.tmpl
@@ -1,6 +1,17 @@
 {#  -*- coding: utf-8 -*- #}
 {% extends 'index.tmpl' %}
 
+{% block content_header %}
+    {% if subcategories %}
+    {{ messages('Subcategories:') }}
+    <ul>
+        {% for name, link in subcategories %}
+        <li><a href="{{ link }}">{{ name }}</a></li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+{% endblock %}
+
 {% block extra_head %}
     {{ super() }}
     {% if translations|length > 1 and generate_atom %}

--- a/nikola/data/themes/base-jinja/templates/tags.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tags.tmpl
@@ -10,19 +10,19 @@
         {% if items %}
             <h2>{{ messages("Categories") }}</h2>
         {% endif %}
-        {% for text, full_name, path, link, indent_levels, indent_change_before, indent_change_after in cat_hierarchy: %}
-            {% for i in range(indent_change_before): %}
+        {% for text, full_name, path, link, indent_levels, indent_change_before, indent_change_after in cat_hierarchy %}
+            {% for i in range(indent_change_before) %}
                 <ul class="postlist">
             {% endfor %}
             <li><a class="reference" href="{{ link }}">{{ text }}</a>
-            {% if indent_change_after <= 0: %}
+            {% if indent_change_after <= 0 %}
                 </li>
             {% endif %}
-            {% for i in range(-indent_change_after): %}
+            {% for i in range(-indent_change_after) %}
                 </ul>
-                % if i + 1 < len(indent_levels): %}
+                {% if i + 1 < indent_levels|length %}
                     </li>
-                % endif %}
+                {% endif %}
             {% endfor %}
         {% endfor %}
         {% if items %}

--- a/nikola/data/themes/base-jinja/templates/tags.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tags.tmpl
@@ -10,13 +10,21 @@
         {% if items %}
             <h2>{{ messages("Categories") }}</h2>
         {% endif %}
-        <ul class="postlist">
-        {% for text, link in cat_items %}
-            {% if text and text not in hidden_categories %}
-                <li><a class="reference" href="{{ link }}">{{ text }}</a></li>
+        {% for text, full_name, path, link, indent_levels, indent_change_before, indent_change_after in cat_hierarchy: %}
+            {% for i in range(indent_change_before): %}
+                <ul class="postlist">
+            {% endfor %}
+            <li><a class="reference" href="{{ link }}">{{ text }}</a>
+            {% if indent_change_after <= 0: %}
+                </li>
             {% endif %}
+            {% for i in range(-indent_change_after): %}
+                </ul>
+                % if i + 1 < len(indent_levels): %}
+                    </li>
+                % endif %}
+            {% endfor %}
         {% endfor %}
-        </ul>
         {% if items %}
             <h2>{{ messages("Tags") }}</h2>
         {% endif %}

--- a/nikola/data/themes/base/messages/messages_de.py
+++ b/nikola/data/themes/base/messages/messages_de.py
@@ -28,6 +28,7 @@ MESSAGES = {
     "Read more": "Weiterlesen",
     "Skip to main content": "Springe zum Hauptinhalt",
     "Source": "Source",
+    "Subcategories:": "Unterkategorien:",
     "Tags and Categories": "Tags und Kategorien",
     "Tags": "Tags",
     "old posts, page %d": "Ältere Einträge, Seite %d",

--- a/nikola/data/themes/base/messages/messages_en.py
+++ b/nikola/data/themes/base/messages/messages_en.py
@@ -28,6 +28,7 @@ MESSAGES = {
     "Read more": "Read more",
     "Skip to main content": "Skip to main content",
     "Source": "Source",
+    "Subcategories:": "Subcategories:",
     "Tags and Categories": "Tags and Categories",
     "Tags": "Tags",
     "old posts, page %d": "old posts, page %d",

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -11,6 +11,14 @@
 </%block>
 
 <%block name="content">
+%if subcategories:
+${messages('Subcategories:')}
+<ul>
+    %for name, link in subcategories:
+    <li><a href="${link}">${name}</a></li>
+    %endfor
+</ul>
+%endif
 <div class="postindex">
 % for post in posts:
     <article class="h-entry post-${post.meta('type')}">

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -11,14 +11,7 @@
 </%block>
 
 <%block name="content">
-%if subcategories:
-${messages('Subcategories:')}
-<ul>
-    %for name, link in subcategories:
-    <li><a href="${link}">${name}</a></li>
-    %endfor
-</ul>
-%endif
+<%block name="content_header"></%block>
 <div class="postindex">
 % for post in posts:
     <article class="h-entry post-${post.meta('type')}">

--- a/nikola/data/themes/base/templates/tag.tmpl
+++ b/nikola/data/themes/base/templates/tag.tmpl
@@ -20,6 +20,14 @@
         %if description:
         <p>${description}</p>
         %endif
+        %if subcategories:
+        ${messages('Subcategories:')}
+        <ul>
+            %for name, link in subcategories:
+            <li><a href="${link}">${name}</a></li>
+            %endfor
+        </ul>
+        %endif
         <div class="metadata">
             %if len(translations) > 1 and generate_rss:
                 %for language in translations:

--- a/nikola/data/themes/base/templates/tagindex.tmpl
+++ b/nikola/data/themes/base/templates/tagindex.tmpl
@@ -1,6 +1,17 @@
 ## -*- coding: utf-8 -*-
 <%inherit file="index.tmpl"/>
 
+<%block name="content_header">
+    %if subcategories:
+    ${messages('Subcategories:')}
+    <ul>
+        %for name, link in subcategories:
+        <li><a href="${link}">${name}</a></li>
+        %endfor
+    </ul>
+    %endif
+</%block>
+
 <%block name="extra_head">
     ${parent.extra_head()}
     %if len(translations) > 1 and generate_atom:

--- a/nikola/data/themes/base/templates/tags.tmpl
+++ b/nikola/data/themes/base/templates/tags.tmpl
@@ -10,13 +10,21 @@
         % if items:
             <h2>${messages("Categories")}</h2>
         % endif
-        <ul class="postlist">
-        % for text, link in cat_items:
-            % if text and text not in hidden_categories:
-                <li><a class="reference" href="${link}">${text}</a></li>
+        % for text, full_name, path, link, indent_levels, indent_change_before, indent_change_after in cat_hierarchy:
+            % for i in range(indent_change_before):
+                <ul class="postlist">
+            % endfor
+            <li><a class="reference" href="${link}">${text}</a>
+            % if indent_change_after <= 0:
+                </li>
             % endif
+            % for i in range(-indent_change_after):
+                </ul>
+                % if i + 1 < len(indent_levels):
+                    </li>
+                % endif
+            % endfor
         % endfor
-        </ul>
         % if items:
             <h2>${messages("Tags")}</h2>
         % endif

--- a/nikola/data/themes/bootstrap-jinja/templates/tags.tmpl
+++ b/nikola/data/themes/bootstrap-jinja/templates/tags.tmpl
@@ -7,13 +7,21 @@
     {% if items %}
         <h2>{{ messages("Categories") }}</h2>
     {% endif %}
-    <ul class="unstyled">
-    {% for text, link in cat_items %}
-        {% if text and text not in hidden_categories %}
-            <li><a class="reference badge" href="{{ link }}">{{ text }}</a></li>
+    {% for text, full_name, path, link, indent_levels, indent_change_before, indent_change_after in cat_hierarchy: %}
+        {% for i in range(indent_change_before): %}
+            <ul class="unstyled">
+        {% endfor %}
+        <li><a class="reference badge" href="{{ link }}">{{ text }}</a>
+        {% if indent_change_after <= 0: %}
+            </li>
         {% endif %}
+        {% for i in range(-indent_change_after): %}
+            </ul>
+            {% if i + 1 < len(indent_levels): %}
+                </li>
+            {% endif %}
+        {% endfor %}
     {% endfor %}
-    </ul>
     {% if items %}
         <h2>{{ messages("Tags") }}</h2>
     {% endif %}

--- a/nikola/data/themes/bootstrap-jinja/templates/tags.tmpl
+++ b/nikola/data/themes/bootstrap-jinja/templates/tags.tmpl
@@ -7,17 +7,17 @@
     {% if items %}
         <h2>{{ messages("Categories") }}</h2>
     {% endif %}
-    {% for text, full_name, path, link, indent_levels, indent_change_before, indent_change_after in cat_hierarchy: %}
-        {% for i in range(indent_change_before): %}
+    {% for text, full_name, path, link, indent_levels, indent_change_before, indent_change_after in cat_hierarchy %}
+        {% for i in range(indent_change_before) %}
             <ul class="unstyled">
         {% endfor %}
         <li><a class="reference badge" href="{{ link }}">{{ text }}</a>
-        {% if indent_change_after <= 0: %}
+        {% if indent_change_after <= 0 %}
             </li>
         {% endif %}
-        {% for i in range(-indent_change_after): %}
+        {% for i in range(-indent_change_after) %}
             </ul>
-            {% if i + 1 < len(indent_levels): %}
+            {% if i + 1 < indent_levels|length %}
                 </li>
             {% endif %}
         {% endfor %}

--- a/nikola/data/themes/bootstrap/templates/tags.tmpl
+++ b/nikola/data/themes/bootstrap/templates/tags.tmpl
@@ -7,13 +7,21 @@
     % if items:
         <h2>${messages("Categories")}</h2>
     % endif
-    <ul class="unstyled">
-    % for text, link in cat_items:
-        % if text and text not in hidden_categories:
-            <li><a class="reference badge" href="${link}">${text}</a></li>
+    % for text, full_name, path, link, indent_levels, indent_change_before, indent_change_after in cat_hierarchy:
+        % for i in range(indent_change_before):
+            <ul class="unstyled">
+        % endfor
+        <li><a class="reference badge" href="${link}">${text}</a>
+        % if indent_change_after <= 0:
+            </li>
         % endif
+        % for i in range(-indent_change_after):
+            </ul>
+            % if i + 1 < len(indent_levels):
+                </li>
+            % endif
+        % endfor
     % endfor
-    </ul>
     % if items:
         <h2>${messages("Tags")}</h2>
     % endif

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1378,7 +1378,7 @@ class Nikola(object):
                         sys.exit(1)
                     esc_ch = category_name[next_backslash + 1]
                     if esc_ch not in {'/', '\\'}:
-                        utils.LOGGER.error("Unknown escape sequence '\\{0}' in '{1}' at last position!".format(esc_ch, category_name))
+                        utils.LOGGER.error("Unknown escape sequence '\\{0}' in '{1}'!".format(esc_ch, category_name))
                         sys.exit(1)
                     current += category_name[index:next_backslash] + esc_ch
                     index = next_backslash + 2

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1412,8 +1412,9 @@ class Nikola(object):
             self.posts_per_category[self.category_path_to_category_name(current_path)].append(post)
 
     def _sort_category_hierarchy(self):
-        self.category_hierarchy_lookup = {}
         # First create a hierarchy of TreeNodes
+        self.category_hierarchy_lookup = {}
+
         def create_hierarchy(cat_hierarchy, parent=None):
             result = []
             for name, children in cat_hierarchy.items():
@@ -1425,6 +1426,7 @@ class Nikola(object):
                 if node.category_name not in self.config.get('HIDDEN_CATEGORIES'):
                     result.append(node)
             return natsort.natsorted(result, key=lambda e: e.name, alg=natsort.ns.F | natsort.ns.IC)
+
         root_list = create_hierarchy(self.category_hierarchy)
         # Next, flatten the hierarchy
         self.category_hierarchy = utils.flatten_tree_structure(root_list)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1358,45 +1358,17 @@ class Nikola(object):
 
     def parse_category_name(self, category_name):
         if self.config['CATEGORY_ALLOW_HIERARCHIES']:
-            result = []
-            current = ''
-            index = 0
-            next_backslash = category_name.find('\\', index)
-            next_slash = category_name.find('/', index)
-            while index < len(category_name):
-                if next_backslash == -1 and next_slash == -1:
-                    current += category_name[index:]
-                    index = len(category_name)
-                elif next_slash >= 0 and (next_backslash == -1 or next_backslash > next_slash):
-                    result.append(current + category_name[index:next_slash])
-                    current = ''
-                    index = next_slash + 1
-                    next_slash = category_name.find('/', index)
-                else:
-                    if len(category_name) == next_backslash + 1:
-                        utils.LOGGER.error("Unexpected '\\' in '{0}' at last position!".format(category_name))
-                        sys.exit(1)
-                    esc_ch = category_name[next_backslash + 1]
-                    if esc_ch not in {'/', '\\'}:
-                        utils.LOGGER.error("Unknown escape sequence '\\{0}' in '{1}'!".format(esc_ch, category_name))
-                        sys.exit(1)
-                    current += category_name[index:next_backslash] + esc_ch
-                    index = next_backslash + 2
-                    next_backslash = category_name.find('\\', index)
-                    if esc_ch == '/':
-                        next_slash = category_name.find('/', index)
-            if len(current) > 0:
-                result.append(current)
-            return result
+            try:
+                return utils.parse_escaped_hierarchical_category_name(category_name)
+            except Exception as e:
+                utils.LOGGER.error(str(e))
+                sys.exit(1)
         else:
             return [category_name] if len(category_name) > 0 else []
 
     def category_path_to_category_name(self, category_path):
         if self.config['CATEGORY_ALLOW_HIERARCHIES']:
-            def escape(s):
-                return s.replace('\\', '\\\\').replace('/', '\\/')
-
-            return '/'.join([escape(p) for p in category_path])
+            return utils.join_hierarchical_category_path(category_path)
         else:
             return ''.join(category_path)
 

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -107,12 +107,16 @@ class RenderTags(Task):
         categories = {}
         for category in self.site.posts_per_category.keys():
             slug = tuple(self.slugify_category_name(category))
+            for part in slug:
+                if len(part) == 0:
+                    utils.LOGGER.error("Category '{0}' yields invalid slug '{1}'!".format(category, '/'.join(slug)))
+                    sys.exit(1)
             if slug in categories:
                 other_category = categories[slug]
                 utils.LOGGER.error('You have categories that are too similar: {0} and {1}'.format(category, other_category))
                 utils.LOGGER.error('Category {0} is used in: {1}'.format(category, ', '.join([p.source_path for p in self.posts_per_category[category]])))
                 utils.LOGGER.error('Category {0} is used in: {1}'.format(other_category, ', '.join([p.source_path for p in self.posts_per_category[other_category]])))
-                pass
+                sys.exit(1)
             categories[slug] = category
 
         tag_list = list(self.site.posts_per_tag.items())

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -28,6 +28,7 @@ from __future__ import unicode_literals
 import json
 import os
 import sys
+import natsort
 try:
     from urlparse import urljoin
 except ImportError:
@@ -93,12 +94,12 @@ class RenderTags(Task):
             return
 
         if kw['category_path'] == kw['tag_path']:
-            tags = {self.slugify_name(tag): tag for tag in self.site.posts_per_tag.keys()}
-            categories = {kw['category_prefix'] + self.slugify_name(category): category for category in self.site.posts_per_category.keys()}
+            tags = {self.slugify_tag_name(tag): tag for tag in self.site.posts_per_tag.keys()}
+            categories = {self.slugify_category_name(category)[0]: category for category in self.site.posts_per_category.keys()}
             intersect = set(tags.keys()) & set(categories.keys())
             if len(intersect) > 0:
                 for slug in intersect:
-                    utils.LOGGER.error("Category '{0}' and tag '{1}' both have the same slug '{2}'!".format(categories[slug], tags[slug], slug))
+                    utils.LOGGER.error("Category '{0}' and tag '{1}' both have the same slug '{2}'!".format('/'.join(categories[slug]), tags[slug], slug))
                 sys.exit(1)
 
         tag_list = list(self.site.posts_per_tag.items())
@@ -124,10 +125,8 @@ class RenderTags(Task):
             for task in render_lists(tag, posts, False):
                 yield task
 
-        for tag, posts in cat_list:
-            if tag == '':  # This is uncategorized posts
-                continue
-            for task in render_lists(tag, posts, True):
+        for path, posts in cat_list:
+            for task in render_lists(path, posts, True):
                 yield task
 
         # Tag cloud json file
@@ -165,14 +164,12 @@ class RenderTags(Task):
 
     def _create_tags_page(self, kw, include_tags=True, include_categories=True):
         """a global "all your tags/categories" page for each language"""
-        tags = list([tag for tag in self.site.posts_per_tag.keys()
-                     if len(self.site.posts_per_tag[tag]) >= kw["taglist_minimum_post_count"]])
-        categories = list(self.site.posts_per_category.keys())
-        # We want our tags to be sorted case insensitive
-        tags.sort(key=lambda a: a.lower())
-        categories.sort(key=lambda a: a.lower())
-        has_tags = (tags != ['']) and include_tags
-        has_categories = (categories != ['']) and include_categories
+        tags = natsort.natsorted([tag for tag in self.site.posts_per_tag.keys()
+                                  if len(self.site.posts_per_tag[tag]) >= kw["taglist_minimum_post_count"]],
+                                 alg=natsort.ns.F | natsort.ns.IC)
+        categories = [cat.category_name for cat in self.site.category_hierarchy]
+        has_tags = (tags != []) and include_tags
+        has_categories = (categories != []) and include_categories
         template_name = "tags.tmpl"
         kw = kw.copy()
         if include_tags:
@@ -198,6 +195,11 @@ class RenderTags(Task):
             if has_categories:
                 context["cat_items"] = [(tag, self.site.link("category", tag, lang)) for tag
                                         in categories]
+                context['cat_hierarchy'] = [(node.name, node.category_name, node.category_path,
+                                             self.site.link("category", node.category_name),
+                                             node.indent_levels, node.indent_change_before,
+                                             node.indent_change_after)
+                                            for node in self.site.category_hierarchy]
             else:
                 context["cat_items"] = None
             context["permalink"] = self.site.link("tag_index" if has_tags else "category_index", None, lang)
@@ -222,6 +224,20 @@ class RenderTags(Task):
             yield self._create_tags_page(kw, False, True)
             yield self._create_tags_page(kw, True, False)
 
+    def _get_title(self, tag, is_category):
+        if is_category:
+            return self.site.parse_category_name(tag)[-1]
+        else:
+            return tag
+
+    def _get_description(self, tag, is_category, kw, lang):
+        descriptions = kw["category_pages_descriptions"] if is_category else kw["tag_pages_descriptions"]
+        return descriptions[lang][tag] if lang in descriptions and tag in descriptions[lang] else None
+
+    def _get_subcategories(self, category):
+        node = self.site.category_hierarchy_lookup[category]
+        return [(child.name, self.site.link("category", child.category_name)) for child in node.children]
+
     def tag_page_as_index(self, tag, lang, post_list, kw, is_category):
         """render a sort of index page collection using only this
         tag's posts."""
@@ -244,12 +260,15 @@ class RenderTags(Task):
                         """{0} ({1})" href="{2}">""".format(
                             tag, lang, self.site.link(kind + "_rss", tag, lang)))
             context_source['rss_link'] = rss_link
-        context_source["tag"] = tag
-        context_source["description"] = None
-        descriptions = kw["category_pages_descriptions"] if is_category else kw["tag_pages_descriptions"]
-        if lang in descriptions and tag in descriptions[lang]:
-            context_source["description"] = descriptions[lang][tag]
-        indexes_title = kw["messages"][lang]["Posts about %s"] % tag
+        title = self._get_title(tag, is_category)
+        if is_category:
+            context_source["category"] = tag
+            context_source["category_path"] = self.site.parse_category_name(tag)
+        context_source["tag"] = title
+        indexes_title = kw["messages"][lang]["Posts about %s"] % title
+        context_source["description"] = self._get_description(tag, is_category, kw, lang)
+        if is_category:
+            context_source["subcategories"] = self._get_subcategories(tag)
         template_name = "tagindex.tmpl"
 
         yield self.site.generic_index_renderer(lang, post_list, indexes_title, template_name, context_source, kw, str(self.name), page_link, page_path)
@@ -262,16 +281,19 @@ class RenderTags(Task):
             kind, tag, lang))
         context = {}
         context["lang"] = lang
-        context["title"] = kw["messages"][lang]["Posts about %s"] % tag
+        title = self._get_title(tag, is_category)
+        if is_category:
+            context["category"] = tag
+            context["category_path"] = self.site.parse_category_name(tag)
+        context["tag"] = title
+        context["title"] = kw["messages"][lang]["Posts about %s"] % title
         context["posts"] = post_list
         context["permalink"] = self.site.link(kind, tag, lang)
-        context["tag"] = tag
         context["kind"] = kind
-        context["description"] = None
-        descriptions = (kw["category_pages_descriptions"] if is_category
-                        else kw["tag_pages_descriptions"])
-        if lang in descriptions and tag in descriptions[lang]:
-            context["description"] = descriptions[lang][tag]
+        context["description"] = self._get_description(tag, is_category, kw, lang)
+        if is_category:
+            context["subcategories"] = self._get_subcategories(tag)
+            print(tag, context["subcategories"])
         task = self.site.generic_post_list_renderer(
             lang,
             post_list,
@@ -305,7 +327,7 @@ class RenderTags(Task):
             'file_dep': deps,
             'targets': [output_name],
             'actions': [(utils.generic_rss_renderer,
-                        (lang, "{0} ({1})".format(kw["blog_title"](lang), tag),
+                        (lang, "{0} ({1})".format(kw["blog_title"](lang), self._get_title(tag, is_category)),
                          kw["site_url"], None, post_list,
                          output_name, kw["rss_teasers"], kw["rss_plain"], kw['feed_length'],
                          feed_url, None, kw["rss_link_append_query"]))],
@@ -315,7 +337,7 @@ class RenderTags(Task):
         }
         return utils.apply_filters(task, kw['filters'])
 
-    def slugify_name(self, name):
+    def slugify_tag_name(self, name):
         if self.site.config['SLUG_TAG_PATH']:
             name = utils.slugify(name)
         return name
@@ -335,42 +357,54 @@ class RenderTags(Task):
             return [_f for _f in [
                 self.site.config['TRANSLATIONS'][lang],
                 self.site.config['TAG_PATH'],
-                self.slugify_name(name),
+                self.slugify_tag_name(name),
                 self.site.config['INDEX_FILE']] if _f]
         else:
             return [_f for _f in [
                 self.site.config['TRANSLATIONS'][lang],
                 self.site.config['TAG_PATH'],
-                self.slugify_name(name) + ".html"] if _f]
+                self.slugify_tag_name(name) + ".html"] if _f]
 
     def tag_atom_path(self, name, lang):
         return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
-                              self.site.config['TAG_PATH'], self.slugify_name(name) + ".atom"] if
+                              self.site.config['TAG_PATH'], self.slugify_tag_name(name) + ".atom"] if
                 _f]
 
     def tag_rss_path(self, name, lang):
         return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
-                              self.site.config['TAG_PATH'], self.slugify_name(name) + ".xml"] if
+                              self.site.config['TAG_PATH'], self.slugify_tag_name(name) + ".xml"] if
                 _f]
+
+    def slugify_category_name(self, name):
+        path = self.site.parse_category_name(name)
+        if self.site.config['CATEGORY_OUTPUT_FLAT_HIERARCHY']:
+            path = path[-1:]  # only the leaf
+        result = [self.slugify_tag_name(part) for part in path]
+        result[0] = self.site.config['CATEGORY_PREFIX'] + result[0]
+        if not self.site.config['PRETTY_URLS']:
+            result = ['-'.join(result)]
+        return result
+
+    def _add_extension(self, path, extension):
+        path[-1] += extension
+        return path
 
     def category_path(self, name, lang):
         if self.site.config['PRETTY_URLS']:
             return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
-                                  self.site.config['CATEGORY_PATH'],
-                                  self.site.config['CATEGORY_PREFIX'] + self.slugify_name(name),
-                                  self.site.config['INDEX_FILE']] if _f]
+                                  self.site.config['CATEGORY_PATH']] if
+                    _f] + self.slugify_category_name(name) + [self.site.config['INDEX_FILE']]
         else:
             return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
-                                  self.site.config['CATEGORY_PATH'],
-                                  self.site.config['CATEGORY_PREFIX'] + self.slugify_name(name) + ".html"] if
-                    _f]
+                                  self.site.config['CATEGORY_PATH']] if
+                    _f] + self._add_extension(self.slugify_category_name(name), ".html")
 
     def category_atom_path(self, name, lang):
         return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
-                              self.site.config['CATEGORY_PATH'], self.site.config['CATEGORY_PREFIX'] + self.slugify_name(name) + ".atom"] if
-                _f]
+                              self.site.config['CATEGORY_PATH']] if
+                _f] + self._add_extension(self.slugify_category_name(name), ".atom")
 
     def category_rss_path(self, name, lang):
         return [_f for _f in [self.site.config['TRANSLATIONS'][lang],
-                              self.site.config['CATEGORY_PATH'], self.site.config['CATEGORY_PREFIX'] + self.slugify_name(name) + ".xml"] if
-                _f]
+                              self.site.config['CATEGORY_PATH']] if
+                _f] + self._add_extension(self.slugify_category_name(name), ".xml")

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -102,6 +102,18 @@ class RenderTags(Task):
                     utils.LOGGER.error("Category '{0}' and tag '{1}' both have the same slug '{2}'!".format('/'.join(categories[slug]), tags[slug], slug))
                 sys.exit(1)
 
+        # Test for category slug clashes
+        categories = {}
+        for category in self.site.posts_per_category.keys():
+            slug = tuple(self.slugify_category_name(category))
+            if slug in categories:
+                other_category = categories[slug]
+                utils.LOGGER.error('You have categories that are too similar: {0} and {1}'.format(category, other_category))
+                utils.LOGGER.error('Category {0} is used in: {1}'.format(category, ', '.join([p.source_path for p in self.posts_per_category[category]])))
+                utils.LOGGER.error('Category {0} is used in: {1}'.format(other_category, ', '.join([p.source_path for p in self.posts_per_category[other_category]])))
+                pass
+            categories[slug] = category
+
         tag_list = list(self.site.posts_per_tag.items())
         cat_list = list(self.site.posts_per_category.items())
 

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -95,7 +95,8 @@ class RenderTags(Task):
 
         if kw['category_path'] == kw['tag_path']:
             tags = {self.slugify_tag_name(tag): tag for tag in self.site.posts_per_tag.keys()}
-            categories = {self.slugify_category_name(category)[0]: category for category in self.site.posts_per_category.keys()}
+            cats = {tuple(self.slugify_category_name(category)): category for category in self.site.posts_per_category.keys()}
+            categories = {k[0]: v for k, v in cats.items() if len(k) == 1}
             intersect = set(tags.keys()) & set(categories.keys())
             if len(intersect) > 0:
                 for slug in intersect:

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -67,7 +67,8 @@ __all__ = ['get_theme_path', 'get_theme_chain', 'load_messages', 'copy_tree',
            'ask', 'ask_yesno', 'options2docstring', 'os_path_split',
            'get_displayed_page_number', 'adjust_name_for_index_path_list',
            'adjust_name_for_index_path', 'adjust_name_for_index_link',
-           'NikolaPygmentsHTML', 'create_redirect']
+           'NikolaPygmentsHTML', 'create_redirect', 'TreeNode',
+           'flatten_tree_structure']
 
 # Are you looking for 'generic_rss_renderer'?
 # It's defined in nikola.nikola.Nikola (the site object).
@@ -1485,3 +1486,90 @@ def create_redirect(src, dst):
                  'content="noindex">\n<meta http-equiv="refresh" content="0; '
                  'url={0}">\n</head>\n<body>\n<p>Page moved '
                  '<a href="{0}">here</a>.</p>\n</body>'.format(dst))
+
+
+class TreeNode(object):
+    indent_levels = None  # use for formatting comments as tree
+    indent_change_before = 0  # use for formatting comments as tree
+    indent_change_after = 0  # use for formatting comments as tree
+
+    # The indent levels and changes allow to render a tree structure
+    # without keeping track of all that information during rendering.
+    #
+    # The indent_change_before is the different between the current
+    # comment's level and the previous comment's level; if the number
+    # is positive, the current level is indented further in, and if it
+    # is negative, it is indented further out. Positive values can be
+    # used to open HTML tags for each opened level.
+    #
+    # The indent_change_after is the difference between the next
+    # comment's level and the current comment's level. Negative values
+    # can be used to close HTML tags for each closed level.
+    #
+    # The indent_levels list contains one entry (index, count) per
+    # level, informing about the index of the current comment on that
+    # level and the count of comments on that level (before a comment
+    # of a higher level comes). This information can be used to render
+    # tree indicators, for example to generate a tree such as:
+    #
+    # +--- [(0,3)]
+    # +-+- [(1,3)]
+    # | +--- [(1,3), (0,2)]
+    # | +-+- [(1,3), (1,2)]
+    # |   +--- [(1,3), (1,2), (0, 1)]
+    # +-+- [(2,3)]
+    #   +- [(2,3), (0,1)]
+    #
+    # (The lists used as labels represent the content of the
+    # indent_levels property for that node.)
+
+    def __init__(self, name, parent=None):
+        self.name = name
+        self.parent = parent
+        self.children = []
+
+    def get_path(self):
+        path = []
+        curr = self
+        while curr is not None:
+            path.append(curr)
+            curr = curr.parent
+        return reversed(path)
+
+    def get_children(self):
+        return self.children
+
+
+def flatten_tree_structure(root_list):
+    elements = []
+
+    def generate(input_list, indent_levels_so_far):
+        for index, element in enumerate(input_list):
+            # add to destination
+            elements.append(element)
+            # compute and set indent levels
+            indent_levels = indent_levels_so_far + [(index, len(input_list))]
+            element.indent_levels = indent_levels
+            # add children
+            children = element.get_children()
+            element.children_count = len(children)
+            generate(children, indent_levels)
+
+    generate(root_list, [])
+    # Add indent change counters
+    level = 0
+    last_element = None
+    for element in elements:
+        new_level = len(element.indent_levels)
+        # Compute level change before this element
+        change = new_level - level
+        if last_element is not None:
+            last_element.indent_change_after = change
+        element.indent_change_before = change
+        # Update variables
+        level = new_level
+        last_element = element
+    # Set level change after last element
+    if last_element is not None:
+        last_element.indent_change_after = -level
+    return elements

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -68,7 +68,8 @@ __all__ = ['get_theme_path', 'get_theme_chain', 'load_messages', 'copy_tree',
            'get_displayed_page_number', 'adjust_name_for_index_path_list',
            'adjust_name_for_index_path', 'adjust_name_for_index_link',
            'NikolaPygmentsHTML', 'create_redirect', 'TreeNode',
-           'flatten_tree_structure']
+           'flatten_tree_structure', 'parse_escaped_hierarchical_category_name',
+           'join_hierarchical_category_path']
 
 # Are you looking for 'generic_rss_renderer'?
 # It's defined in nikola.nikola.Nikola (the site object).

--- a/translations/nikola.messages/de.po
+++ b/translations/nikola.messages/de.po
@@ -122,3 +122,6 @@ msgstr "%d min verbleiben zum Lesen"
 
 msgid "Skip to main content"
 msgstr "Springe zum Hauptinhalt"
+
+msgid "Subcategories:"
+msgstr "Unterkategorien:"

--- a/translations/nikola.messages/en.po
+++ b/translations/nikola.messages/en.po
@@ -115,3 +115,6 @@ msgstr "%d min remaining to read"
 
 msgid "Skip to main content"
 msgstr "Skip to main content"
+
+msgid "Subcategories:"
+msgstr "Subcategories:"


### PR DESCRIPTION
This is a first shot on implementing category hierarchies, as discussed in #1520. Hierarchies must be explicitly enabled via `CATEGORY_ALLOW_HIERARCHIES = True` in `conf.py`. Then `/` in a category name is used to specify a category path, and `\` is used for escaping `/` and `\`.

`CATEGORY_OUTPUT_FLAT_HIERARCHY` can be used to switch between using the full category path to determine the category's slug (when set to `False`, which is the default), or to just use the subcategory name for the slug (when set to `True`).