### PR TITLE
Fix site menu (don’t escape HTML in navbar)

### DIFF
--- a/nikola/data/themes/base-jinja/templates/author.tmpl
+++ b/nikola/data/themes/base-jinja/templates/author.tmpl
@@ -18,7 +18,7 @@
     <header>
         <h1>{{ title|e }}</h1>
         {% if description %}
-        <p>{{ description|e }}</p>
+        <p>{{ description }}</p>
         {% endif %}
         <div class="metadata">
             {% if translations|length > 1 and generate_rss %}

--- a/nikola/data/themes/base-jinja/templates/base_header.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_header.tmpl
@@ -32,7 +32,7 @@
     <ul>
     {% for url, text in navigation_links[lang] %}
         {% if isinstance(url, tuple) %}
-            <li> {{ text|e }}
+            <li> {{ text }}
             <ul>
             {% for suburl, text in url %}
                 {% if rel_link(permalink, suburl) == "#" %}

--- a/nikola/data/themes/base-jinja/templates/base_header.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_header.tmpl
@@ -36,17 +36,17 @@
             <ul>
             {% for suburl, text in url %}
                 {% if rel_link(permalink, suburl) == "#" %}
-                    <li class="active"><a href="{{ permalink }}">{{ text|e }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a></li>
+                    <li class="active"><a href="{{ permalink }}">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a></li>
                 {% else %}
-                    <li><a href="{{ suburl }}">{{ text|e }}</a></li>
+                    <li><a href="{{ suburl }}">{{ text }}</a></li>
                 {% endif %}
             {% endfor %}
             </ul>
         {% else %}
             {% if rel_link(permalink, url) == "#" %}
-                <li class="active"><a href="{{ permalink }}">{{ text|e }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a></li>
+                <li class="active"><a href="{{ permalink }}">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a></li>
             {% else %}
-                <li><a href="{{ url }}">{{ text|e }}</a></li>
+                <li><a href="{{ url }}">{{ text }}</a></li>
             {% endif %}
         {% endif %}
     {% endfor %}

--- a/nikola/data/themes/base-jinja/templates/index.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index.tmpl
@@ -20,7 +20,7 @@
         <div class="metadata">
             <p class="byline author vcard"><span class="byline-name fn">
             {% if author_pages_generated %}
-                <a href="{{ _link('author', post.author()) }}">{{ post.author() }}</a>
+                <a href="{{ _link('author', post.author()) }}">{{ post.author()|e }}</a>
             {% else %}
                 {{ post.author()|e }}
             {% endif %}

--- a/nikola/data/themes/base-jinja/templates/tag.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tag.tmpl
@@ -18,7 +18,7 @@
     <header>
         <h1>{{ title|e }}</h1>
         {% if description %}
-        <p>{{ description|e }}</p>
+        <p>{{ description }}</p>
         {% endif %}
         {% if subcategories %}
         {{ messages('Subcategories:') }}

--- a/nikola/data/themes/base/templates/author.tmpl
+++ b/nikola/data/themes/base/templates/author.tmpl
@@ -18,7 +18,7 @@
     <header>
         <h1>${title|h}</h1>
         %if description:
-        <p>${description|h}</p>
+        <p>${description}</p>
         %endif
         <div class="metadata">
             %if len(translations) > 1 and generate_rss:

--- a/nikola/data/themes/base/templates/base_header.tmpl
+++ b/nikola/data/themes/base/templates/base_header.tmpl
@@ -36,17 +36,17 @@
             <ul>
             %for suburl, text in url:
                 % if rel_link(permalink, suburl) == "#":
-                    <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a></li>
+                    <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a></li>
                 %else:
-                    <li><a href="${suburl}">${text|h}</a></li>
+                    <li><a href="${suburl}">${text}</a></li>
                 %endif
             %endfor
             </ul>
         % else:
             % if rel_link(permalink, url) == "#":
-                <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a></li>
+                <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a></li>
             %else:
-                <li><a href="${url}">${text|h}</a></li>
+                <li><a href="${url}">${text}</a></li>
             %endif
         % endif
     %endfor

--- a/nikola/data/themes/base/templates/base_header.tmpl
+++ b/nikola/data/themes/base/templates/base_header.tmpl
@@ -32,7 +32,7 @@
     <ul>
     %for url, text in navigation_links[lang]:
         % if isinstance(url, tuple):
-            <li> ${text|h}
+            <li> ${text}
             <ul>
             %for suburl, text in url:
                 % if rel_link(permalink, suburl) == "#":

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -20,7 +20,7 @@
         <div class="metadata">
             <p class="byline author vcard"><span class="byline-name fn">
             % if author_pages_generated:
-                <a href="${_link('author', post.author())}">${post.author()}</a>
+                <a href="${_link('author', post.author())}">${post.author()|h}</a>
             % else:
                 ${post.author()|h}
             % endif

--- a/nikola/data/themes/base/templates/tag.tmpl
+++ b/nikola/data/themes/base/templates/tag.tmpl
@@ -18,7 +18,7 @@
     <header>
         <h1>${title|h}</h1>
         %if description:
-        <p>${description|h}</p>
+        <p>${description}</p>
         %endif
         %if subcategories:
         ${messages('Subcategories:')}

--- a/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
@@ -135,7 +135,7 @@ lang="{{ lang }}">
 {% macro html_navigation_links() %}
     {% for url, text in navigation_links[lang] %}
         {% if isinstance(url, tuple) %}
-            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ text|e }} <b class="caret"></b></a>
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ text }} <b class="caret"></b></a>
             <ul class="dropdown-menu">
             {% for suburl, text in url %}
                 {% if rel_link(permalink, suburl) == "#" %}

