### PR TITLE
Ensure link path to be URL encoded

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1042,6 +1042,10 @@ UNSLUGIFY_TITLES = True
 # sometimes crash Nikola, your web server, or eat your cat.
 # USE_SLUGIFY = True
 
+# If you use URL encoding rather than UTF-8 encoding for URLs, you should
+# set this to true.
+# USE_URLENCODING = False
+
 # Templates will use those filters, along with the defaults.
 # Consult your engine's documentation on filters if you need help defining
 # those.

--- a/nikola/data/themes/base/templates/author.tmpl
+++ b/nikola/data/themes/base/templates/author.tmpl
@@ -5,10 +5,10 @@
     ${parent.extra_head()}
     %if len(translations) > 1 and generate_rss:
         %for language in sorted(translations):
-            <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${author} (${language})" href="${_link(kind + "_rss", author, language)}">
+            <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${author|h} (${language})" href="${_link(kind + "_rss", author, language)}">
         %endfor
     %elif generate_rss:
-        <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${author}" href="${_link(kind + "_rss", author)}">
+        <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${author|h}" href="${_link(kind + "_rss", author)}">
     %endif
 </%block>
 
@@ -18,7 +18,7 @@
     <header>
         <h1>${title|h}</h1>
         %if description:
-        <p>${description}</p>
+        <p>${description|h}</p>
         %endif
         <div class="metadata">
             %if len(translations) > 1 and generate_rss:
@@ -35,7 +35,7 @@
     %if posts:
     <ul class="postlist">
     % for post in posts:
-        <li><a href="${post.permalink()}" class="listtitle">${post.title()|h}</a><time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)}">${post.formatted_date(date_format)}</time></li>
+        <li><a href="${post.permalink()}" class="listtitle">${post.title()|h}</a><time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time></li>
     % endfor
     </ul>
     %endif

--- a/nikola/data/themes/base/templates/authorindex.tmpl
+++ b/nikola/data/themes/base/templates/authorindex.tmpl
@@ -5,9 +5,9 @@
     ${parent.extra_head()}
     %if len(tranlations) > 1 and generate_atom:
         %for language in sorted(translations):
-            <link rel="alternate" type="application/atom+xml" title="Atom for the ${author} section (${language})" href="${_link(kind + "_atom", author, language)}">
+            <link rel="alternate" type="application/atom+xml" title="Atom for the ${author|h} section (${language})" href="${_link(kind + "_atom", author, language)}">
         %endfor
     %elif generate_atom:
-        <link rel="alternate" type="application/atom+xml" title="Atom for the ${author} section" href="${_link("author" + "_atom", author)}">
+        <link rel="alternate" type="application/atom+xml" title="Atom for the ${author|h} section" href="${_link("author" + "_atom", author)}">
     %endif
 </%block>

--- a/nikola/data/themes/base/templates/authors.tmpl
+++ b/nikola/data/themes/base/templates/authors.tmpl
@@ -8,7 +8,7 @@
         <ul class="postlist">
         % for text, link in items:
             % if text not in hidden_authors:
-                <li><a class="reference listtitle" href="${link}">${text}</a></li>
+                <li><a class="reference listtitle" href="${link}">${text|h}</a></li>
             % endif
         % endfor
         </ul>

--- a/nikola/data/themes/base/templates/base_header.tmpl
+++ b/nikola/data/themes/base/templates/base_header.tmpl
@@ -16,13 +16,13 @@
 </%def>
 
 <%def name="html_site_title()">
-    <h1 id="brand"><a href="${abs_link(_link("root", None, lang))}" title="${blog_title}" rel="home">
+    <h1 id="brand"><a href="${abs_link(_link("root", None, lang))}" title="${blog_title|h}" rel="home">
     %if logo_url:
-        <img src="${logo_url}" alt="${blog_title}" id="logo">
+        <img src="${logo_url}" alt="${blog_title|h}" id="logo">
     %endif
 
     % if show_blog_title:
-        <span id="blog-title">${blog_title}</span>
+        <span id="blog-title">${blog_title|h}</span>
     % endif
     </a></h1>
 </%def>
