### PR TITLE
Emit an event when a post/page already exists, also.

### DIFF
--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -349,6 +349,13 @@ class CommandNewPost(Command):
 
         if (not onefile and os.path.isfile(meta_path)) or \
                 os.path.isfile(txt_path):
+
+            # Emit an event when a post exists
+            event = dict(path=txt_path)
+            if not onefile:  # write metadata file
+                event['meta_path'] = meta_path
+            signal('existing_' + content_type).send(self, **event)
+
             LOGGER.error("The title already exists!")
             exit(8)
 


### PR DESCRIPTION
Creation of new_post successfully emits an event, but no event is fired
new_post fails because there is an existing post.  This event can be
used by plugins, for e.g. open the post in an editor or prompt to delete
the post, etc.