### PR TITLE
Fix #2094 - scaling and colorbox of SVG thumbnails

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -106,3 +106,4 @@
 * `yarko <https://github.com/yarko>`_
 * `小明 <https://github.com/dongweiming>`_
 * `Brad Miller <https://github.com/bnmnetp>`_
+* `Florian Finkernagel <https://github.com/TyberiusPrime>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Bugfixes
 --------
 
 * /robots.txt was never being built (Issue #2098)
+* SVG thumbnails (Issue #2094)
 
 New in v7.7.1
 =============

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -94,6 +94,7 @@ class ImageProcessor(object):
             utils.copy_file(src, dst)
 
     def resize_svg(self, src, dst, max_size, bigger_panoramas):
+        """Make a copy of an svg at the requested size"""
         try:
             # Resize svg based on viewport hacking.
             # note that this can also lead to enlarged svgs

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -121,10 +121,10 @@ class ImageProcessor(object):
                 h = max_size
             w = int(w)
             h = int(h)
-            tree.attrib['width'] = "%ipx" % w
-            tree.attrib['height'] = "%ipx" % h
+            tree.attrib.pop("width")
+            tree.attrib.pop("height")
             tree.attrib['viewport'] = "0 0 %ipx %ipx" % (w, h)
-            if dst.endswith('.tgz'):
+            if dst.endswith('.svgz'):
                 op = gzip.GzipFile(dst, 'w')
             else:
                 op = open(dst, 'w')

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -56,7 +56,7 @@ class ImageProcessor(object):
     def resize_image(self, src, dst, max_size, bigger_panoramas=True):
         """Make a copy of the image in the requested size."""
         if not Image or os.path.splitext(src)[1] in ['.svg', '.svgz']:
-            self.resize_svg(src, dst,  max_size, bigger_panoramas)
+            self.resize_svg(src, dst, max_size, bigger_panoramas)
             return
         im = Image.open(src)
         w, h = im.size
@@ -109,7 +109,7 @@ class ImageProcessor(object):
             height = tree.attrib['height']
             w = int(re.search("[0-9]+", width).group(0))
             h = int(re.search("[0-9]+", height).group(0))
-            #calculate new size preserving aspect ratio.
+            # calculate new size preserving aspect ratio.
             ratio = float(w) / h
             # Panoramas get larger thumbnails because they look *awful*
             if bigger_panoramas and w > 2 * h:
@@ -132,7 +132,7 @@ class ImageProcessor(object):
             op.write(lxml.etree.tostring(tree))
             op.close()
         except (KeyError, AttributeError) as e:
-            self.logger.warn("No width/height in %s" % src)
+            self.logger.warn("No width/height in %s. Actuall exception: %s" % (src, e))
             utils.copy_file(src, dst)
 
     def image_date(self, src):

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -94,7 +94,7 @@ class ImageProcessor(object):
             utils.copy_file(src, dst)
 
     def resize_svg(self, src, dst, max_size, bigger_panoramas):
-        """Make a copy of an svg at the requested size"""
+        """Make a copy of an svg at the requested size."""
         try:
             # Resize svg based on viewport hacking.
             # note that this can also lead to enlarged svgs

--- a/nikola/plugins/compile/rest/thumbnail.py
+++ b/nikola/plugins/compile/rest/thumbnail.py
@@ -72,9 +72,9 @@ class Thumbnail(Figure):
         uri = directives.uri(self.arguments[0])
         if uri.endswith('.svg'):
             # the ? at the end makes docutil output an <img> instead of an object for the svg, which colorbox requires
-            self.arguments[0] = '.thumbnail'.join(os.path.splitext(uri)) + '?' 
+            self.arguments[0] = '.thumbnail'.join(os.path.splitext(uri)) + '?'
         else:
-            self.arguments[0] = '.thumbnail'.join(os.path.splitext(uri)) 
+            self.arguments[0] = '.thumbnail'.join(os.path.splitext(uri))
         self.options['target'] = uri
         if self.content:
             (node,) = Figure.run(self)

--- a/nikola/plugins/compile/rest/thumbnail.py
+++ b/nikola/plugins/compile/rest/thumbnail.py
@@ -70,8 +70,12 @@ class Thumbnail(Figure):
     def run(self):
         """Run the thumbnail directive."""
         uri = directives.uri(self.arguments[0])
+        if uri.endswith('.svg'):
+            # the ? at the end makes docutil output an <img> instead of an object for the svg, which colorbox requires
+            self.arguments[0] = '.thumbnail'.join(os.path.splitext(uri)) + '?' 
+        else:
+            self.arguments[0] = '.thumbnail'.join(os.path.splitext(uri)) 
         self.options['target'] = uri
-        self.arguments[0] = '.thumbnail'.join(os.path.splitext(uri))
         if self.content:
             (node,) = Figure.run(self)
         else:


### PR DESCRIPTION
This change rescales SVGs by manipulating their width, height and viewport.
It extracts width and height from the parse tree, throws away the units, calculates aspect ratio
and rewrites them accordingly in px.

To enable colorbox-functionality for SVG thumbnails, the thumbnail plugin confuses docutils
to treat svgs like other images by appending a '?' to the uri.