### PR TITLE
Fix #1605

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Support SVG in galleries (Issue #1605)
 * Allow inheriting templates with theme name (Issue #1814)
 * Made TAG_PATH translatable (Issue #1914)
 * Made CATEGORY_PATH translatable (Issue #1914)

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -52,7 +52,7 @@ class ImageProcessor(object):
 
     def resize_image(self, src, dst, max_size, bigger_panoramas=True):
         """Make a copy of the image in the requested size."""
-        if not Image:
+        if not Image or os.path.splitext(src)[1] in ['.svg', '.svgz']:
             utils.copy_file(src, dst)
             return
         im = Image.open(src)

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -563,9 +563,12 @@ class Galleries(Task, ImageProcessor):
         for img, thumb, title in zip(img_list, thumbs, img_titles):
             w, h = _image_size_cache.get(thumb, (None, None))
             if w is None:
-                im = Image.open(thumb)
-                w, h = im.size
-                _image_size_cache[thumb] = w, h
+                if os.path.splitext(thumb)[1] in ['.svg', '.svgz']:
+                    w, h = 200, 200
+                else:
+                    im = Image.open(thumb)
+                    w, h = im.size
+                    _image_size_cache[thumb] = w, h
             # Thumbs are files in output, we need URLs
             photo_array.append({
                 'url': url_from_path(img),


### PR DESCRIPTION
This makes SVG images in galleries work.

The images appear with the correct aspect ratio, but letterboxed in a square on the gallery layout, which may not be PERFECT but it's not bad.