### PR TITLE
Avoiding Nikola trying to cache posts which aren't written anyway.

### DIFF
--- a/nikola/plugins/task/posts.py
+++ b/nikola/plugins/task/posts.py
@@ -77,6 +77,8 @@ class RenderPosts(Task):
             deps_dict = copy(kw)
             deps_dict.pop('timeline')
             for post in kw['timeline']:
+                if not post.is_translation_available(lang) and not self.site.config['SHOW_UNTRANSLATED_POSTS']:
+                    return
                 # Extra config dependencies picked from config
                 for p in post.fragment_deps(lang):
                     if p.startswith('####MAGIC####CONFIG:'):

--- a/nikola/plugins/task/posts.py
+++ b/nikola/plugins/task/posts.py
@@ -78,7 +78,7 @@ class RenderPosts(Task):
             deps_dict.pop('timeline')
             for post in kw['timeline']:
                 if not post.is_translation_available(lang) and not self.site.config['SHOW_UNTRANSLATED_POSTS']:
-                    return
+                    continue
                 # Extra config dependencies picked from config
                 for p in post.fragment_deps(lang):
                     if p.startswith('####MAGIC####CONFIG:'):


### PR DESCRIPTION
If `SHOW_UNTRANSLATED_POSTS` is set to `False` and a post's translation doesn't exist, Nikola nonetheless tries to create the cached post every time `nikola build` is run. Since it never creates it anyway (as it notices that the translation isn't available and `SHOW_UNTRANSLATED_POSTS` is set to `False` -- there's identical code to the one I inserted in `Post.compile` which simply returns in this condition), there's no need to schedule a task for it.