### PR TITLE
Fix NameError caused by failed import in auto plugin.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Bugfixes
 --------
 
 * Ignore sliced multibyte characters when reading metadata for sitemaps
+* Fix NameError caused by failed import in auto plugin.
 
 New in v7.6.3
 =============

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -447,7 +447,6 @@ try:
     else:
         EX = IOError
 
-
     def finish_response(self):
         """Monkeypatched finish_response that ignores broken pipes."""
         try:
@@ -459,4 +458,3 @@ try:
 except NameError:
     # In case there is no WebSocketWSGIHandler because of a failed import.
     pass
-


### PR DESCRIPTION
After upgrading to 7.6.3 I got the following error message:

```
[2015-08-09T18:01:02Z] ERROR: yapsy: Unable to import plugin: /Users/niko/.virtualenvs/nikola/lib/python3.4/site-packages/nikola/plugins/command/auto
Traceback (most recent call last):
  File "/Users/niko/.virtualenvs/nikola/lib/python3.4/site-packages/yapsy/PluginManager.py", line 485, in loadPlugins
    candidate_module = imp.load_module(plugin_module_name,None,candidate_filepath,("py","r",imp.PKG_DIRECTORY))
  File "/Users/niko/.virtualenvs/nikola/lib/python3.4/imp.py", line 245, in load_module
    return load_package(name, filename)
  File "/Users/niko/.virtualenvs/nikola/lib/python3.4/imp.py", line 217, in load_package
    return methods.load()
  File "<frozen importlib._bootstrap>", line 1220, in load
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1471, in exec_module
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/Users/niko/.virtualenvs/nikola/lib/python3.4/site-packages/nikola/plugins/command/auto/__init__.py", line 443, in <module>
    f = WebSocketWSGIHandler.finish_response
NameError: name 'WebSocketWSGIHandler' is not defined
```

This was introduced through this fix for #1906: https://github.com/getnikola/nikola/commit/80a49adb373b0762560c473cff00daa0c50e502b
The introduced `WebSocketWSGIHandler` may not be available.

This PR avoids crashing the plugin.