### PR TITLE
Make Nikola Faster 1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in Master
 Bugfixes
 --------
 
+* Make Nikola startup faster by not loading useless plugins (Issue #1825)
 * Ignore sliced multibyte characters when reading metadata for sitemaps
 * Fix NameError caused by failed import in auto plugin.
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -745,7 +745,10 @@ class Nikola(object):
 
         self.plugin_manager.getPluginLocator().setPluginPlaces(places)
         self.plugin_manager.locatePlugins()
+        # Remove compilers we don't use
         self.plugin_manager._candidates = [p for p in self.plugin_manager._candidates if p[-1].name not in bad_compilers]
+        # Remove blacklisted plugins
+        self.plugin_manager._candidates = [p for p in self.plugin_manager._candidates if p[-1].name not in self.config['DISABLED_PLUGINS']]
         self.plugin_manager.loadPlugins()
 
         self._activate_plugins_of_category("SignalHandler")
@@ -870,12 +873,9 @@ class Nikola(object):
         # this code duplicated in tests/base.py
         plugins = []
         for plugin_info in self.plugin_manager.getPluginsOfCategory(category):
-            if plugin_info.name in self.config.get('DISABLED_PLUGINS'):
-                self.plugin_manager.removePluginFromCategory(plugin_info, category)
-            else:
-                self.plugin_manager.activatePluginByName(plugin_info.name)
-                plugin_info.plugin_object.set_site(self)
-                plugins.append(plugin_info)
+            self.plugin_manager.activatePluginByName(plugin_info.name)
+            plugin_info.plugin_object.set_site(self)
+            plugins.append(plugin_info)
         return plugins
 
     def _get_themes(self):

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -716,7 +716,6 @@ class Nikola(object):
                 os.path.expanduser('~/.nikola/plugins'),
             ] + [utils.sys_encode(path) for path in extra_plugins_dirs if path]
 
-
         # Store raw compilers for internal use (need a copy for that)
         self.config['_COMPILERS_RAW'] = {}
         for k, v in self.config['COMPILERS'].items():
@@ -735,7 +734,7 @@ class Nikola(object):
         # Remove compilers that match nothing in POSTS/PAGES
         # And put them in "bad compilers"
         pp_exts = set([os.path.splitext(x[0])[1] for x in self.config['post_pages']])
-        self.config['COMPILERS']={}
+        self.config['COMPILERS'] = {}
         bad_compilers = set([])
         for k, v in compilers.items():
             if pp_exts.intersection(v):


### PR DESCRIPTION
* Add a plugin filtering step so we can NOT load some of them.
* Avoid loading compiler plugins we don't need because of configuration.
* Avoid loading plugins listed in DISABLED_PLUGINS
* Avoid loading compiler extensions for compilers we don't load

At this point this branch brings "nikola help" from 0.65 seconds to 0.31 in average of 100 runs.