### PR TITLE
Fix #1837 -- nikola new_post --available-compilers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Add ``-F``, ``--available-compilers`` option to ``nikola new_post``
+  and ``nikola new_page`` (Issue #1837)
 * Add print CSS to all default themes (Issue #1817)
 * Support other kernels for ipynb/Jupyter using
   ``nikola new_post -f ipynb@kernel`` (Issues #1774, #1834)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -710,6 +710,11 @@ class Nikola(object):
         self._activate_plugins_of_category("LateTask")
         self._activate_plugins_of_category("TaskMultiplier")
 
+        # Store raw compilers for internal use (need a copy for that)
+        self.config['_COMPILERS_RAW'] = {}
+        for k, v in self.config['COMPILERS'].items():
+            self.config['_COMPILERS_RAW'][k] = list(v)
+
         compilers = defaultdict(set)
         # Also add aliases for combinations with TRANSLATIONS_PATTERN
         for compiler, exts in self.config['COMPILERS'].items():

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -231,7 +231,8 @@ class TaskMultiplier(BasePlugin):
 class PageCompiler(BasePlugin):
     """Plugins that compile text files into HTML."""
 
-    name = "dummy compiler"
+    name = "dummy_compiler"
+    friendly_name = ''
     demote_headers = False
     supports_onefile = True
     default_metadata = {

--- a/nikola/plugins/command/new_page.py
+++ b/nikola/plugins/command/new_page.py
@@ -79,8 +79,15 @@ class CommandNewPage(Command):
             'long': 'format',
             'type': str,
             'default': '',
-            'help': 'Markup format for the page, one of rest, markdown, wiki, '
-                    'bbcode, html, textile, txt2tags',
+            'help': 'Markup format for the page (use --available-formats for list)',
+        },
+        {
+            'name': 'available-formats',
+            'short': 'F',
+            'long': 'available-formats',
+            'type': bool,
+            'default': False,
+            'help': 'List all available input formats'
         },
         {
             'name': 'import',
@@ -94,6 +101,7 @@ class CommandNewPage(Command):
 
     def _execute(self, options, args):
         """Create a new page."""
+        # Defaults for some values that don’t apply to pages and the is_page option (duh!)
         options['tags'] = ''
         options['schedule'] = False
         options['is_page'] = True

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -118,8 +118,8 @@ def print_compilers(compilers_raw, post_pages, compiler_objs):
 
     print("Available input formats:\n")
 
-    name_width = max([len(i[0]) for i in parsed_list] + [4]) # 4 == len('NAME')
-    fname_width = max([len(i[1]) for i in parsed_list] + [11]) # 11 == len('DESCRIPTION')
+    name_width = max([len(i[0]) for i in parsed_list] + [4])  # 4 == len('NAME')
+    fname_width = max([len(i[1]) for i in parsed_list] + [11])  # 11 == len('DESCRIPTION')
 
     print((' {0:<' + str(name_width) + '}  {1:<' + str(fname_width) + '}  EXTENSIONS\n').format('NAME', 'DESCRIPTION'))
 

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -43,11 +43,11 @@ POSTLOGGER = utils.get_logger('new_post', utils.STDERR_HANDLER)
 PAGELOGGER = utils.get_logger('new_page', utils.STDERR_HANDLER)
 LOGGER = POSTLOGGER
 
+
 def filter_post_pages(compiler, is_post, compilers, post_pages, compiler_names, compilers_raw=None):
     """Given a compiler ("markdown", "rest"), and whether it's meant for
     a post or a page, and compilers, return the correct entry from
     post_pages."""
-
 
     # compilers_raw is used only for passing to print_compilers, but we can fill
     # in the old version ifneeded
@@ -141,6 +141,7 @@ Compilers marked with ! and ~ require additional configuration:
     ! not in the PAGES/POSTS tuples (unused)
     ~ not in the COMPILERS dict (disabled)
 Read more: {0}""".format(COMPILERS_DOC_LINK))
+
 
 def get_default_compiler(is_post, compilers, post_pages):
     """Given compilers and post_pages, return a reasonable

--- a/nikola/plugins/compile/html.py
+++ b/nikola/plugins/compile/html.py
@@ -38,6 +38,7 @@ from nikola.utils import makedirs, write_metadata
 class CompileHtml(PageCompiler):
     """Compile HTML into HTML."""
     name = "html"
+    friendly_name = "HTML"
 
     def compile_html(self, source, dest, is_two_file=True):
         makedirs(os.path.dirname(dest))

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -56,6 +56,7 @@ class CompileIPynb(PageCompiler):
     """Compile IPynb into HTML."""
 
     name = "ipynb"
+    friendly_name = "Jupyter/IPython Notebook"
     demote_headers = True
     default_kernel = 'python2' if sys.version_info[0] == 2 else 'python3'
 

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -44,9 +44,10 @@ from nikola.utils import makedirs, req_missing, write_metadata
 
 
 class CompileMarkdown(PageCompiler):
-    """Compile markdown into HTML."""
+    """Compile Markdown into HTML."""
 
     name = "markdown"
+    friendly_name = "Markdown"
     demote_headers = True
     extensions = []
     site = None

--- a/nikola/plugins/compile/pandoc.py
+++ b/nikola/plugins/compile/pandoc.py
@@ -44,6 +44,7 @@ class CompilePandoc(PageCompiler):
     """Compile markups into HTML using pandoc."""
 
     name = "pandoc"
+    friendly_name = "pandoc"
 
     def set_site(self, site):
         self.config_dependencies = [str(site.config['PANDOC_OPTIONS'])]

--- a/nikola/plugins/compile/php.py
+++ b/nikola/plugins/compile/php.py
@@ -40,6 +40,7 @@ class CompilePhp(PageCompiler):
     """Compile PHP into PHP."""
 
     name = "php"
+    friendly_name = "PHP"
 
     def compile_html(self, source, dest, is_two_file=True):
         makedirs(os.path.dirname(dest))

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -40,9 +40,10 @@ from nikola.utils import unicode_str, get_logger, makedirs, write_metadata
 
 
 class CompileRest(PageCompiler):
-    """Compile reSt into HTML."""
+    """Compile reStructuredText into HTML."""
 
     name = "rest"
+    friendly_name = "reStructuredText"
     demote_headers = True
     logger = None
 


### PR DESCRIPTION
This is #1837.

Also accessible as -F, and in nikola new_page.

Sample output (from my own blog):

```
$ nikola new_post --available-compilers
Available input formats:

 NAME      EXTENSIONS

 html      .html, .htm
 rest      .txt, .rst
!ipynb     .ipynb
!markdown  .md, .mdown, .markdown
~pandoc    (disabled: not in COMPILERS)
~php       (disabled: not in COMPILERS)

More compilers are available in the Plugins Index.

Compilers marked with ! and ~ require additional configuration:
    ! not in the PAGES/POSTS tuples (unused)
    ~ not in the COMPILERS dict (disabled)
Read more: https://getnikola.com/handbook.html#configuring-other-input-formats
```

(there is no “friendly name” field, cannot do that)

Signed-off-by: Chris Warrick <kwpolska@gmail.com>