### PR TITLE
Nikola build on demo site always finds something to do

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1469,7 +1469,7 @@ class Nikola(object):
         # Sort everything.
 
         for thing in self.timeline, self.posts, self.all_posts, self.pages:
-            thing.sort(key=lambda p: p.date)
+            thing.sort(key=lambda p: (p.date, p.source_path))
             thing.reverse()
         self._sort_category_hierarchy()
 


### PR DESCRIPTION
If you run `nikola build` on the demo site more than once, it will always find something to do. The first thing is that it always executes `render_posts:timeline_changes`. The reason is that the order of the posts in the timeline can change if two posts have the same date, which happens with pages. Therefore, this patch sorts the timeline (and all other post lists) not only by date, but also by source path.