### PR TITLE
Fix #2079 - slash caused task conflict on Windows

### DIFF
--- a/nikola/post.py
+++ b/nikola/post.py
@@ -769,7 +769,7 @@ class Post(object):
 
         if not self.config['POSTS_SECTION_FROM_META']:
             dest = self.destination_path(lang)
-            if dest[-(1 + len(self.index_file)):] == '/' + self.index_file:
+            if dest[-(1 + len(self.index_file)):] == os.sep + self.index_file:
                 dest = dest[:-(1 + len(self.index_file))]
             dirname = os.path.dirname(dest)
             slug = dest.split(os.sep)


### PR DESCRIPTION
One-line fix for  #2079 (proposed by @felixfontein).

Problem summary:

```
ERROR: 'output\posts\math-test-new\index.html' is a target for 
render_indexes:output\posts\math-test-new\index.html and 
render_pages:output\posts\math-test-new\index.html
```
