### PR TITLE
Making path handlers of indexes plugin work before get_tasks() is run.

### DIFF
--- a/nikola/plugins/task/indexes.py
+++ b/nikola/plugins/task/indexes.py
@@ -55,12 +55,18 @@ class Indexes(Task):
         return super(Indexes, self).set_site(site)
 
     def _get_filtered_posts(self, lang, show_untranslated_posts):
+        """Return a filtered list of all posts for the given language.
+
+        If show_untranslated_posts is True, will only include posts which
+        are translated to the given language. Otherwise, returns all posts.
+        """
         if show_untranslated_posts:
             return self.site.posts
         else:
             return [x for x in self.site.posts if x.is_translation_available(lang)]
 
     def _compute_number_of_pages(self, filtered_posts, posts_count):
+        """Given a list of posts and the maximal number of posts per page, computes the number of pages needed."""
         return min(1, (len(filtered_posts) + posts_count - 1) // posts_count)
 
     def gen_tasks(self):
@@ -242,7 +248,7 @@ class Indexes(Task):
                                                                     self.site.config['INDEX_PATH'],
                                                                     index_file] if _f],
                                                      name,
-                                                     utils.get_displayed_page_number(name, self.number_of_pages, self.site),
+                                                     utils.get_displayed_page_number(name, number_of_pages, self.site),
                                                      lang,
                                                      self.site,
                                                      extension=extension)

--- a/nikola/plugins/task/indexes.py
+++ b/nikola/plugins/task/indexes.py
@@ -83,7 +83,6 @@ class Indexes(Task):
         }
 
         template_name = "index.tmpl"
-        posts = self.site.posts
         for lang in kw["translations"]:
             def page_link(i, displayed_i, num_pages, force_addition, extension=None):
                 feed = "_atom" if extension == ".atom" else ""
@@ -265,7 +264,7 @@ class Indexes(Task):
         if name in self.number_of_pages_section[lang]:
             number_of_pages = self.number_of_pages_section[lang][name]
         else:
-            posts = [post for post in self._get_filtered_posts(lang, self.site.config['SHOW_UNTRANSLATED_POSTS']) if p.section_slug(lang) == name]
+            posts = [post for post in self._get_filtered_posts(lang, self.site.config['SHOW_UNTRANSLATED_POSTS']) if post.section_slug(lang) == name]
             number_of_pages = self._compute_number_of_pages(posts, self.site.config['INDEX_DISPLAY_POST_COUNT'])
             self.number_of_pages_section[lang][name] = number_of_pages
         return utils.adjust_name_for_index_path_list([_f for _f in [self.site.config['TRANSLATIONS'][lang],

--- a/nikola/plugins/task/indexes.py
+++ b/nikola/plugins/task/indexes.py
@@ -54,11 +54,11 @@ class Indexes(Task):
         site.register_path_handler('section_index_atom', self.index_section_atom_path)
         return super(Indexes, self).set_site(site)
 
-    def _get_filtered_posts(self, language, show_untranslated_posts):
+    def _get_filtered_posts(self, lang, show_untranslated_posts):
         if show_untranslated_posts:
             return self.site.posts
         else:
-            return [x for x in self.site.posts if x.is_translation_available(language)]
+            return [x for x in self.site.posts if x.is_translation_available(lang)]
 
     def _compute_number_of_pages(self, filtered_posts, posts_count):
         return min(1, (len(filtered_posts) + posts_count - 1) // posts_count)
@@ -95,7 +95,7 @@ class Indexes(Task):
                 return utils.adjust_name_for_index_path(self.site.path("index" + feed, None, lang), i, displayed_i,
                                                         lang, self.site, force_addition, extension)
 
-            filtered_posts = self._get_filtered_posts(language, kw["show_untranslated_posts"])
+            filtered_posts = self._get_filtered_posts(lang, kw["show_untranslated_posts"])
 
             indexes_title = kw['indexes_title'](lang) or kw['blog_title'](lang)
             self.number_of_pages[lang] = self._compute_number_of_pages(filtered_posts, kw['index_display_post_count'])


### PR DESCRIPTION
Fixes #2040.