@@ -32,21 +32,21 @@
     <ul>
     %for url, text in navigation_links[lang]:
         % if isinstance(url, tuple):
-            <li> ${text}
+            <li> ${text|h}
             <ul>
             %for suburl, text in url:
                 % if rel_link(permalink, suburl) == "#":
-                    <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a></li>
+                    <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a></li>
                 %else:
-                    <li><a href="${suburl}">${text}</a></li>
+                    <li><a href="${suburl}">${text|h}</a></li>
                 %endif
             %endfor
             </ul>
         % else:
             % if rel_link(permalink, url) == "#":
-                <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a></li>
+                <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a></li>
             %else:
-                <li><a href="${url}">${text}</a></li>
+                <li><a href="${url}">${text|h}</a></li>
             %endif
         % endif
     %endfor

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -25,7 +25,7 @@ lang="${lang}">
     <base href="${abs_link(permalink)}">
     % endif
     %if description:
-    <meta name="description" content="${description}">
+    <meta name="description" content="${description|h}">
     %endif
     <meta name="viewport" content="width=device-width">
     %if title == blog_title:

--- a/nikola/data/themes/base/templates/gallery.tmpl
+++ b/nikola/data/themes/base/templates/gallery.tmpl
@@ -17,8 +17,13 @@
     %if folders:
     <ul>
     % for folder, ftitle in folders:
-        <li><a href="${folder}"><i
-        class="icon-folder-open"></i>&nbsp;${ftitle}</a></li>
+        % if use_urlencoding:
+            <li><a href="${folder|u}"><i
+            class="icon-folder-open"></i>&nbsp;${ftitle|h}</a></li>
+        % else:
+            <li><a href="${folder}"><i
+            class="icon-folder-open"></i>&nbsp;${ftitle|h}</a></li>
+        % endif
     % endfor
     </ul>
     %endif
@@ -26,7 +31,7 @@
     <ul class="thumbnails">
         %for image in photo_array:
             <li><a href="${image['url']}" class="thumbnail image-reference" title="${image['title']}">
-                <img src="${image['url_thumb']}" alt="${image['title']}" /></a>
+                <img src="${image['url_thumb']}" alt="${image['title']|h}" /></a>
         %endfor
     </ul>
     %endif

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -22,10 +22,10 @@
             % if author_pages_generated:
                 <a href="${_link('author', post.author())}">${post.author()}</a>
             % else:
-                ${post.author()}
+                ${post.author()|h}
             % endif
             </span></p>
-            <p class="dateline"><a href="${post.permalink()}" rel="bookmark"><time class="published dt-published" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)}">${post.formatted_date(date_format)}</time></a></p>
+            <p class="dateline"><a href="${post.permalink()}" rel="bookmark"><time class="published dt-published" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time></a></p>
             % if not post.meta('nocomments') and site_has_comments:
                 <p class="commentline">${comments.comment_link(post.permalink(), post._base_path)}
             % endif

--- a/nikola/data/themes/base/templates/list.tmpl
+++ b/nikola/data/themes/base/templates/list.tmpl
@@ -4,12 +4,12 @@
 <%block name="content">
 <article class="listpage">
     <header>
-        <h1>${title}</h1>
+        <h1>${title|h}</h1>
     </header>
     %if items:
     <ul class="postlist">
     % for text, link, count in items:
-        <li><a href="${link}">${text}</a>
+        <li><a href="${link}">${text|h}</a>
         % if count:
             (${count})
         % endif

--- a/nikola/data/themes/base/templates/list_post.tmpl
+++ b/nikola/data/themes/base/templates/list_post.tmpl
@@ -4,12 +4,12 @@
 <%block name="content">
 <article class="listpage">
     <header>
-        <h1>${title}</h1>
+        <h1>${title|h}</h1>
     </header>
     %if posts:
     <ul class="postlist">
     % for post in posts:
-        <li><a href="${post.permalink()}" class="listtitle">${post.title()|h}</a> <time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)}">${post.formatted_date(date_format)}</time></li>
+        <li><a href="${post.permalink()}" class="listtitle">${post.title()|h}</a> <time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time></li>
     % endfor
     </ul>
     %else:

