### PR TITLE
Add print CSS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Add print CSS to all default themes (Issue #1817)
 * Add support for ``html_tidy_withconfig`` to use a ``tidy5.conf`` file
   (Issue #1795)
 * Change default tidy5 filters not to drop empty elements (Issue #1795)

--- a/nikola/data/themes/base-jinja/templates/post.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post.tmpl
@@ -40,7 +40,7 @@
     </nav>
     </aside>
     {% if not post.meta('nocomments') and site_has_comments %}
-        <section class="comments">
+        <section class="comments hidden-print">
         <h2>{{ messages("Comments") }}</h2>
         {{ comments.comment_form(post.permalink(absolute=True), post.title(), post._base_path) }}
         </section>

--- a/nikola/data/themes/base-jinja/templates/post_header.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_header.tmpl
@@ -38,7 +38,7 @@
             {% endif %}
             {{ html_sourcelink() }}
             {% if post.meta('link') %}
-                    <p><a href='{{ post.meta('link') }}'>{{ messages("Original site") }}</a></p>
+                    <p class="linkline"><a href='{{ post.meta('link') }}'>{{ messages("Original site") }}</a></p>
             {% endif %}
             {% if post.description() %}
                 <meta name="description" itemprop="description" content="{{ post.description() }}">

--- a/nikola/data/themes/base-jinja/templates/post_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_helper.tmpl
@@ -24,7 +24,7 @@
 
 {% macro html_pager(post) %}
     {% if post.prev_post or post.next_post %}
-        <ul class="pager">
+        <ul class="pager hidden-print">
         {% if post.prev_post %}
             <li class="previous">
                 <a href="{{ post.prev_post.permalink() }}" rel="prev" title="{{ post.prev_post.title()|e }}">{{ messages("Previous post") }}</a>

--- a/nikola/data/themes/base/assets/css/theme.css
+++ b/nikola/data/themes/base/assets/css/theme.css
@@ -37,6 +37,9 @@ body {
 	body {
 		font-family: Garamond, serif;
 	}
+	.hidden-print {
+		display: none !important;
+	}
 }
 
 #container {

--- a/nikola/data/themes/base/assets/css/theme.css
+++ b/nikola/data/themes/base/assets/css/theme.css
@@ -33,14 +33,6 @@ body {
 	line-height: 1.4;
 	padding: 1em;
 }
-@media print {
-	body {
-		font-family: Garamond, serif;
-	}
-	.hidden-print {
-		display: none !important;
-	}
-}
 
 #container {
 	margin: 1em auto;
@@ -287,4 +279,110 @@ img {
 	clip: auto;
 }
 
-pre.code, code { white-space: pre; word-wrap: normal; overflow: auto; }
+pre.code, code {
+	white-space: pre;
+	word-wrap: normal;
+	overflow: auto;
+}
+
+/* SOURCE: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
+@media print {
+	*,
+	*:before,
+	*:after {
+		background: transparent !important;
+		color: #000 !important; /* Black prints faster: http://www.sanbeiji.com/archives/953 */
+		box-shadow: none !important;
+		text-shadow: none !important;
+		font-family: Garamond, Junicode, serif;
+	}
+
+	body {
+		font-size: 12pt;
+	}
+
+	a,
+	a:visited {
+		text-decoration: underline;
+	}
+
+	a[href]:after {
+		content: " (" attr(href) ")";
+	}
+
+	abbr[title]:after {
+		content: " (" attr(title) ")";
+	}
+
+	/*
+	 * Don't show links that are fragment identifiers,
+	 * or use the `javascript:` pseudo protocol
+	 */
+
+	a[href^="#"]:after,
+	a[href^="javascript:"]:after {
+		content: "";
+	}
+
+	pre,
+	blockquote {
+		border: 1px solid #999;
+		page-break-inside: avoid;
+	}
+
+	/*
+	 * Printing Tables:
+	 * http://css-discuss.incutio.com/wiki/Printing_Tables
+	 */
+
+	thead {
+		display: table-header-group;
+	}
+
+	tr,
+	img {
+		page-break-inside: avoid;
+	}
+
+	img {
+		max-width: 100% !important;
+	}
+
+	p,
+	h2,
+	h3 {
+		orphans: 3;
+		widows: 3;
+	}
+
+	h2,
+	h3 {
+		page-break-after: avoid;
+	}
+
+	.hidden-print {
+		display: none !important;
+	}
+
+	article .entry-title a[href]:after,
+	article .metadata a[href]:after,
+	article .tags a[href]:after {
+		content: "";
+	}
+
+	article .metadata .sourceline {
+		display: none;
+	}
+
+	article .metadata .linkline a[href]:after {
+		content: " (" attr(href) ")";
+	}
+
+	#header {
+		display: none;
+	}
+
+	.postpromonav {
+		padding: 0;
+	}
+}

