### PR TITLE
Add -d, --detach to nikola serve

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Add ``-d``, ``--detach`` option to ``nikola serve`` (Issue #1871)
 * Use provided teaser format (``*_READ_MORE_LINK``) with custom teaser text
   (Issue #1879)
 * Delete old ``bootstrap`` theme (use ``bootstrap3`` instead)

--- a/docs/man/nikola.rst
+++ b/docs/man/nikola.rst
@@ -94,7 +94,7 @@ The most basic commands needed to get by are:
     deploy the site using the ``DEPLOY_COMMANDS`` setting
 ``nikola github_deploy```
     deploy the site to GitHub Pages
-``nikola serve [-p PORT] [-a ADDRESS] [-b|--browser] [-6|--ipv6]``
+``nikola serve [-p PORT] [-a ADDRESS] [-d|--detach] [-b|--browser] [-6|--ipv6]``
     start development web server
 ``nikola auto [-p PORT] [-a ADDRESS] [-b|--browser] [-6|--ipv6]``
     start development web server with automated rebuilds and reloads


### PR DESCRIPTION
This is a clone of `jekyll serve --detach`.  The feature will return control to your terminal immediately, letting you work on your website with the server running in the background.  This is accomplished by
forking right before the server is initialized. All log messages are discarded.

    $ nikola serve -d
    [2015-07-08T08:20:25Z] INFO: serve: Serving HTTP on 0.0.0.0 port 8000...
    [2015-07-08T08:20:25Z] INFO: serve: Detached with PID 14594. Run `kill 14594` to stop the server.

This is functionally equivalent to `nikola serve 2> /dev/null &`, but is shell-independent and easier to type.