### PR TITLE
Add the option to configure TEASER_REGEXP

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -86,6 +86,7 @@
 * `Tolu Sonaike <https://github.com/tolusonaike>`_
 * `Troy Toman <https://github.com/troytoman>`_
 * `Udo Spallek <https://github.com/udono>`_
+* `Yamila Moreno <https://github.com/yamila-moreno>`_
 * `Yaşar Arabacı <https://github.com/yasar11732>`_
 * `Yasuhiko Shiga <https://github.com/quoth>`_
 * `Zhaojun Meng <https://github.com/zhaojunmeng>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 New in Master
 =============
 
+Features
+--------
+
+* New option to use custom, and several TEASER_ENDs
+
 Bugfixes
 --------
 

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -352,7 +352,7 @@ to your configuration:
    However, starting with Nikola v7, you can now use ``.meta`` files and put
    all metadata you want, complete with the explanations — they look just like
    the beginning of our reST files.
-      
+
       .. code:: restructuredtext
 
          .. title: How to make money
@@ -496,6 +496,13 @@ change that text, you can use a custom teaser:
 .. code:: restructuredtext
 
     .. TEASER_END: click to read the rest of the article
+
+You can override the default value for `TEASER_END` in `conf.py`:
+
+..code:: python
+
+    import re
+    TEASER_REGEXP = re.compile('<!--\s*(more|TEASER_END)(:(.+))?\s*-->', re.IGNORECASE)
 
 Or you can completely customize the link using the ``READ_MORE_LINK`` option
 

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -605,11 +605,12 @@ class Post(object):
             data = lxml.html.tostring(document, encoding='unicode')
 
         if teaser_only:
-            teaser = TEASER_REGEXP.split(data)[0]
+            teaser_regexp = self.config.get('TEASER_REGEXP', TEASER_REGEXP)
+            teaser = teaser_regexp.split(data)[0]
             if teaser != data:
                 if not strip_html and show_read_more_link:
-                    if TEASER_REGEXP.search(data).groups()[-1]:
-                        teaser_text = TEASER_REGEXP.search(data).groups()[-1]
+                    if teaser_regexp.search(data).groups()[-1]:
+                        teaser_text = teaser_regexp.search(data).groups()[-1]
                     else:
                         teaser_text = self.messages[lang]["Read more"]
                     l = self.config['RSS_READ_MORE_LINK'](lang) if rss_read_more_link else self.config['INDEX_READ_MORE_LINK'](lang)


### PR DESCRIPTION
For those who migrate from wordpress (thanks for the importer!), we have the "<!--more-->" tag for the "Read more" link. But the new posts will have ".. TEASER_END" as recommended.

So I'll end with two different "strings" to detect as TEASER_REGEXP.

For that reason, I suggest those changes:

- by default the behaviour is the same
- but if you need to use two (or more!!) different ways, you can create the regexp in the conf.py