### PR TITLE
Fixing two things with category hierarchies.

### DIFF
--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -270,14 +270,14 @@ class RenderTags(Task):
             return utils.adjust_name_for_index_path(self.site.path(kind + feed, tag, lang), i, displayed_i, lang, self.site, force_addition, extension)
 
         context_source = {}
+        title = self._get_title(tag, is_category)
         if kw["generate_rss"]:
             # On a tag page, the feeds include the tag's feeds
             rss_link = ("""<link rel="alternate" type="application/rss+xml" """
                         """type="application/rss+xml" title="RSS for tag """
                         """{0} ({1})" href="{2}">""".format(
-                            tag, lang, self.site.link(kind + "_rss", tag, lang)))
+                            title, lang, self.site.link(kind + "_rss", tag, lang)))
             context_source['rss_link'] = rss_link
-        title = self._get_title(tag, is_category)
         if is_category:
             context_source["category"] = tag
             context_source["category_path"] = self.site.parse_category_name(tag)

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -114,8 +114,8 @@ class RenderTags(Task):
             if slug in categories:
                 other_category = categories[slug]
                 utils.LOGGER.error('You have categories that are too similar: {0} and {1}'.format(category, other_category))
-                utils.LOGGER.error('Category {0} is used in: {1}'.format(category, ', '.join([p.source_path for p in self.posts_per_category[category]])))
-                utils.LOGGER.error('Category {0} is used in: {1}'.format(other_category, ', '.join([p.source_path for p in self.posts_per_category[other_category]])))
+                utils.LOGGER.error('Category {0} is used in: {1}'.format(category, ', '.join([p.source_path for p in self.site.posts_per_category[category]])))
+                utils.LOGGER.error('Category {0} is used in: {1}'.format(other_category, ', '.join([p.source_path for p in self.site.posts_per_category[other_category]])))
                 sys.exit(1)
             categories[slug] = category
 


### PR DESCRIPTION
Fixes two problems:
 * A bug when two category names are too similar: an exception occured during error logging (commit 8f2f168)
 * When a category page was created as an index, the link to the RSS (if generated) had a not so nice title (commit 3883012)