### PR TITLE
give meaningful error if two posts conflict (Fix #1749)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,7 @@ Features
 Bugfixes
 --------
 
+* Better error if two posts/pages output conflict (Issue #1749)
 * Scanning of posts refactored out of core (Issue #1700)
 * github_deploy records lastdeploy timestamp like regular deploy
 * Use a global directory for gallery images, ignoring translations (Issue #1726)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1463,8 +1463,22 @@ class Nikola(object):
                 self.pages.append(post)
 
             for lang in self.config['TRANSLATIONS'].keys():
-                self.post_per_file[post.destination_path(lang=lang)] = post
-                self.post_per_file[post.destination_path(lang=lang, extension=post.source_ext())] = post
+                dest = post.destination_path(lang=lang)
+                src_dest = post.destination_path(lang=lang, extension=post.source_ext())
+                if dest in self.post_per_file:
+                    utils.LOGGER.error('Two posts are trying to generate {0}: {1} and {2}'.format(
+                        dest,
+                        self.post_per_file[dest].source_path,
+                        post.source_path))
+                    sys.exit(1)
+                if (src_dest in self.post_per_file) and self.config['COPY_SOURCES']:
+                    utils.LOGGER.error('Two posts are trying to generate {0}: {1} and {2}'.format(
+                        src_dest,
+                        self.post_per_file[dest].source_path,
+                        post.source_path))
+                    sys.exit(1)
+                self.post_per_file[dest] = post
+                self.post_per_file[src_dest] = post
 
         # Sort everything.
 


### PR DESCRIPTION
Give a meaningful error and exit when slugs conflict.