### PR TITLE
Fix #1856 -- make tag listing pages per-language

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 source = nikola
-omit = /tmp/*, _*, nikola/packages, nikola/data, nikola/winutils
+omit = /tmp/*, _*, nikola/packages*, nikola/data*, nikola/winutils*
 [report]
 exclude_lines =
     pragma: no cover

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 source = nikola
-omit = /tmp/*, _*
+omit = /tmp/*, _*, nikola/packages, nikola/data, nikola/winutils
 [report]
 exclude_lines =
     pragma: no cover

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Features
 Bugfixes
 --------
 
+* Show tags only from the current language on tag listing pages (Issue #1856)
 * Remove gap between line numbers and code (Issue #1859)
 * Fix spurious warnings about posts published in the future (Issue #1850)
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -273,6 +273,7 @@ class Nikola(object):
         self.posts_per_month = defaultdict(list)
         self.posts_per_tag = defaultdict(list)
         self.posts_per_category = defaultdict(list)
+        self.tags_per_language = defaultdict(list)
         self.post_per_file = {}
         self.timeline = []
         self.pages = []
@@ -1440,6 +1441,7 @@ class Nikola(object):
         self.posts_per_month = defaultdict(list)
         self.posts_per_tag = defaultdict(list)
         self.posts_per_category = defaultdict(list)
+        self.tags_per_language = defaultdict(list)
         self.category_hierarchy = {}
         self.post_per_file = {}
         self.timeline = []
@@ -1472,6 +1474,8 @@ class Nikola(object):
                     else:
                         slugged_tags.add(utils.slugify(tag, force=True))
                     self.posts_per_tag[tag].append(post)
+                for lang in post.translated_to:
+                    self.tags_per_language[lang].extend(post.tags_for_language(lang))
                 self._add_post_to_category(post, post.meta('category'))
 
             if post.is_post:
@@ -1497,6 +1501,8 @@ class Nikola(object):
                     quit = True
                 self.post_per_file[dest] = post
                 self.post_per_file[src_dest] = post
+                # deduplicate tags_per_language
+                self.tags_per_language[lang] = list(set(self.tags_per_language[lang]))
 
         # Sort everything.
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1474,7 +1474,7 @@ class Nikola(object):
                     else:
                         slugged_tags.add(utils.slugify(tag, force=True))
                     self.posts_per_tag[tag].append(post)
-                for lang in post.translated_to:
+                for lang in self.config['TRANSLATIONS'].keys():
                     self.tags_per_language[lang].extend(post.tags_for_language(lang))
                 self._add_post_to_category(post, post.meta('category'))
 

--- a/nikola/plugins/compile/markdown/mdx_gist.py
+++ b/nikola/plugins/compile/markdown/mdx_gist.py
@@ -304,7 +304,7 @@ class GistExtension(MarkdownExtension, Extension):
         md.registerExtension(self)
 
 
-def makeExtension(configs=None):
+def makeExtension(configs=None):  # pragma: no cover
     return GistExtension(configs)
 
 if __name__ == '__main__':

--- a/nikola/plugins/compile/markdown/mdx_nikola.py
+++ b/nikola/plugins/compile/markdown/mdx_nikola.py
@@ -58,5 +58,5 @@ class NikolaExtension(MarkdownExtension, Extension):
         md.registerExtension(self)
 
 
-def makeExtension(configs=None):
+def makeExtension(configs=None):  # pragma: no cover
     return NikolaExtension(configs)

--- a/nikola/plugins/compile/markdown/mdx_podcast.py
+++ b/nikola/plugins/compile/markdown/mdx_podcast.py
@@ -84,7 +84,7 @@ class PodcastExtension(MarkdownExtension, Extension):
         md.registerExtension(self)
 
 
-def makeExtension(configs=None):
+def makeExtension(configs=None):  # pragma: no cover
     return PodcastExtension(configs)
 
 if __name__ == '__main__':

--- a/nikola/plugins/compile/rest/slides.py
+++ b/nikola/plugins/compile/rest/slides.py
@@ -50,7 +50,7 @@ class Slides(Directive):
     has_content = True
 
     def run(self):
-        if len(self.content) == 0:
+        if len(self.content) == 0:  # pragma: no cover
             return
 
         if self.site.invariant:  # for testing purposes

--- a/nikola/plugins/compile/rest/soundcloud.py
+++ b/nikola/plugins/compile/rest/soundcloud.py
@@ -57,7 +57,7 @@ class SoundCloud(Directive):
 
     def check_content(self):
         """ Emit a deprecation warning if there is content """
-        if self.content:
+        if self.content:  # pragma: no cover
             raise self.warning("This directive does not accept content. The "
                                "'key=value' format for options is deprecated, "
                                "use ':key: value' instead")

--- a/nikola/plugins/compile/rest/youtube.py
+++ b/nikola/plugins/compile/rest/youtube.py
@@ -75,7 +75,7 @@ class Youtube(Directive):
         return [nodes.raw('', CODE.format(**options), format='html')]
 
     def check_content(self):
-        if self.content:
+        if self.content:  # pragma: no cover
             raise self.warning("This directive does not accept content. The "
                                "'key=value' format for options is deprecated, "
                                "use ':key: value' instead")

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -179,19 +179,19 @@ class RenderTags(Task):
 
     def _create_tags_page(self, kw, include_tags=True, include_categories=True):
         """a global "all your tags/categories" page for each language"""
-        tags = natsort.natsorted([tag for tag in self.site.posts_per_tag.keys()
-                                  if len(self.site.posts_per_tag[tag]) >= kw["taglist_minimum_post_count"]],
-                                 alg=natsort.ns.F | natsort.ns.IC)
         categories = [cat.category_name for cat in self.site.category_hierarchy]
-        has_tags = (tags != []) and include_tags
         has_categories = (categories != []) and include_categories
         template_name = "tags.tmpl"
         kw = kw.copy()
-        if include_tags:
-            kw['tags'] = tags
         if include_categories:
             kw['categories'] = categories
         for lang in kw["translations"]:
+            tags = natsort.natsorted([tag for tag in self.site.tags_per_language[lang]
+                                    if len(self.site.posts_per_tag[tag]) >= kw["taglist_minimum_post_count"]],
+                                    alg=natsort.ns.F | natsort.ns.IC)
+            has_tags = (tags != []) and include_tags
+            if include_tags:
+                kw['tags'] = tags
             output_name = os.path.join(
                 kw['output_folder'], self.site.path('tag_index' if has_tags else 'category_index', None, lang))
             output_name = output_name

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -187,8 +187,8 @@ class RenderTags(Task):
             kw['categories'] = categories
         for lang in kw["translations"]:
             tags = natsort.natsorted([tag for tag in self.site.tags_per_language[lang]
-                                    if len(self.site.posts_per_tag[tag]) >= kw["taglist_minimum_post_count"]],
-                                    alg=natsort.ns.F | natsort.ns.IC)
+                                      if len(self.site.posts_per_tag[tag]) >= kw["taglist_minimum_post_count"]],
+                                     alg=natsort.ns.F | natsort.ns.IC)
             has_tags = (tags != []) and include_tags
             if include_tags:
                 kw['tags'] = tags

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -261,15 +261,18 @@ class Post(object):
             tags.extend(self._tags[l])
         return list(set(tags))
 
-    @property
-    def tags(self):
-        lang = nikola.utils.LocaleBorg().current_lang
+    def tags_for_language(self, lang):
         if lang in self._tags:
             return self._tags[lang]
         elif self.default_lang in self._tags:
             return self._tags[self.default_lang]
         else:
             return []
+
+    @property
+    def tags(self):
+        lang = nikola.utils.LocaleBorg().current_lang
+        return self.tags_for_language(lang)
 
     @property
     def prev_post(self):

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -264,6 +264,8 @@ class Post(object):
     def tags_for_language(self, lang):
         if lang in self._tags:
             return self._tags[lang]
+        elif lang not in self.translated_to and self.skip_untranslated:
+            return []
         elif self.default_lang in self._tags:
             return self._tags[self.default_lang]
         else:


### PR DESCRIPTION
This change will display only tags that exist in this language’s posts, honoring `SHOW_UNTRANSLATED_POSTS`.  However, the current behavior of per-tag pages is retained to help people who jump between languages by changing URLs.

cc @tekNico

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/getnikola/nikola/1861)
<!-- Reviewable:end -->