--- a/nikola/data/themes/base/templates/post.tmpl
+++ b/nikola/data/themes/base/templates/post.tmpl
@@ -40,7 +40,7 @@
     </nav>
     </aside>
     % if not post.meta('nocomments') and site_has_comments:
-        <section class="comments">
+        <section class="comments hidden-print">
         <h2>${messages("Comments")}</h2>
         ${comments.comment_form(post.permalink(absolute=True), post.title(), post._base_path)}
         </section>

--- a/nikola/data/themes/base/templates/post_header.tmpl
+++ b/nikola/data/themes/base/templates/post_header.tmpl
@@ -38,7 +38,7 @@
             % endif
             ${html_sourcelink()}
             % if post.meta('link'):
-                    <p><a href='${post.meta('link')}'>${messages("Original site")}</a></p>
+                    <p class="linkline"><a href='${post.meta('link')}'>${messages("Original site")}</a></p>
             % endif
             %if post.description():
                 <meta name="description" itemprop="description" content="${post.description()}">

--- a/nikola/data/themes/base/templates/post_helper.tmpl
+++ b/nikola/data/themes/base/templates/post_helper.tmpl
@@ -24,7 +24,7 @@
 
 <%def name="html_pager(post)">
     %if post.prev_post or post.next_post:
-        <ul class="pager">
+        <ul class="pager hidden-print">
         %if post.prev_post:
             <li class="previous">
                 <a href="${post.prev_post.permalink()}" rel="prev" title="${post.prev_post.title()|h}">${messages("Previous post")}</a>

--- a/nikola/data/themes/bootstrap-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap-jinja/assets/css/theme.css
@@ -174,3 +174,24 @@ article.post-micro {
     overflow: visible;
     clip: auto;
 }
+
+/* hat tip bootstrap/html5 boilerplate */
+@media print {
+    article .entry-title a[href]:after,
+    article .metadata a[href]:after,
+    article .tags a[href]:after {
+        content: "";
+    }
+
+    article .metadata .sourceline {
+        display: none;
+    }
+
+    article .metadata .linkline a[href]:after {
+        content: " (" attr(href) ")";
+    }
+
+    .navbar {
+        display: none;
+    }
+}

