### PR TITLE
Fixing wrong file_deps for copy_assets's copy tasks.

### DIFF
--- a/nikola/plugins/task/copy_assets.py
+++ b/nikola/plugins/task/copy_assets.py
@@ -77,7 +77,9 @@ class CopyAssets(Task):
                 task['uptodate'] = [utils.config_changed(kw, 'nikola.plugins.task.copy_assets')]
                 task['basename'] = self.name
                 if code_css_input:
-                    task['file_dep'] = [code_css_input]
+                    if 'file_dep' not in task:
+                        task['file_dep'] = []
+                    task['file_dep'].append(code_css_input)
                 yield utils.apply_filters(task, kw['filters'])
 
         # Check whether or not there is a code.css file around.


### PR DESCRIPTION
When a `code.css` is present, the `file_dep` of all copy tasks generated by `copy_assets` is overwritten with the path to `code.css`, causing changes in the theme's `css` files (other than `code.css`) to not result in being copied to the output folder.
This should fix it.