--- a/nikola/data/themes/base/templates/listing.tmpl
+++ b/nikola/data/themes/base/templates/listing.tmpl
@@ -6,10 +6,18 @@ ${ui.bar(crumbs)}
 %if folders or files:
 <ul>
 % for name in folders:
-    <li><a href="${name}"><i class="icon-folder-open"></i> ${name}</a>
+    % if use_urlencoding:
+        <li><a href="${name|u}"><i class="icon-folder-open"></i> ${name|h}</a>
+    % else:
+        <li><a href="${name}"><i class="icon-folder-open"></i> ${name|h}</a>
+    % endif
 % endfor
 % for name in files:
-    <li><a href="${name}.html"><i class="icon-file"></i> ${name}</a>
+    % if use_urlencoding:
+        <li><a href="${name|u}.html"><i class="icon-file"></i> ${name|h}</a>
+    % else:
+        <li><a href="${name}.html"><i class="icon-file"></i> ${name|h}</a>
+    % endif
 % endfor
 </ul>
 %endif

--- a/nikola/data/themes/base/templates/post.tmpl
+++ b/nikola/data/themes/base/templates/post.tmpl
@@ -10,9 +10,9 @@
     <meta name="keywords" content="${post.meta('keywords')|h}">
     % endif
     %if post.description():
-    <meta name="description" content="${post.description()}">
+    <meta name="description" content="${post.description()|h}">
     %endif
-    <meta name="author" content="${post.author()}">
+    <meta name="author" content="${post.author()|h}">
     %if post.prev_post:
         <link rel="prev" href="${post.prev_post.permalink()}" title="${post.prev_post.title()|h}" type="text/html">
     %endif

--- a/nikola/data/themes/base/templates/post_header.tmpl
+++ b/nikola/data/themes/base/templates/post_header.tmpl
@@ -33,12 +33,12 @@
         <div class="metadata">
             <p class="byline author vcard"><span class="byline-name fn">
                 % if author_pages_generated:
-                    <a href="${_link('author', post.author())}">${post.author()}</a>
+                    <a href="${_link('author', post.author())}">${post.author()|h}</a>
                 % else:
-                    ${post.author()}
+                    ${post.author()|h}
                 % endif
             </span></p>
-            <p class="dateline"><a href="${post.permalink()}" rel="bookmark"><time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)}">${post.formatted_date(date_format)}</time></a></p>
+            <p class="dateline"><a href="${post.permalink()}" rel="bookmark"><time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time></a></p>
             % if not post.meta('nocomments') and site_has_comments:
                 <p class="commentline">${comments.comment_link(post.permalink(), post._base_path)}
             % endif
@@ -47,7 +47,7 @@
                     <p class="linkline"><a href="${post.meta('link')}">${messages("Original site")}</a></p>
             % endif
             %if post.description():
-                <meta name="description" itemprop="description" content="${post.description()}">
+                <meta name="description" itemprop="description" content="${post.description()|h}">
             %endif
         </div>
         ${html_translations(post)}

--- a/nikola/data/themes/base/templates/post_helper.tmpl
+++ b/nikola/data/themes/base/templates/post_helper.tmpl
@@ -15,7 +15,7 @@
         <ul itemprop="keywords" class="tags">
         %for tag in post.tags:
           % if tag not in hidden_tags:
-            <li><a class="tag p-category" href="${_link('tag', tag)}" rel="tag">${tag}</a></li>
+            <li><a class="tag p-category" href="${_link('tag', tag)}" rel="tag">${tag|h}</a></li>
           % endif
         %endfor
         </ul>
@@ -41,7 +41,7 @@
 
 <%def name="open_graph_metadata(post)">
 %if use_open_graph:
-    <meta property="og:site_name" content="${blog_title|striphtml}">
+    <meta property="og:site_name" content="${blog_title|striphtml,h}">
     <meta property="og:title" content="${post.title()[:70]|h}">
     <meta property="og:url" content="${abs_link(permalink)}">
     %if post.description():
