### PR TITLE
Extending and refactoring WordPress importer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,21 @@ New in master
 Features
 --------
 
+* Several improvements to WordPress importer (PR #1867):
+  * Allowing to export categories and category hierarchy with
+    --export-categories-as-categories
+  * Allowing to exclude private posts, and allowing to include empty posts
+  * Allowing to use HTTP authentication for downloads with --download-auth
+    (PR #1848)
+  * Allowing to export comments with --export-comments
+  * Allowing to use WordPress page compiler to directly convert posts
+    to HTML on import with --transform-to-html
+  * Allowing to use WordPress page compiler on imported site instead of
+    converting posts to markdown with --use-wordpress-compiler
+  * Allowing to automatically install the WordPress page compiler when
+    needed with --install-wordpress-compiler
+  * Exporting information on attachments per post as JSON
+  * Exporting post status and excerpt
 * New ‘pagekind’ variable available to identify different kind of pages from theme templates
 * Add ``--no-server`` option to ``nikola auto`` (Issue #1883)
 * Always return unicode in slugify (Issue #1885)

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1908,15 +1908,47 @@ the following:
 
   This is also useful for DISQUS thread migration!
 
-* Will try to convert the content of your posts. This is *not* error free, because
-  WordPress uses some unholy mix of HTML and strange things. Currently we are treating it
-  as markdown, which does a reasonable job of it.
+* Allows you to export your comments with each post
+* Exports information on attachments per post
+* There are different methods to transfer the content of your posts:
 
-  You will find your old posts in ``new_site/posts/post-title.wp`` in case you need to fix
-  any of them.
+  - You can convert them to HTML with the WordPress page compiler plugin
+    for Nikola. This will format the posts including supported shortcodes
+    the same way as WordPress does. Use the ``--transform-to-html`` option
+    to convert your posts to HTML.
+
+    If you use this option, you do not need to install the plugin
+    permanently. You can ask Nikola to install the plugin into the subdirectory
+    ``plugins`` of the current working directory by specifying
+    the ``--install-wordpress-compiler`` option.
+
+  - You can leave the posts the way they are and use the WordPress page
+    compiler plugin to render them when building your new blog. This also
+    allows you to create new posts using the WordPress syntax, or to manually
+    add more shortcode plugins later. Use the ``--use-wordpress-compiler``
+    option to not touch your posts.
+
+    If you want to use this option, you have to install the plugin permanently.
+    You can ask Nikola to install the plugin into your new site by specifying
+    the ``--install-wordpress-compiler`` option.
+
+  - You can let Nikola convert your posts to Markdown. This is *not* error
+    free, because WordPress uses some unholy mix of HTML and strange things.
+    This is the default option and requires no plugins.
+
+  You will find your old posts in ``new_site/posts/post-title.html`` in the first case,
+  ``new_site/posts/post-title.wp`` in the second case or ``new_site/posts/post-title.md``
+  in the last case if you need to edit or fix any of them.
+
+  Please note that the page compiler currently only supports the ``[code]`` shortcode,
+  but other shortcodes can be supported via plugins.
+
+  Also note that the WordPress page compiler is licensed under GPL v2 since
+  it uses code from WordPress itself, while Nikola is licensed under the more
+  liberal MIT license.
 
 This feature is a work in progress, and the only way to improve it is to have it used for
-as many sites as possible and make it work better each time, so I am happy to get requests
+as many sites as possible and make it work better each time, so we are happy to get requests
 about it.
 
 .. [#] The dump needs to be in 1.2 format. You can check by reading it, it should say

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -255,10 +255,10 @@ HIDDEN_TAGS = ['mathjax']
 # using a forward slash ('/') to separate paths. Use a backslash ('\') to escape
 # a forward slash or a backslash (i.e. '\//\\' is a path specifying the
 # subcategory called '\' of the top-level category called '/').
-# CATEGORY_ALLOW_HIERARCHIES = False
+CATEGORY_ALLOW_HIERARCHIES = ${CATEGORY_ALLOW_HIERARCHIES}
 # If CATEGORY_OUTPUT_FLAT_HIERARCHY is set to True, the output written to output
 # contains only the name of the leaf category and not the whole path.
-# CATEGORY_OUTPUT_FLAT_HIERARCHY = False
+CATEGORY_OUTPUT_FLAT_HIERARCHY = ${CATEGORY_OUTPUT_FLAT_HIERARCHY}
 
 # If CATEGORY_PAGES_ARE_INDEXES is set to True, each category's page will contain
 # the posts themselves. If set to False, it will be just a list of links.

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -837,7 +837,7 @@ class CommandImportWordpress(Command, ImportMixin):
         if post_type == 'attachment':
             files = self.import_attachment(item, wordpress_namespace)
             # If parent was found, store relation with imported files
-            if parent_id is not None:
+            if parent_id is not None and int(parent_id) != 0:
                 self.attachments[int(parent_id)][post_id] = files
             else:
                 LOGGER.warn("Attachment #{0} ({1}) has no parent!".format(post_id, files))

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -79,6 +79,8 @@ def install_plugin(site, plugin_name, output_dir=None, show_install_notes=False)
         return False
     # Let the plugin manager find newly installed plugins
     site.plugin_manager.collectPlugins()
+    # Re-scan for compiler extensions
+    site.compiler_extensions = site._activate_plugins_of_category("CompilerExtension")
     return True
 
 

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -245,15 +245,6 @@ class CommandImportWordpress(Command, ImportMixin):
                 LOGGER.error("Please note that the WordPress post compiler is licensed under the GPL v2.")
                 return False
 
-        if self.use_wordpress_compiler:
-            if self.install_wordpress_compiler:
-                if not install_plugin(self.site, 'wordpress_compiler', output_dir=os.path.join(self.output_folder, 'plugins')):
-                    return False
-            else:
-                LOGGER.warn("Make sure to install the WordPress page compiler via")
-                LOGGER.warn("    nikola plugin -i wordpress_compiler")
-                LOGGER.warn("in your imported blog's folder ({0}), if you haven't installed it system-wide or user-wide. Otherwise, your newly imported blog won't compile.".format(self.output_folder))
-
         return True
 
     def _prepare(self, channel):
@@ -339,6 +330,15 @@ class CommandImportWordpress(Command, ImportMixin):
         rendered_template = conf_template.render(**prepare_config(self.context))
         self.write_configuration(self.get_configuration_output_path(),
                                  rendered_template)
+
+        if self.use_wordpress_compiler:
+            if self.install_wordpress_compiler:
+                if not install_plugin(self.site, 'wordpress_compiler', output_dir=os.path.join(self.output_folder, 'plugins')):
+                    return False
+            else:
+                LOGGER.warn("Make sure to install the WordPress page compiler via")
+                LOGGER.warn("    nikola plugin -i wordpress_compiler")
+                LOGGER.warn("in your imported blog's folder ({0}), if you haven't installed it system-wide or user-wide. Otherwise, your newly imported blog won't compile.".format(self.output_folder))
 
     @classmethod
     def read_xml_file(cls, filename):

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -574,8 +574,8 @@ class CommandImportWordpress(Command, ImportMixin):
                 try:
                     content, extension = self.transform_content(content, post_format)
                 except:
-                    LOGGER.error('Cannot interpret post "{0}" (language {1}) with post ' +
-                                 'format {2}!'.format(os.path.join(out_folder, slug), lang, post_format))
+                    LOGGER.error(('Cannot interpret post "{0}" (language {1}) with post ' +
+                                  'format {2}!').format(os.path.join(out_folder, slug), lang, post_format))
                     return False
                 if lang:
                     out_meta_filename = slug + '.meta'
@@ -601,8 +601,8 @@ class CommandImportWordpress(Command, ImportMixin):
                     content)
             return (out_folder, slug)
         else:
-            LOGGER.warn('Not going to import "{0}" because it seems to contain'
-                        ' no content.'.format(title))
+            LOGGER.warn(('Not going to import "{0}" because it seems to contain'
+                         ' no content.').format(title))
             return False
 
     def process_item(self, item):
@@ -649,8 +649,8 @@ class CommandImportWordpress(Command, ImportMixin):
                                            self.posts_pages[post_id][2] + ".attachments.json")
                 self.write_attachments_info(destination, self.attachments[post_id])
             else:
-                LOGGER.warn("Found attachments for post or page #{0}, but didn't find post or page. " +
-                            "(Attachments: {1})".format(post_id, [e[0] for _, e in self.attachments[post_id].items()]))
+                LOGGER.warn(("Found attachments for post or page #{0}, but didn't find post or page. " +
+                             "(Attachments: {1})").format(post_id, [e[0] for _, e in self.attachments[post_id].items()]))
 
 
 def get_text_tag(tag, name, default):

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -57,7 +57,8 @@ from nikola.plugins.command import plugin
 LOGGER = utils.get_logger('import_wordpress', utils.STDERR_HANDLER)
 
 
-def install_plugin(site, plugin_name, output_dir=None):
+def install_plugin(site, plugin_name, output_dir=None, show_install_notes=False):
+    LOGGER.notice("Installing plugin '{0}'".format(plugin_name))
     plugin_installer = plugin.CommandPlugin()
     plugin_installer.set_site(site)
     options = {}
@@ -65,6 +66,7 @@ def install_plugin(site, plugin_name, output_dir=None):
         options[option['name']] = option['default']
     options['install'] = plugin_name
     options['output_dir'] = output_dir
+    options['show_install_notes'] = show_install_notes
     if not plugin_installer.execute(options=options):
         return False
     site.plugin_manager.collectPlugins()

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -201,23 +201,6 @@ class CommandImportWordpress(Command, ImportMixin):
             for cat, path in cat_map.items():
                 self._category_paths[cat] = utils.join_hierarchical_category_path(path)
 
-    def _adjust_config_template(self, channel, rendered_template):
-        rendered_template = re.sub('# REDIRECTIONS = ', 'REDIRECTIONS = ',
-                                   rendered_template)
-
-        if self.timezone:
-            rendered_template = re.sub('# TIMEZONE = \'UTC\'',
-                                       'TIMEZONE = \'' + self.timezone + '\'',
-                                       rendered_template)
-
-        if self.export_categories_as_categories:
-            rendered_template = re.sub('(# |)CATEGORY_ALLOW_HIERARCHIES = (True|False)', 'CATEGORY_ALLOW_HIERARCHIES = True',
-                                       rendered_template)
-            rendered_template = re.sub('(# |)CATEGORY_OUTPUT_FLAT_HIERARCHY = (True|False)', 'CATEGORY_OUTPUT_FLAT_HIERARCHY = True',
-                                       rendered_template)
-
-        return rendered_template
-
     def _execute(self, options={}, args=[]):
         """Import a WordPress blog from an export file into a Nikola site."""
         if not args:
@@ -258,6 +241,11 @@ class CommandImportWordpress(Command, ImportMixin):
             self.extra_languages)
         self.context['REDIRECTIONS'] = self.configure_redirections(
             self.url_map)
+        if self.timezone:
+            self.context['TIMEZONE'] = self.timezone
+        if self.export_categories_as_categories:
+            self.context['CATEGORY_ALLOW_HIERARCHIES'] = True
+            self.context['CATEGORY_OUTPUT_FLAT_HIERARCHY'] = True
 
         # Add tag redirects
         for tag in self.all_tags:
@@ -274,7 +262,6 @@ class CommandImportWordpress(Command, ImportMixin):
         self.write_urlmap_csv(
             os.path.join(self.output_folder, 'url_map.csv'), self.url_map)
         rendered_template = conf_template.render(**prepare_config(self.context))
-        rendered_template = self._adjust_config_template(channel, rendered_template)
         self.write_configuration(self.get_configuration_output_path(),
                                  rendered_template)
 

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -180,13 +180,14 @@ class CommandImportWordpress(Command, ImportMixin):
     all_tags = set([])
 
     def _find_wordpress_compiler(self):
-        for plugin_info in self.site.plugin_manager.getPluginsOfCategory('PageCompiler'):
-            if plugin_info.name == 'wordpress':
-                if not plugin_info.is_activated:
-                    self.site.plugin_manager.activatePluginByName(plugin_info.name)
-                    plugin_info.plugin_object.set_site(self.site)
-                self.wordpress_page_compiler = plugin_info.plugin_object
-                break
+        if self.wordpress_page_compiler is not None:
+            return
+        plugin_info = self.site.plugin_manager.getPluginByName('wordpress', 'PageCompiler')
+        if plugin_info is not None:
+            if not plugin_info.is_activated:
+                self.site.plugin_manager.activatePluginByName(plugin_info.name)
+                plugin_info.plugin_object.set_site(self.site)
+            self.wordpress_page_compiler = plugin_info.plugin_object
 
     def _read_options(self, options, args):
         options['filename'] = args.pop(0)

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -623,6 +623,10 @@ class CommandImportWordpress(Command, ImportMixin):
             if out_folder_slug:
                 self.posts_pages[post_id] = (post_type, out_folder_slug[0], out_folder_slug[1])
 
+    def write_attachments_info(self, path, attachments):
+        with io.open(path, "wb") as file:
+            file.write(json.dumps(attachments).encode('utf-8'))
+
     def import_posts(self, channel):
         self.posts_pages = {}
         self.attachments = defaultdict(dict)
@@ -633,10 +637,9 @@ class CommandImportWordpress(Command, ImportMixin):
             if post_id in self.posts_pages:
                 destination = os.path.join(self.output_folder, self.posts_pages[post_id][1],
                                            self.posts_pages[post_id][2] + ".attachments.json")
-                with io.open(destination, "wb") as file:
-                    file.write(json.dumps(self.attachments[post_id]).encode('utf-8'))
+                self.write_attachments_info(destination, self.attachments[post_id])
             else:
-                LOGGER.warn("Found attachments for post or page #{0}, but didn't find find or page. (Attachments: {1})".format(post_id, [e[0] for _, e in self.attachments[post_id].items()]))
+                LOGGER.warn("Found attachments for post or page #{0}, but didn't find post or page. (Attachments: {1})".format(post_id, [e[0] for _, e in self.attachments[post_id].items()]))
 
 
 def get_text_tag(tag, name, default):

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -65,6 +65,8 @@ SAMPLE_CONF = {
     'TIMEZONE': 'UTC',
     'COMMENT_SYSTEM': 'disqus',
     'COMMENT_SYSTEM_ID': 'nikolademo',
+    'CATEGORY_ALLOW_HIERARCHIES': False,
+    'CATEGORY_OUTPUT_FLAT_HIERARCHY': False,
     'TRANSLATIONS_PATTERN': DEFAULT_TRANSLATIONS_PATTERN,
     'INDEX_READ_MORE_LINK': DEFAULT_INDEX_READ_MORE_LINK,
     'RSS_READ_MORE_LINK': DEFAULT_RSS_READ_MORE_LINK,
@@ -201,19 +203,18 @@ def format_navigation_links(additional_languages, default_lang, messages, strip_
     return u'{{\n{0}\n}}'.format('\n\n'.join(pairs))
 
 
-# In order to ensure proper escaping, all variables but the three
-# pre-formatted ones are handled by json.dumps().
+# In order to ensure proper escaping, all variables but the pre-formatted ones
+# are handled by json.dumps().
 def prepare_config(config):
     """Parse sample config with JSON."""
     p = config.copy()
-    p.update(dict((k, json.dumps(v, ensure_ascii=False)) for k, v in p.items()
-             if k not in ('POSTS', 'PAGES', 'COMPILERS', 'TRANSLATIONS', 'NAVIGATION_LINKS', '_SUPPORTED_LANGUAGES', '_SUPPORTED_COMMENT_SYSTEMS', 'INDEX_READ_MORE_LINK', 'RSS_READ_MORE_LINK', 'STRIP_INDEXES', 'PRETTY_URLS')))
+    p.update({k: json.dumps(v, ensure_ascii=False) for k, v in p.items()
+             if k not in ('POSTS', 'PAGES', 'COMPILERS', 'TRANSLATIONS', 'NAVIGATION_LINKS', '_SUPPORTED_LANGUAGES', '_SUPPORTED_COMMENT_SYSTEMS', 'INDEX_READ_MORE_LINK', 'RSS_READ_MORE_LINK')})
     # READ_MORE_LINKs require some special treatment.
     p['INDEX_READ_MORE_LINK'] = "'" + p['INDEX_READ_MORE_LINK'].replace("'", "\\'") + "'"
     p['RSS_READ_MORE_LINK'] = "'" + p['RSS_READ_MORE_LINK'].replace("'", "\\'") + "'"
-    # json would make that `true` instead of `True`
-    p['PRETTY_URLS'] = str(p['PRETTY_URLS'])
-    p['STRIP_INDEXES'] = str(p['STRIP_INDEXES'])
+    # fix booleans and None
+    p.update({k: str(v) for k, v in config.items() if isinstance(v, bool) or v is None})
     return p
 
 

--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -137,17 +137,19 @@ class CommandPlugin(Command):
             self.output_dir = os.path.expanduser('~/.nikola/plugins')
         else:
             self.output_dir = 'plugins'
+        if options.get('output_dir') is not None:
+            self.output_dir = options.get('output_dir')
 
         if list_available:
-            self.list_available(url)
+            return self.list_available(url)
         elif list_installed:
-            self.list_installed()
+            return self.list_installed()
         elif upgrade:
-            self.do_upgrade(url)
+            return self.do_upgrade(url)
         elif uninstall:
-            self.do_uninstall(uninstall)
+            return self.do_uninstall(uninstall)
         elif install:
-            self.do_install(url, install)
+            return self.do_install(url, install)
 
     def list_available(self, url):
         data = self.get_json(url)
@@ -170,6 +172,7 @@ class CommandPlugin(Command):
         plugins.sort()
         for name, path in plugins:
             print('{0} at {1}'.format(name, path))
+        return True
 
     def do_upgrade(self, url):
         LOGGER.warning('This is not very smart, it just reinstalls some plugins and hopes for the best')
@@ -198,6 +201,7 @@ class CommandPlugin(Command):
                 else:
                     path = tail
             self.do_install(url, name)
+        return True
 
     def do_install(self, url, name):
         data = self.get_json(url)

--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -119,6 +119,7 @@ class CommandPlugin(Command):
         upgrade = options.get('upgrade')
         list_available = options.get('list')
         list_installed = options.get('list_installed')
+        show_install_notes = options.get('show_install_notes', True)
         command_count = [bool(x) for x in (
             install,
             uninstall,
@@ -129,16 +130,17 @@ class CommandPlugin(Command):
             print(self.help())
             return
 
-        if not self.site.configured and not user_mode and install:
-            LOGGER.notice('No site found, assuming --user')
-            user_mode = True
-
-        if user_mode:
-            self.output_dir = os.path.expanduser('~/.nikola/plugins')
-        else:
-            self.output_dir = 'plugins'
         if options.get('output_dir') is not None:
             self.output_dir = options.get('output_dir')
+        else:
+            if not self.site.configured and not user_mode and install:
+                LOGGER.notice('No site found, assuming --user')
+                user_mode = True
+
+            if user_mode:
+                self.output_dir = os.path.expanduser('~/.nikola/plugins')
+            else:
+                self.output_dir = 'plugins'
 
         if list_available:
             return self.list_available(url)
@@ -149,7 +151,7 @@ class CommandPlugin(Command):
         elif uninstall:
             return self.do_uninstall(uninstall)
         elif install:
-            return self.do_install(url, install)
+            return self.do_install(url, install, show_install_notes)
 
     def list_available(self, url):
         data = self.get_json(url)
@@ -203,7 +205,7 @@ class CommandPlugin(Command):
             self.do_install(url, name)
         return True
 
-    def do_install(self, url, name):
+    def do_install(self, url, name, show_install_notes=True):
         data = self.get_json(url)
         if name in data:
             utils.makedirs(self.output_dir)
@@ -260,7 +262,7 @@ class CommandPlugin(Command):
             print('You have to install those yourself or through a package '
                   'manager.')
         confpypath = os.path.join(dest_path, 'conf.py.sample')
-        if os.path.exists(confpypath):
+        if os.path.exists(confpypath) and show_install_notes:
             LOGGER.notice('This plugin has a sample config file.  Integrate it with yours in order to make this plugin work!')
             print('Contents of the conf.py.sample file:\n')
             with io.open(confpypath, 'r', encoding='utf-8') as fh:

--- a/tests/test_command_import_wordpress.py
+++ b/tests/test_command_import_wordpress.py
@@ -172,6 +172,8 @@ class CommandImportWordpressTest(BasicCommandImportWordpress):
     def test_populate_context(self):
         channel = self.import_command.get_channel_from_file(
             self.import_filename)
+        self.import_command.transform_to_html = False
+        self.import_command.use_wordpress_compiler = False
         context = self.import_command.populate_context(channel)
 
         for required_key in ('POSTS', 'PAGES', 'COMPILERS'):
@@ -188,14 +190,16 @@ class CommandImportWordpressTest(BasicCommandImportWordpress):
     def test_importing_posts_and_attachments(self):
         channel = self.import_command.get_channel_from_file(
             self.import_filename)
-        self.import_command.context = self.import_command.populate_context(
-            channel)
         self.import_command.base_dir = ''
         self.import_command.output_folder = 'new_site'
         self.import_command.squash_newlines = True
         self.import_command.no_downloads = False
         self.import_command.export_categories_as_categories = False
         self.import_command.export_comments = False
+        self.import_command.transform_to_html = False
+        self.import_command.use_wordpress_compiler = False
+        self.import_command.context = self.import_command.populate_context(
+            channel)
 
         # Ensuring clean results
         self.import_command.url_map = {}
@@ -242,7 +246,7 @@ print sys.version
 
 The end.
 
-""")
+""", True)
 
         self.assertTrue(write_attachments_info.called)
         write_attachments_info.assert_any_call('new_site/posts/2008/07/arzt-und-pfusch-s-i-c-k.attachments.json'.replace('/', os.sep),
@@ -253,7 +257,7 @@ The end.
             'new_site/posts/2008/07/arzt-und-pfusch-s-i-c-k.md'.replace('/', os.sep),
             '''<img class="size-full wp-image-10 alignright" title="Arzt+Pfusch - S.I.C.K." src="http://some.blog/wp-content/uploads/2008/07/arzt_und_pfusch-sick-cover.png" alt="Arzt+Pfusch - S.I.C.K." width="210" height="209" />Arzt+Pfusch - S.I.C.K.Gerade bin ich \xfcber das Album <em>S.I.C.K</em> von <a title="Arzt+Pfusch" href="http://www.arztpfusch.com/" target="_blank">Arzt+Pfusch</a> gestolpert, welches Arzt+Pfusch zum Download f\xfcr lau anbieten. Das Album steht unter einer Creative Commons <a href="http://creativecommons.org/licenses/by-nc-nd/3.0/de/">BY-NC-ND</a>-Lizenz.
 
-Die Ladung <em>noisebmstupidevildustrial</em> gibts als MP3s mit <a href="http://www.archive.org/download/dmp005/dmp005_64kb_mp3.zip">64kbps</a> und <a href="http://www.archive.org/download/dmp005/dmp005_vbr_mp3.zip">VBR</a>, als Ogg Vorbis und als FLAC (letztere <a href="http://www.archive.org/details/dmp005">hier</a>). <a href="http://www.archive.org/download/dmp005/dmp005-artwork.zip">Artwork</a> und <a href="http://www.archive.org/download/dmp005/dmp005-lyrics.txt">Lyrics</a> gibts nochmal einzeln zum Download.''')
+Die Ladung <em>noisebmstupidevildustrial</em> gibts als MP3s mit <a href="http://www.archive.org/download/dmp005/dmp005_64kb_mp3.zip">64kbps</a> und <a href="http://www.archive.org/download/dmp005/dmp005_vbr_mp3.zip">VBR</a>, als Ogg Vorbis und als FLAC (letztere <a href="http://www.archive.org/details/dmp005">hier</a>). <a href="http://www.archive.org/download/dmp005/dmp005-artwork.zip">Artwork</a> und <a href="http://www.archive.org/download/dmp005/dmp005-lyrics.txt">Lyrics</a> gibts nochmal einzeln zum Download.''', True)
         write_content.assert_any_call(
             'new_site/stories/kontakt.md'.replace('/', os.sep), """<h1>Datenschutz</h1>
 
@@ -273,7 +277,7 @@ Ich erhebe und speichere automatisch in meine Server Log Files Informationen, di
 
 </ul>
 
-Diese Daten sind f\xfcr mich nicht bestimmten Personen zuordenbar. Eine Zusammenf\xfchrung dieser Daten mit anderen Datenquellen wird nicht vorgenommen, die Daten werden einzig zu statistischen Zwecken erhoben.""")
+Diese Daten sind f\xfcr mich nicht bestimmten Personen zuordenbar. Eine Zusammenf\xfchrung dieser Daten mit anderen Datenquellen wird nicht vorgenommen, die Daten werden einzig zu statistischen Zwecken erhoben.""", True)
 
         self.assertTrue(len(self.import_command.url_map) > 0)
 
@@ -314,6 +318,9 @@ Diese Daten sind f\xfcr mich nicht bestimmten Personen zuordenbar. Eine Zusammen
         transform_code = mock.MagicMock()
         transform_caption = mock.MagicMock()
         transform_newlines = mock.MagicMock()
+
+        self.import_command.transform_to_html = False
+        self.import_command.use_wordpress_compiler = False
 
         with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.transform_code', transform_code):
             with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.transform_caption', transform_caption):

--- a/tests/test_command_import_wordpress.py
+++ b/tests/test_command_import_wordpress.py
@@ -325,7 +325,7 @@ Diese Daten sind f\xfcr mich nicht bestimmten Personen zuordenbar. Eine Zusammen
         with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.transform_code', transform_code):
             with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.transform_caption', transform_caption):
                 with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.transform_multiple_newlines', transform_newlines):
-                    self.import_command.transform_content("random content", "wp")
+                    self.import_command.transform_content("random content", "wp", None)
 
         self.assertTrue(transform_code.called)
         self.assertTrue(transform_caption.called)

--- a/tests/test_command_import_wordpress.py
+++ b/tests/test_command_import_wordpress.py
@@ -201,13 +201,15 @@ class CommandImportWordpressTest(BasicCommandImportWordpress):
 
         write_metadata = mock.MagicMock()
         write_content = mock.MagicMock()
+        write_attachments_info = mock.MagicMock()
         download_mock = mock.MagicMock()
 
         with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.write_content', write_content):
             with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.write_metadata', write_metadata):
                 with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.download_url_content_to_file', download_mock):
-                    with mock.patch('nikola.plugins.command.import_wordpress.os.makedirs'):
-                        self.import_command.import_posts(channel)
+                    with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.write_attachments_info', write_attachments_info):
+                        with mock.patch('nikola.plugins.command.import_wordpress.os.makedirs'):
+                            self.import_command.import_posts(channel)
 
         self.assertTrue(download_mock.called)
         qpath = 'new_site/files/wp-content/uploads/2008/07/arzt_und_pfusch-sick-cover.png'
@@ -218,10 +220,10 @@ class CommandImportWordpressTest(BasicCommandImportWordpress):
         self.assertTrue(write_metadata.called)
         write_metadata.assert_any_call(
             'new_site/stories/kontakt.meta'.replace('/', os.sep), 'Kontakt',
-            'kontakt', '2009-07-16 20:20:32', '', [])
+            'kontakt', '2009-07-16 20:20:32', '', [], **{'wp-status': 'publish'})
 
         self.assertTrue(write_content.called)
-        write_content.assert_any_call('new_site/posts/2007/04/hoert.wp'.replace('/', os.sep),
+        write_content.assert_any_call('new_site/posts/2007/04/hoert.md'.replace('/', os.sep),
                                       """An image.
 
 <img class="size-full wp-image-16" title="caption test" src="http://some.blog/wp-content/uploads/2009/07/caption_test.jpg" alt="caption test" width="739" height="517" />
@@ -240,13 +242,18 @@ The end.
 
 """)
 
+        self.assertTrue(write_attachments_info.called)
+        write_attachments_info.assert_any_call('new_site/posts/2008/07/arzt-und-pfusch-s-i-c-k.attachments.json'.replace('/', os.sep),
+                                               {10: ['/wp-content/uploads/2008/07/arzt_und_pfusch-sick-cover.png',
+                                                     '/wp-content/uploads/2008/07/arzt_und_pfusch-sick-cover-150x150.png']})
+
         write_content.assert_any_call(
-            'new_site/posts/2008/07/arzt-und-pfusch-s-i-c-k.wp'.replace('/', os.sep),
+            'new_site/posts/2008/07/arzt-und-pfusch-s-i-c-k.md'.replace('/', os.sep),
             '''<img class="size-full wp-image-10 alignright" title="Arzt+Pfusch - S.I.C.K." src="http://some.blog/wp-content/uploads/2008/07/arzt_und_pfusch-sick-cover.png" alt="Arzt+Pfusch - S.I.C.K." width="210" height="209" />Arzt+Pfusch - S.I.C.K.Gerade bin ich \xfcber das Album <em>S.I.C.K</em> von <a title="Arzt+Pfusch" href="http://www.arztpfusch.com/" target="_blank">Arzt+Pfusch</a> gestolpert, welches Arzt+Pfusch zum Download f\xfcr lau anbieten. Das Album steht unter einer Creative Commons <a href="http://creativecommons.org/licenses/by-nc-nd/3.0/de/">BY-NC-ND</a>-Lizenz.
 
 Die Ladung <em>noisebmstupidevildustrial</em> gibts als MP3s mit <a href="http://www.archive.org/download/dmp005/dmp005_64kb_mp3.zip">64kbps</a> und <a href="http://www.archive.org/download/dmp005/dmp005_vbr_mp3.zip">VBR</a>, als Ogg Vorbis und als FLAC (letztere <a href="http://www.archive.org/details/dmp005">hier</a>). <a href="http://www.archive.org/download/dmp005/dmp005-artwork.zip">Artwork</a> und <a href="http://www.archive.org/download/dmp005/dmp005-lyrics.txt">Lyrics</a> gibts nochmal einzeln zum Download.''')
         write_content.assert_any_call(
-            'new_site/stories/kontakt.wp'.replace('/', os.sep), """<h1>Datenschutz</h1>
+            'new_site/stories/kontakt.md'.replace('/', os.sep), """<h1>Datenschutz</h1>
 
 Ich erhebe und speichere automatisch in meine Server Log Files Informationen, die dein Browser an mich \xfcbermittelt. Dies sind:
 
@@ -309,7 +316,7 @@ Diese Daten sind f\xfcr mich nicht bestimmten Personen zuordenbar. Eine Zusammen
         with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.transform_code', transform_code):
             with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.transform_caption', transform_caption):
                 with mock.patch('nikola.plugins.command.import_wordpress.CommandImportWordpress.transform_multiple_newlines', transform_newlines):
-                    self.import_command.transform_content("random content")
+                    self.import_command.transform_content("random content", "wp")
 
         self.assertTrue(transform_code.called)
         self.assertTrue(transform_caption.called)

--- a/tests/test_command_import_wordpress.py
+++ b/tests/test_command_import_wordpress.py
@@ -194,6 +194,8 @@ class CommandImportWordpressTest(BasicCommandImportWordpress):
         self.import_command.output_folder = 'new_site'
         self.import_command.squash_newlines = True
         self.import_command.no_downloads = False
+        self.import_command.export_categories_as_categories = False
+        self.import_command.export_comments = False
 
         # Ensuring clean results
         self.import_command.url_map = {}


### PR DESCRIPTION
Beginning with some refactoring and extending of the WordPress importer.
Done so far:
 * Feeding all posts together with post format through transform_content, and let it decide extension.
 * No longer using extension `.wp` for WordPress-to-markdown converted posts.
 * Exporting wp-status and excerpt (if available).
 * Allowing to exclude private items and include empty items.
 * Exporting attachment-post/page relation as JSON file.
 * Exporting categories (if there's only one per post) including category hierarchy.
 * Exporting comments.
 * Add support for WordPress page compiler plugin (both to make new site use it, or to use it to convert WordPress posts to `.html` files).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/getnikola/nikola/1867)
<!-- Reviewable:end -->
