### PR TITLE
Fix #1810 -- use watchdog in auto

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,14 @@
+New in master
+=============
+
+Features
+--------
+
+* Use ``watchdog`` in ``nikola auto`` (Issue #1810)
+
+Bugfixes
+--------
+
 New in v7.5.1
 =============
 

--- a/nikola/plugins/command/auto.plugin
+++ b/nikola/plugins/command/auto.plugin
@@ -4,6 +4,6 @@ Module = auto
 
 [Documentation]
 Author = Roberto Alsina
-Version = 1.0
+Version = 2.1.0
 Website = http://getnikola.com
 Description = Automatically detect site changes, rebuild and optionally refresh a browser.

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -138,19 +138,19 @@ class CommandAuto(Command):
             + 'script>')</script>
         </head>'''.format(port)
 
-        watched = [
-            self.site.configuration_filename,
+        # Do not duplicate entries -- otherwise, multiple rebuilds are triggered
+        watched = set([
             'themes/',
             'templates/',
-        ]
+        ])
         for item in self.site.config['post_pages']:
-            watched.append(os.path.dirname(item[0]))
+            watched.add(os.path.dirname(item[0]))
         for item in self.site.config['FILES_FOLDERS']:
-            watched.append(item)
+            watched.add(item)
         for item in self.site.config['GALLERY_FOLDERS']:
-            watched.append(item)
+            watched.add(item)
         for item in self.site.config['LISTINGS_FOLDERS']:
-            watched.append(item)
+            watched.add(item)
 
         out_folder = self.site.config['OUTPUT_FOLDER']
         if options and options.get('browser'):

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -58,8 +58,7 @@ except ImportError:
 
 
 from nikola.plugin_categories import Command
-from nikola.utils import req_missing, get_logger
-
+from nikola.utils import req_missing, get_logger, get_theme_path
 LRJS_PATH = os.path.join(os.path.dirname(__file__), 'livereload.js')
 error_signal = signal('error')
 refresh_signal = signal('refresh')
@@ -142,9 +141,8 @@ class CommandAuto(Command):
 
         # Do not duplicate entries -- otherwise, multiple rebuilds are triggered
         watched = set([
-            'themes/',
             'templates/',
-        ])
+        ] + [os.path.join(get_theme_path(name), "templates") for name in self.site.THEMES])
         for item in self.site.config['post_pages']:
             watched.add(os.path.dirname(item[0]))
         for item in self.site.config['FILES_FOLDERS']:

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -142,7 +142,7 @@ class CommandAuto(Command):
         # Do not duplicate entries -- otherwise, multiple rebuilds are triggered
         watched = set([
             'templates/',
-        ] + [os.path.join(get_theme_path(name), "templates") for name in self.site.THEMES])
+        ] + [get_theme_path(name) for name in self.site.THEMES])
         for item in self.site.config['post_pages']:
             watched.add(os.path.dirname(item[0]))
         for item in self.site.config['FILES_FOLDERS']:

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -219,11 +219,15 @@ class CommandAuto(Command):
             os.kill(os.getpid(), 15)
 
     def do_rebuild(self, event):
+        self.logger.info('REBUILDING SITE (from {0})'.format(event.src_path))
         p = subprocess.Popen(self.cmd_arguments, stderr=subprocess.PIPE)
         if p.wait() != 0:
             error = p.stderr.read()
             self.logger.error(error)
             error_signal.send(error=error)
+        else:
+            error = p.stderr.read()
+            print(error)
 
     def do_refresh(self, event):
         self.logger.info('REFRESHING: {0}'.format(event.src_path))

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -10,3 +10,4 @@ webassets>=0.10.1
 ipython[notebook]>=1.2.1
 ghp-import>=0.4.1
 ws4py==0.3.4
+watchdog==0.8.3


### PR DESCRIPTION
This is #1810.

Fixes (some of which would be useful even without `watchdog`):

* ~~make rebuilds actually work~~ cherry-picked onto master
* rebuild only once by using a set
* tell people we’re rebuilding and show them the log when we’re done

Also, we have to watch the directory with `conf.py` and filter out events because you must watch entire directories with `watchdog`.

cc @ralsina