### PR TITLE
Fix #1905

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Features
 Bugfixes
 --------
 
+* Don't auto-rebuild on changes to ".foo" or "foo~" or changes in folders.
 * Don’t get metadata from file if compiler-specific metadata exist (Issue #1904)
 * Fix PRETTY_URLS prompt for Windows (Issue #1901)
 * Fix reST and Markdown title extraction from documents (Issue #1895, #1898)

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -248,6 +248,11 @@ class CommandAuto(Command):
                 os.kill(os.getpid(), 15)
 
     def do_rebuild(self, event):
+        fname = os.path.basename(event.src_path)
+        if (fname.endswith('~') or
+                fname.startswith('.') or
+                os.path.isdir(event.src_path)):  # Skip on folders, these are usually duplicates
+            return
         self.logger.info('REBUILDING SITE (from {0})'.format(event.src_path))
         p = subprocess.Popen(self.cmd_arguments, stderr=subprocess.PIPE)
         error = p.stderr.read()


### PR DESCRIPTION
* Do not rebuild on backup files like foobar~
* Do not rebuild on changes to "hidden" files like .foobar
* Do not rebuild on changes to directories. These are usually duplicates of changes to a file inside the folder.

Fixes #1905.