### PR TITLE
Fixing atom feed renderer for empty post lists.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1822,7 +1822,7 @@ class Nikola(object):
         feed_id = lxml.etree.SubElement(feed_root, "id")
         feed_id.text = self.abs_link(context["feedlink"])
         feed_updated = lxml.etree.SubElement(feed_root, "updated")
-        feed_updated.text = post.formatted_date('webiso', datetime.datetime.now(tz=dateutil.tz.tzutc()))
+        feed_updated.text = utils.formatted_date('webiso', datetime.datetime.now(tz=dateutil.tz.tzutc()))
         feed_author = lxml.etree.SubElement(feed_root, "author")
         feed_author_name = lxml.etree.SubElement(feed_author, "name")
         feed_author_name.text = self.config["BLOG_AUTHOR"](lang)

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -56,7 +56,6 @@ from math import ceil
 # for tearDown with _reload we cannot use 'from import' to get forLocaleBorg
 import nikola.utils
 from .utils import (
-    bytes_str,
     current_time,
     Functionary,
     LOGGER,
@@ -324,19 +323,7 @@ class Post(object):
 
     def formatted_date(self, date_format, date=None):
         """Return the formatted date as unicode."""
-        date = date if date else self.date
-
-        if date_format == 'webiso':
-            # Formatted after RFC 3339 (web ISO 8501 profile) with Zulu
-            # zone desgignator for times in UTC and no microsecond precision.
-            fmt_date = date.replace(microsecond=0).isoformat().replace('+00:00', 'Z')
-        else:
-            fmt_date = date.strftime(date_format)
-
-        # Issue #383, this changes from py2 to py3
-        if isinstance(fmt_date, bytes_str):
-            fmt_date = fmt_date.decode('utf8')
-        return fmt_date
+        return utils.formatted_date(date_format, date if date else self.date)
 
     def formatted_updated(self, date_format):
         """Return the updated date as unicode."""

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -71,7 +71,7 @@ __all__ = ('CustomEncoder', 'get_theme_path', 'get_theme_chain', 'load_messages'
            'adjust_name_for_index_path', 'adjust_name_for_index_link',
            'NikolaPygmentsHTML', 'create_redirect', 'TreeNode',
            'flatten_tree_structure', 'parse_escaped_hierarchical_category_name',
-           'join_hierarchical_category_path', 'indent')
+           'join_hierarchical_category_path', 'indent', 'formatted_date')
 
 # Are you looking for 'generic_rss_renderer'?
 # It's defined in nikola.nikola.Nikola (the site object).
@@ -1732,3 +1732,18 @@ def indent(text, prefix, predicate=None):
         for line in text.splitlines(True):
             yield (prefix + line if predicate(line) else line)
     return ''.join(prefixed_lines())
+
+
+def formatted_date(date_format, date):
+    """Return the formatted date as unicode."""
+    if date_format == 'webiso':
+        # Formatted after RFC 3339 (web ISO 8501 profile) with Zulu
+        # zone desgignator for times in UTC and no microsecond precision.
+        fmt_date = date.replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+    else:
+        fmt_date = date.strftime(date_format)
+
+    # Issue #383, this changes from py2 to py3
+    if isinstance(fmt_date, bytes_str):
+        fmt_date = fmt_date.decode('utf8')
+    return fmt_date


### PR DESCRIPTION
When the atom feed renderer is called with a empty `post` list, it crashes with an exception as it tries to call `formatted_date` of the last `post` object. Since it doesn't care about the `post` object, I moved most of the code of `Post.formatted_date` to `utils` and left a wrapper in `Post` which substitutes the post's date if it wasn't given.