### PR TITLE
Fix for #1850

### DIFF
--- a/nikola/post.py
+++ b/nikola/post.py
@@ -102,7 +102,7 @@ class Post(object):
         if self.config['FUTURE_IS_NOW']:
             self.current_time = None
         else:
-            self.current_time = current_time()
+            self.current_time = current_time(tzinfo)
         self.translated_to = set([])
         self._prev_post = None
         self._next_post = None


### PR DESCRIPTION
Fix for problem where posts may be tagged as being in the future when due to time zone configuration not being used and the fallback not working

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/getnikola/nikola/1858)
<!-- Reviewable:end -->