@@ -55,14 +55,14 @@
     <meta property="og:type" content="article">
 ### Will only work with Pintrest and breaks everywhere else who expect a [Facebook] URI.
 ###    %if post.author():
-###    <meta property="article:author" content="${post.author()}">
+###    <meta property="article:author" content="${post.author()|h}">
 ###    %endif
     %if post.date.isoformat():
     <meta property="article:published_time" content="${post.formatted_date('webiso')}">
     %endif
     %if post.tags:
         %for tag in post.tags:
-           <meta property="article:tag" content="${tag}">
+           <meta property="article:tag" content="${tag|h}">
         %endfor
     %endif
 %endif

--- a/nikola/data/themes/base/templates/post_list_directive.tmpl
+++ b/nikola/data/themes/base/templates/post_list_directive.tmpl
@@ -6,7 +6,7 @@
     <ul class="post-list">
         % for post in posts:
             <li class="post-list-item">
-	        ${post.formatted_date(date_format)}
+	        ${post.formatted_date(date_format)|h}
 		&nbsp;
 		<a href="${post.permalink(lang)}">${post.title(lang)|h}</a>
 	    </li>

--- a/nikola/data/themes/base/templates/sectionindex.tmpl
+++ b/nikola/data/themes/base/templates/sectionindex.tmpl
@@ -4,14 +4,14 @@
 <%block name="extra_head">
     ${parent.extra_head()}
     % if generate_atom:
-        <link rel="alternate" type="application/atom+xml" title="Atom for the ${posts[0].section_name()} section" href="${_link('section_index_atom', posts[0].section_slug())}">
+        <link rel="alternate" type="application/atom+xml" title="Atom for the ${posts[0].section_name()|h} section" href="${_link('section_index_atom', posts[0].section_slug())}">
     % endif
 </%block>
 
 <%block name="content">
 <div class="sectionindex">
     <header>
-        <h2><a href="${posts[0].section_link()}">${title}</a></h2>
+        <h2><a href="${posts[0].section_link()}">${title|h}</a></h2>
         % if generate_atom:
             <p class="feedlink"><a href="${_link('section_index_atom', posts[0].section_slug())}" type="application/atom+xml">${messages('Updates')}</a></p>
         % endif

--- a/nikola/data/themes/base/templates/tag.tmpl
+++ b/nikola/data/themes/base/templates/tag.tmpl
@@ -5,10 +5,10 @@
     ${parent.extra_head()}
     %if len(translations) > 1 and generate_rss:
         %for language in sorted(translations):
-            <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${tag} (${language})" href="${_link(kind + "_rss", tag, language)}">
+            <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${tag|h} (${language})" href="${_link(kind + "_rss", tag, language)}">
         %endfor
     %elif generate_rss:
-        <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${tag}" href="${_link(kind + "_rss", tag)}">
+        <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${tag|h}" href="${_link(kind + "_rss", tag)}">
     %endif
 </%block>
 
@@ -18,13 +18,13 @@
     <header>
         <h1>${title|h}</h1>
         %if description:
-        <p>${description}</p>
+        <p>${description|h}</p>
         %endif
         %if subcategories:
         ${messages('Subcategories:')}
         <ul>
             %for name, link in subcategories:
-            <li><a href="${link}">${name}</a></li>
+            <li><a href="${link}">${name|h}</a></li>
             %endfor
         </ul>
         %endif
@@ -43,7 +43,7 @@
     %if posts:
     <ul class="postlist">
     % for post in posts:
-        <li><time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)}">${post.formatted_date(date_format)}</time><a href="${post.permalink()}" class="listtitle">${post.title()|h}<a></li>
+        <li><time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time><a href="${post.permalink()}" class="listtitle">${post.title()|h}<a></li>
     % endfor
     </ul>
     %endif

--- a/nikola/data/themes/base/templates/tagindex.tmpl
+++ b/nikola/data/themes/base/templates/tagindex.tmpl
@@ -6,7 +6,7 @@
     ${messages('Subcategories:')}
     <ul>
         %for name, link in subcategories:
