### PR TITLE
fix #1747

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,7 @@ Features
 Bugfixes
 --------
 
+* Avoid some rebuild loops (Issue #1747)
 * Better error if two posts/pages output conflict (Issue #1749)
 * Scanning of posts refactored out of core (Issue #1700)
 * github_deploy records lastdeploy timestamp like regular deploy

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -235,7 +235,11 @@ class Post(object):
         m = hashlib.md5()
         # source_path modification date (to avoid reading it)
         m.update(utils.unicode_str(os.stat(self.source_path).st_mtime).encode('utf-8'))
-        m.update(utils.unicode_str(json.dumps(self.meta, cls=utils.CustomEncoder, sort_keys=True)).encode('utf-8'))
+        clean_meta = {}
+        for k, v in self.meta.items():
+            if v:
+                clean_meta[k] = v
+        m.update(utils.unicode_str(json.dumps(clean_meta, cls=utils.CustomEncoder, sort_keys=True)).encode('utf-8'))
         return '<Post: {0} {1}>'.format(self.source_path, m.hexdigest())
 
     def _has_pretty_url(self, lang):

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -237,8 +237,11 @@ class Post(object):
         m.update(utils.unicode_str(os.stat(self.source_path).st_mtime).encode('utf-8'))
         clean_meta = {}
         for k, v in self.meta.items():
-            if v:
-                clean_meta[k] = v
+            sub_meta = {}
+            clean_meta[k] = sub_meta
+            for kk, vv in v.items():
+                if vv:
+                    sub_meta[kk] = vv
         m.update(utils.unicode_str(json.dumps(clean_meta, cls=utils.CustomEncoder, sort_keys=True)).encode('utf-8'))
         return '<Post: {0} {1}>'.format(self.source_path, m.hexdigest())
 


### PR DESCRIPTION
Remove empty/Falsish values from post metadata when hashing it for repr.

This doesn't break "post repr should change if metadata changes" because when a Falsish value becomes truish it will change the hash.

@felixfontein can you take a look since this is your idea and I can't reproduce the bug? :-)