### PR TITLE
Add footer styling to bootstrap3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Add distinct styling for the site footer in bootstrap3
 * Bootstrap v3.3.5 (Issue #1828)
 * Use ``watchdog`` in ``nikola auto`` (Issue #1810)
 * Add redirection for tags in Wordpress importer (Issue #1168)

--- a/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3-jinja/assets/css/theme.css
@@ -173,5 +173,12 @@ article.post-micro {
 
 /* for alignment with Bootstrap's .entry-content styling */
 .entry-summary {
-  margin-top: 1em;
+    margin-top: 1em;
+}
+
+/* Custom page footer */
+#footer {
+    padding-top: 19px;
+    color: #777;
+    border-top: 1px solid #e5e5e5;
 }

--- a/nikola/data/themes/bootstrap3-jinja/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/base.tmpl
@@ -67,7 +67,7 @@
         </div>
         <!--End of body content-->
 
-        <footer>
+        <footer id="footer">
             {{ content_footer }}
             {{ template_hooks['page_footer']() }}
         </footer>

--- a/nikola/data/themes/bootstrap3/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3/assets/css/theme.css
@@ -173,5 +173,12 @@ article.post-micro {
 
 /* for alignment with Bootstrap's .entry-content styling */
 .entry-summary {
-  margin-top: 1em;
+    margin-top: 1em;
+}
+
+/* Custom page footer */
+#footer {
+    padding-top: 19px;
+    color: #777;
+    border-top: 1px solid #e5e5e5;
 }

--- a/nikola/data/themes/bootstrap3/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base.tmpl
@@ -67,7 +67,7 @@ ${template_hooks['extra_head']()}
         </div>
         <!--End of body content-->
 
-        <footer>
+        <footer id="footer">
             ${content_footer}
             ${template_hooks['page_footer']()}
         </footer>


### PR DESCRIPTION
It used to look like yet another paragraph of actual content; now it has a rule separating from the rest (that extends to the end of the container, obviously) a padding and is grey.

CSS stolen from: http://getbootstrap.com/examples/jumbotron-narrow/

### Before

![Before](https://cloud.githubusercontent.com/assets/327323/8266506/082d540a-1732-11e5-9541-0057d5007500.png)

### After

![After](https://cloud.githubusercontent.com/assets/327323/8266510/17f31b36-1732-11e5-8b68-2671a9dcba27.png)