-        <li><a href="${link}">${name}</a></li>
+        <li><a href="${link}">${name|h}</a></li>
         %endfor
     </ul>
     %endif
@@ -16,9 +16,9 @@
     ${parent.extra_head()}
     %if len(translations) > 1 and generate_atom:
         %for language in sorted(translations):
-            <link rel="alternate" type="application/atom+xml" title="Atom for the ${tag} section (${language})" href="${_link(kind + "_atom", tag, language)}">
+            <link rel="alternate" type="application/atom+xml" title="Atom for the ${tag|h} section (${language})" href="${_link(kind + "_atom", tag, language)}">
         %endfor
     %elif generate_atom:
-        <link rel="alternate" type="application/atom+xml" title="Atom for the ${tag} section" href="${_link("tag" + "_atom", tag)}">
+        <link rel="alternate" type="application/atom+xml" title="Atom for the ${tag|h} section" href="${_link("tag" + "_atom", tag)}">
     %endif
 </%block>

--- a/nikola/data/themes/base/templates/tags.tmpl
+++ b/nikola/data/themes/base/templates/tags.tmpl
@@ -4,7 +4,7 @@
 <%block name="content">
 <article class="tagindex">
     <header>
-        <h1>${title}</h1>
+        <h1>${title|h}</h1>
     </header>
     % if cat_items:
         % if items:
@@ -33,7 +33,7 @@
         <ul class="postlist">
         % for text, link in items:
             % if text not in hidden_tags:
-                <li><a class="reference listtitle" href="${link}">${text}</a></li>
+                <li><a class="reference listtitle" href="${link}">${text|h}</a></li>
             % endif
         % endfor
         </ul>

--- a/nikola/data/themes/bootstrap3/templates/authors.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/authors.tmpl
@@ -9,7 +9,7 @@
     <ul class="list-inline">
     % for text, link in items:
         % if text not in hidden_authors:
-            <li><a class="reference badge" href="${link}">${text}</a></li>
+            <li><a class="reference badge" href="${link}">${text|h}</a></li>
         % endif
     % endfor
     </ul>

--- a/nikola/data/themes/bootstrap3/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base.tmpl
@@ -24,11 +24,11 @@ ${template_hooks['extra_head']()}
             </button>
             <a class="navbar-brand" href="${abs_link(_link("root", None, lang))}">
             %if logo_url:
-                <img src="${logo_url}" alt="${blog_title}" id="logo">
+                <img src="${logo_url}" alt="${blog_title|h}" id="logo">
             %endif
 
             % if show_blog_title:
-                <span id="blog-title">${blog_title}</span>
+                <span id="blog-title">${blog_title|h}</span>
             % endif
             </a>
         </div><!-- /.navbar-header -->

--- a/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
@@ -30,7 +30,7 @@ lang="${lang}">
     <base href="${abs_link(permalink)}">
     % endif
     %if description:
-    <meta name="description" content="${description}">
+    <meta name="description" content="${description|h}">
     %endif
     <meta name="viewport" content="width=device-width, initial-scale=1">
     %if title == blog_title:
@@ -135,21 +135,21 @@ lang="${lang}">
 <%def name="html_navigation_links()">
     %for url, text in navigation_links[lang]:
         % if isinstance(url, tuple):
-            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${text} <b class="caret"></b></a>
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${text|h} <b class="caret"></b></a>
             <ul class="dropdown-menu">
             %for suburl, text in url:
                 % if rel_link(permalink, suburl) == "#":
-                    <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a>
+                    <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a>
                 %else:
-                    <li><a href="${suburl}">${text}</a>
+                    <li><a href="${suburl}">${text|h}</a>
                 %endif
             %endfor
             </ul>
         % else:
             % if rel_link(permalink, url) == "#":
-                <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a>
+                <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a>
             %else:
-                <li><a href="${url}">${text}</a>
+                <li><a href="${url}">${text|h}</a>
             %endif
         % endif
     %endfor

--- a/nikola/data/themes/bootstrap3/templates/gallery.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/gallery.tmpl
@@ -17,7 +17,11 @@
     %if folders:
     <ul>
     % for folder, ftitle in folders:
