### PR TITLE
Fixing little things in WordPress importer (WIP)

### DIFF
--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -550,7 +550,7 @@ def get_text_tag(tag, name, default):
     if tag is None:
         return default
     t = tag.find(name)
-    if t is not None:
+    if t is not None and t.text is not None:
         return t.text
     else:
         return default

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -184,7 +184,11 @@ class CommandImportWordpress(Command, ImportMixin):
 
         # Add tag redirects
         for tag in self.all_tags:
-            tag = tag.decode('utf8')
+            # In python 2, path is a str. slug requires a unicode
+            # object. According to wikipedia, unquoted strings will
+            # usually be UTF8
+            tag_str = tag.decode('utf8') if isinstance(tag, utils.bytes_str) else tag
+            tag = utils.slugify(tag_str)
             src_url = '{}tag/{}'.format(self.context['SITE_URL'], tag)
             dst_url = self.site.link('tag', tag)
             if src_url != dst_url:

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -184,10 +184,10 @@ class CommandImportWordpress(Command, ImportMixin):
 
         # Add tag redirects
         for tag in self.all_tags:
-            # In python 2, path is a str. slug requires a unicode
-            # object. According to wikipedia, unquoted strings will
-            # usually be UTF8
-            tag_str = tag.decode('utf8') if isinstance(tag, utils.bytes_str) else tag
+            try:
+                tag_str = tag.decode('utf8')
+            except AttributeError:
+                tag_str = tag
             tag = utils.slugify(tag_str)
             src_url = '{}tag/{}'.format(self.context['SITE_URL'], tag)
             dst_url = self.site.link('tag', tag)
@@ -420,11 +420,10 @@ class CommandImportWordpress(Command, ImportMixin):
         parsed = urlparse(link)
         path = unquote(parsed.path.strip('/'))
 
-        # In python 2, path is a str. slug requires a unicode
-        # object. According to wikipedia, unquoted strings will
-        # usually be UTF8
-        if isinstance(path, utils.bytes_str):
+        try:
             path = path.decode('utf8')
+        except AttributeError:
+            pass
 
         # Cut out the base directory.
         if path.startswith(self.base_dir.strip('/')):

--- a/tests/test_command_import_wordpress.py
+++ b/tests/test_command_import_wordpress.py
@@ -218,7 +218,7 @@ class CommandImportWordpressTest(BasicCommandImportWordpress):
         self.assertTrue(write_metadata.called)
         write_metadata.assert_any_call(
             'new_site/stories/kontakt.meta'.replace('/', os.sep), 'Kontakt',
-            'kontakt', '2009-07-16 20:20:32', None, [])
+            'kontakt', '2009-07-16 20:20:32', '', [])
 
         self.assertTrue(write_content.called)
         write_content.assert_any_call('new_site/posts/2007/04/hoert.wp'.replace('/', os.sep),


### PR DESCRIPTION
When importing a WordPress blog whose blog description was not set, I got `null` inserted into `conf.py` instead of `"PUT DESCRIPTION HERE"`, which caused `nikola build` to fail. This is fixed in 5781644609e3aac850c41d4e71a08220934bb52d.

Then, there are two more problems with the WordPress importer which make it fail for me; see comments here: https://github.com/getnikola/nikola/commit/b6cbfcbc