--- a/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
@@ -139,17 +139,17 @@ lang="{{ lang }}">
             <ul class="dropdown-menu">
             {% for suburl, text in url %}
                 {% if rel_link(permalink, suburl) == "#" %}
-                    <li class="active"><a href="{{ permalink }}">{{ text|e }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
+                    <li class="active"><a href="{{ permalink }}">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
                 {% else %}
-                    <li><a href="{{ suburl }}">{{ text|e }}</a>
+                    <li><a href="{{ suburl }}">{{ text }}</a>
                 {% endif %}
             {% endfor %}
             </ul>
         {% else %}
             {% if rel_link(permalink, url) == "#" %}
-                <li class="active"><a href="{{ permalink }}">{{ text|e }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
+                <li class="active"><a href="{{ permalink }}">{{ text }} <span class="sr-only">{{ messages("(active)", lang) }}</span></a>
             {% else %}
-                <li><a href="{{ url }}">{{ text|e }}</a>
+                <li><a href="{{ url }}">{{ text }}</a>
             {% endif %}
         {% endif %}
     {% endfor %}

--- a/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
@@ -139,17 +139,17 @@ lang="${lang}">
             <ul class="dropdown-menu">
             %for suburl, text in url:
                 % if rel_link(permalink, suburl) == "#":
-                    <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a>
+                    <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a>
                 %else:
-                    <li><a href="${suburl}">${text|h}</a>
+                    <li><a href="${suburl}">${text}</a>
                 %endif
             %endfor
             </ul>
         % else:
             % if rel_link(permalink, url) == "#":
-                <li class="active"><a href="${permalink}">${text|h} <span class="sr-only">${messages("(active)", lang)}</span></a>
+                <li class="active"><a href="${permalink}">${text} <span class="sr-only">${messages("(active)", lang)}</span></a>
             %else:
-                <li><a href="${url}">${text|h}</a>
+                <li><a href="${url}">${text}</a>
             %endif
         % endif
     %endfor

--- a/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
@@ -135,7 +135,7 @@ lang="${lang}">
 <%def name="html_navigation_links()">
     %for url, text in navigation_links[lang]:
         % if isinstance(url, tuple):
-            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${text|h} <b class="caret"></b></a>
+            <li class="dropdown"><a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">${text} <b class="caret"></b></a>
             <ul class="dropdown-menu">
             %for suburl, text in url:
                 % if rel_link(permalink, suburl) == "#":


### PR DESCRIPTION
This fixes the getnikola.com site menu by not escaping things in the navbar.

I also added one missing escape.  However, we could debate doing it for some places that also could use formatting, such as:

 * post titles (?)
 * tag and author descriptions (which are long-form fields — makes a lot of sense)

Comments?