-        <li><a href="${folder}"><i class="glyphicon glyphicon-folder-open"></i>&nbsp;${ftitle}</a></li>
+        % if use_urlencoding:
+            <li><a href="${folder|u}"><i class="glyphicon glyphicon-folder-open"></i>&nbsp;${ftitle|h}</a></li>
+        % else:
+            <li><a href="${folder}"><i class="glyphicon glyphicon-folder-open"></i>&nbsp;${ftitle|h}</a></li>
+        % endif
     % endfor
     </ul>
     %endif
@@ -27,8 +31,8 @@
 <noscript>
 <ul class="thumbnails">
     %for image in photo_array:
-        <li><a href="${image['url']}" class="thumbnail image-reference" title="${image['title']}">
-            <img src="${image['url_thumb']}" alt="${image['title']}" /></a>
+        <li><a href="${image['url']}" class="thumbnail image-reference" title="${image['title']|h}">
+            <img src="${image['url_thumb']}" alt="${image['title']|h}" /></a>
     %endfor
 </ul>
 </noscript>

--- a/nikola/data/themes/bootstrap3/templates/listing.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/listing.tmpl
@@ -7,10 +7,18 @@ ${ui.bar(crumbs)}
 %if folders or files:
 <ul class="list-unstyled">
 % for name in folders:
-    <li><a href="${name}"><i class="glyphicon glyphicon-folder-open"></i> ${name}</a>
+    % if use_urlencoding:
+        <li><a href="${name|u}"><i class="glyphicon glyphicon-folder-open"></i> ${name|h}</a>
+    % else:
+        <li><a href="${name}"><i class="glyphicon glyphicon-folder-open"></i> ${name|h}</a>
+    % endif
 % endfor
 % for name in files:
-    <li><a href="${name}.html"><i class="glyphicon glyphicon-file"></i> ${name}</a>
+    % if use_urlencoding:
+        <li><a href="${name|u}.html"><i class="glyphicon glyphicon-file"></i> ${name|h}</a>
+    % else:
+        <li><a href="${name}.html"><i class="glyphicon glyphicon-file"></i> ${name|h}</a>
+    % endif
 % endfor
 </ul>
 %endif

--- a/nikola/data/themes/bootstrap3/templates/post.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/post.tmpl
@@ -10,9 +10,9 @@
     <meta name="keywords" content="${post.meta('keywords')|h}">
     % endif
     %if post.description():
-    <meta name="description" itemprop="description" content="${post.description()}">
+    <meta name="description" itemprop="description" content="${post.description()|h}">
     %endif
-    <meta name="author" content="${post.author()}">
+    <meta name="author" content="${post.author()|h}">
     %if post.prev_post:
         <link rel="prev" href="${post.prev_post.permalink()}" title="${post.prev_post.title()|h}" type="text/html">
     %endif

--- a/nikola/data/themes/bootstrap3/templates/tags.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/tags.tmpl
@@ -2,7 +2,7 @@
 <%inherit file="base.tmpl"/>
 
 <%block name="content">
-<h1>${title}</h1>
+<h1>${title|h}</h1>
 % if cat_items:
     % if items:
         <h2>${messages("Categories")}</h2>
@@ -11,7 +11,7 @@
         % for i in range(indent_change_before):
             <ul class="list-inline">
         % endfor
-        <li><a class="reference badge" href="${link}">${text}</a>
+        <li><a class="reference badge" href="${link}">${text|h}</a>
         % if indent_change_after <= 0:
             </li>
         % endif
@@ -30,7 +30,7 @@
     <ul class="list-inline">
     % for text, link in items:
         % if text not in hidden_tags:
-            <li><a class="reference badge" href="${link}">${text}</a></li>
+            <li><a class="reference badge" href="${link}">${text|h}</a></li>
         % endif
     % endfor
     </ul>

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -40,8 +40,9 @@ import natsort
 import mimetypes
 try:
     from urlparse import urlparse, urlsplit, urlunsplit, urljoin, unquote