--- a/nikola/data/themes/bootstrap-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap-jinja/assets/css/theme.css
@@ -178,7 +178,7 @@ article.post-micro {
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
     *, *:before, *:after {
-        font-family: Junicode, Garamond, serif;
+        font-family: Garamond, Junicode, serif;
     }
 
     article .entry-title a[href]:after,

--- a/nikola/data/themes/bootstrap-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap-jinja/assets/css/theme.css
@@ -181,6 +181,10 @@ article.post-micro {
         font-family: Garamond, Junicode, serif;
     }
 
+    body {
+        font-size: 12pt;
+    }
+
     article .entry-title a[href]:after,
     article .metadata a[href]:after,
     article .tags a[href]:after {

--- a/nikola/data/themes/bootstrap-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap-jinja/assets/css/theme.css
@@ -177,6 +177,10 @@ article.post-micro {
 
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
+    *, *:before, *:after {
+        font-family: Junicode, Garamond, serif;
+    }
+
     article .entry-title a[href]:after,
     article .metadata a[href]:after,
     article .tags a[href]:after {

--- a/nikola/data/themes/bootstrap-jinja/templates/post.tmpl
+++ b/nikola/data/themes/bootstrap-jinja/templates/post.tmpl
@@ -40,7 +40,7 @@
     </nav>
     </aside>
     {% if not post.meta('nocomments') and site_has_comments %}
-        <section class="comments">
+        <section class="comments hidden-print">
         <h2>{{ messages("Comments") }}</h2>
         {{ comments.comment_form(post.permalink(absolute=True), post.title(), post._base_path) }}
         </section>

--- a/nikola/data/themes/bootstrap/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap/assets/css/theme.css
@@ -174,3 +174,24 @@ article.post-micro {
     overflow: visible;
     clip: auto;
 }
+
+/* hat tip bootstrap/html5 boilerplate */
+@media print {
+    article .entry-title a[href]:after,
+    article .metadata a[href]:after,
+    article .tags a[href]:after {
+        content: "";
+    }
+
+    article .metadata .sourceline {
+        display: none;
+    }
+
+    article .metadata .linkline a[href]:after {
+        content: " (" attr(href) ")";
+    }
+
+    .navbar {
+        display: none;
+    }
+}

--- a/nikola/data/themes/bootstrap/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap/assets/css/theme.css
@@ -178,7 +178,7 @@ article.post-micro {
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
     *, *:before, *:after {
-        font-family: Junicode, Garamond, serif;
+        font-family: Garamond, Junicode, serif;
     }
 
     article .entry-title a[href]:after,

--- a/nikola/data/themes/bootstrap/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap/assets/css/theme.css
@@ -181,6 +181,10 @@ article.post-micro {
         font-family: Garamond, Junicode, serif;
     }
 
+    body {
+        font-size: 12pt;
+    }
+
     article .entry-title a[href]:after,
     article .metadata a[href]:after,
     article .tags a[href]:after {

--- a/nikola/data/themes/bootstrap/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap/assets/css/theme.css
@@ -177,6 +177,10 @@ article.post-micro {
 
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
+    *, *:before, *:after {
+        font-family: Junicode, Garamond, serif;
+    }
+
     article .entry-title a[href]:after,
     article .metadata a[href]:after,
     article .tags a[href]:after {

--- a/nikola/data/themes/bootstrap/templates/post.tmpl
+++ b/nikola/data/themes/bootstrap/templates/post.tmpl
@@ -40,7 +40,7 @@
     </nav>
     </aside>
     % if not post.meta('nocomments') and site_has_comments:
-        <section class="comments">
+        <section class="comments hidden-print">
         <h2>${messages("Comments")}</h2>
         ${comments.comment_form(post.permalink(absolute=True), post.title(), post._base_path)}
         </section>

--- a/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
@@ -179,7 +179,7 @@ article.post-micro {
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
     *, *:before, *:after {
-        font-family: Junicode, Garamond, serif;
+        font-family: Garamond, Junicode, serif;
     }
 
     article .entry-title a[href]:after,

--- a/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
@@ -178,6 +178,10 @@ article.post-micro {
 
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
+    *, *:before, *:after {
+        font-family: Junicode, Garamond, serif;
+    }
+
     article .entry-title a[href]:after,
     article .metadata a[href]:after,
     article .tags a[href]:after {

--- a/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
@@ -182,6 +182,10 @@ article.post-micro {
         font-family: Garamond, Junicode, serif;
     }
 
+    body {
+        font-size: 12pt;
+    }
+
     article .entry-title a[href]:after,
     article .metadata a[href]:after,
     article .tags a[href]:after {

--- a/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
@@ -175,3 +175,24 @@ article.post-micro {
 .entry-summary {
   margin-top: 1em;
 }
+
+/* hat tip bootstrap/html5 boilerplate */
+@media print {
+    article .entry-title a[href]:after,
+    article .metadata a[href]:after,
+    article .tags a[href]:after {
+        content: "";
+    }
+
+    article .metadata .sourceline {
+        display: none;
+    }
+
+    article .metadata .linkline a[href]:after {
+        content: " (" attr(href) ")";
+    }
+
+    .navbar {
+        display: none;
+    }
+}

--- a/nikola/data/themes/bootstrap3/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3/assets/css/theme.css
@@ -179,7 +179,7 @@ article.post-micro {
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
     *, *:before, *:after {
-        font-family: Junicode, Garamond, serif;
+        font-family: Garamond, Junicode, serif;
     }
 
     article .entry-title a[href]:after,

--- a/nikola/data/themes/bootstrap3/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3/assets/css/theme.css
@@ -178,6 +178,10 @@ article.post-micro {
 
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
+    *, *:before, *:after {
+        font-family: Junicode, Garamond, serif;
+    }
+
     article .entry-title a[href]:after,
     article .metadata a[href]:after,
     article .tags a[href]:after {

--- a/nikola/data/themes/bootstrap3/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3/assets/css/theme.css
@@ -182,6 +182,10 @@ article.post-micro {
         font-family: Garamond, Junicode, serif;
     }
 
+    body {
+        font-size: 12pt;
+    }
+
     article .entry-title a[href]:after,
     article .metadata a[href]:after,
     article .tags a[href]:after {

--- a/nikola/data/themes/bootstrap3/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3/assets/css/theme.css
@@ -175,3 +175,24 @@ article.post-micro {
 .entry-summary {
   margin-top: 1em;
 }
+
+/* hat tip bootstrap/html5 boilerplate */
+@media print {
+    article .entry-title a[href]:after,
+    article .metadata a[href]:after,
+    article .tags a[href]:after {
+        content: "";
+    }
+
+    article .metadata .sourceline {
+        display: none;
+    }
+
+    article .metadata .linkline a[href]:after {
+        content: " (" attr(href) ")";
+    }
+
+    .navbar {
+        display: none;
+    }
+}


### PR DESCRIPTION
# Bootstrap & Bootstrap 3 [v2]

* Post pages look well, meta lines have (mostly) hidden URLs and the Source link is hidden altogether; comments are hidden
* ~~Helvetica is used, which may or may not be a good idea~~ v2: Switched to Garamond with fallback to Junicode
* The only thing that is missing is the blog title, which may or may not be necessary, and that would have to be added in a different way (we would have to put a special print-only title outside of navbar).
* Any comments?

![image](https://cloud.githubusercontent.com/assets/327323/8144450/d951d96e-11df-11e5-88df-5981a1d6d82b.png)

# Base [v1]

* Very similar to Bootstrap’s, uses the same HTML 5 Boilerplate styles as base
* Blog title can be added easily, but was skipped for consistency

![image](https://cloud.githubusercontent.com/assets/327323/8144463/4712d318-11e0-11e5-97c9-9dbccddd08c4.png)