+    from urllib import quote
 except ImportError:
-    from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote  # NOQA
+    from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote, quote  # NOQA
 
 try:
     import pyphen
@@ -493,6 +494,7 @@ class Nikola(object):
             'USE_FILENAME_AS_TITLE': True,
             'USE_OPEN_GRAPH': True,
             'USE_SLUGIFY': True,
+            'USE_URLENCODING': False,
             'TIMEZONE': 'UTC',
             'WRITE_TAG_CLOUD': True,
             'DEPLOY_DRAFTS': True,
@@ -1355,9 +1357,10 @@ class Nikola(object):
                 index_len = len(self.config['INDEX_FILE'])
                 if self.config['STRIP_INDEXES'] and \
                         link[-(1 + index_len):] == '/' + self.config['INDEX_FILE']:
-                    return link[:-index_len]
-                else:
-                    return link
+                    link = link[:-index_len]
+                if self.config['USE_URLENCODING']:
+                    link = quote(link.encode('utf-8'))
+                return link
             else:
                 return os.path.join(*path)
         except KeyError:

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -140,6 +140,7 @@ class Archive(Task):
             "strip_indexes": self.site.config['STRIP_INDEXES'],
             "index_file": self.site.config['INDEX_FILE'],
             "generate_atom": self.site.config["GENERATE_ATOM"],
+            "use_urlencoding": self.site.config['USE_URLENCODING'],
         }
         self.site.scan_posts()
         yield self.group_task()

--- a/nikola/plugins/task/authors.py
+++ b/nikola/plugins/task/authors.py
@@ -77,6 +77,7 @@ class RenderAuthors(Task):
             "pretty_urls": self.site.config['PRETTY_URLS'],
             "strip_indexes": self.site.config['STRIP_INDEXES'],
             "index_file": self.site.config['INDEX_FILE'],
+            "use_urlencoding": self.site.config['USE_URLENCODING'],
         }
 
         yield self.group_task()

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -36,8 +36,9 @@ import os
 import sys
 try:
     from urlparse import urljoin
+    from urllib import quote
 except ImportError:
-    from urllib.parse import urljoin  # NOQA
+    from urllib.parse import urljoin, quote  # NOQA
 
 import natsort
 try:
@@ -87,6 +88,7 @@ class Galleries(Task, ImageProcessor):
             'tzinfo': site.tzinfo,
             'comments_in_galleries': site.config['COMMENTS_IN_GALLERIES'],
             'generate_rss': site.config['GENERATE_RSS'],
+            'use_urlencoding': site.config['USE_URLENCODING'],
         }
 
         # Verify that no folder in GALLERY_FOLDERS appears twice
@@ -272,6 +274,7 @@ class Galleries(Task, ImageProcessor):
                 context["enable_comments"] = self.kw['comments_in_galleries']
                 context["thumbnail_size"] = self.kw["thumbnail_size"]
                 context["pagekind"] = ["gallery_front"]
+                context["use_urlencoding"] = self.kw["use_urlencoding"]
 
                 if post:
                     yield {
@@ -557,6 +560,8 @@ class Galleries(Task, ImageProcessor):
 
         def url_from_path(p):
             url = '/'.join(os.path.relpath(p, os.path.dirname(output_name) + os.sep).split(os.sep))
+            if self.kw['use_urlencoding']:
+                url = quote(url.encode('utf-8'))
             return url
 
         photo_array = []

--- a/nikola/plugins/task/indexes.py
+++ b/nikola/plugins/task/indexes.py
@@ -69,6 +69,7 @@ class Indexes(Task):
             "strip_indexes": self.site.config['STRIP_INDEXES'],
             "blog_title": self.site.config["BLOG_TITLE"],
             "generate_atom": self.site.config["GENERATE_ATOM"],
+            "use_urlencoding": self.site.config['USE_URLENCODING'],
         }
 
         template_name = "index.tmpl"

--- a/nikola/plugins/task/listings.py
+++ b/nikola/plugins/task/listings.py
@@ -67,6 +67,7 @@ class Listings(Task):
             "index_file": site.config["INDEX_FILE"],
             "strip_indexes": site.config['STRIP_INDEXES'],
             "filters": site.config["FILTERS"],
+            "use_urlencoding": site.config['USE_URLENCODING'],
         }
 
         # Verify that no folder in LISTINGS_FOLDERS appears twice (on output side)
@@ -164,6 +165,7 @@ class Listings(Task):
                 'description': title,
                 'source_link': source_link,
                 'pagekind': ['listing'],
+                'use_urlencoding': self.kw['use_urlencoding'],
             }
             if needs_ipython_css:
                 # If someone does not have ipynb posts and only listings, we

--- a/nikola/plugins/task/posts.py
+++ b/nikola/plugins/task/posts.py
@@ -58,6 +58,7 @@ class RenderPosts(Task):
             "default_lang": self.site.config["DEFAULT_LANG"],
             "show_untranslated_posts": self.site.config['SHOW_UNTRANSLATED_POSTS'],
             "demote_headers": self.site.config['DEMOTE_HEADERS'],
+            "use_urlencoding": self.site.config['USE_URLENCODING'],
         }
         self.tl_changed = False
 

--- a/nikola/plugins/task/rss.py
+++ b/nikola/plugins/task/rss.py
@@ -65,6 +65,7 @@ class GenerateRSS(Task):
             "tzinfo": self.site.tzinfo,
             "rss_read_more_link": self.site.config["RSS_READ_MORE_LINK"],
             "rss_links_append_query": self.site.config["RSS_LINKS_APPEND_QUERY"],
+            "use_urlencoding": self.site.config['USE_URLENCODING'],
         }
         self.site.scan_posts()
         # Check for any changes in the state of use_in_feeds for any post.

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -88,6 +88,7 @@ class RenderTags(Task):
             "category_pages_titles": self.site.config['CATEGORY_PAGES_TITLES'],
             "tag_pages_descriptions": self.site.config['TAG_PAGES_DESCRIPTIONS'],
             "tag_pages_titles": self.site.config['TAG_PAGES_TITLES'],
+            "use_urlencoding": self.site.config['USE_URLENCODING'],
         }
 
         self.site.scan_posts()

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -38,8 +38,9 @@ import re
 import string
 try:
     from urlparse import urljoin
+    from urllib import quote
 except ImportError:
-    from urllib.parse import urljoin  # NOQA
+    from urllib.parse import urljoin, quote  # NOQA
 
 from . import utils
 
@@ -720,10 +721,13 @@ class Post(object):
     def source_link(self, lang=None):
         """Return absolute link to the post's source."""
         ext = self.source_ext(True)
-        return "/" + self.destination_path(
+        path = "/" + self.destination_path(
             lang=lang,
             extension=ext,
             sep='/')
+        if self.config['USE_URLENCODING']:
+            path = quote(path.encode('utf-8'))
+        return path
 
     def destination_path(self, lang=None, extension='.html', sep=os.sep):
         """Destination path for this post, relative to output/.
@@ -760,6 +764,8 @@ class Post(object):
             link = urljoin('/' + slug + '/', self.index_file)
         else:
             link = '/' + slug + '/'
+        if self.config['USE_URLENCODING']:
+            link = quote(link.encode('utf-8'))
         return link
 
     def section_name(self, lang=None):
@@ -805,11 +811,13 @@ class Post(object):
             pieces += [self.meta[lang]['slug'] + extension]
         pieces = [_f for _f in pieces if _f and _f != '.']
         link = '/' + '/'.join(pieces)
-        if absolute:
-            link = urljoin(self.base_url, link[1:])
         index_len = len(self.index_file)
         if self.strip_indexes and link[-(1 + index_len):] == '/' + self.index_file:
             link = link[:-index_len]
+        if self.config['USE_URLENCODING']:
+            link = quote(link.encode('utf-8'))
+        if absolute:
+            link = urljoin(self.base_url, link[1:])
         if query:
             link = link + "?" + query
         return link


### PR DESCRIPTION
This PR allow to use characters not permitted in URL. For example, in the case of tag, category and author not sluged appear in a generated path.