### PR TITLE
Markdown support strikethrough by default

### DIFF
--- a/nikola/plugins/compile/markdown/mdx_nikola.py
+++ b/nikola/plugins/compile/markdown/mdx_nikola.py
@@ -24,21 +24,28 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Markdown Extension for Nikola-specific post-processing."""
+"""Markdown Extension for Nikola.
+
+- Specific post-processing.
+- Strikethrough inline patterns.
+"""
 
 from __future__ import unicode_literals
 import re
 try:
     from markdown.postprocessors import Postprocessor
+    from markdown.inlinepatterns import SimpleTagPattern
     from markdown.extensions import Extension
 except ImportError:
     # No need to catch this, if you try to use this without Markdown,
     # the markdown compiler will fail first
-    Postprocessor = Extension = object
+    Postprocessor = SimpleTagPattern = Extension = object
 
 from nikola.plugin_categories import MarkdownExtension
 
+
 CODERE = re.compile('<div class="codehilite"><pre>(.*?)</pre></div>', flags=re.MULTILINE | re.DOTALL)
+STRIKE_RE = r"(~{2})(.+?)(~{2})"  # ~~strike~~
 
 
 class NikolaPostProcessor(Postprocessor):
@@ -56,12 +63,22 @@ class NikolaPostProcessor(Postprocessor):
 
 
 class NikolaExtension(MarkdownExtension, Extension):
-    """Extension for injecting the postprocessor."""
+    """MNikola markdown extensions."""
 
-    def extendMarkdown(self, md, md_globals):
+    def _add_nikola_post_processor(self, md):
         """Extend Markdown with the postprocessor."""
         pp = NikolaPostProcessor()
         md.postprocessors.add('nikola_post_processor', pp, '_end')
+
+    def _add_strikethrough_inline_pattern(self, md):
+        """Support PHP-Markdown style strikethrough.For example: ``~~strike~~``."""
+        pattern = SimpleTagPattern(STRIKE_RE, 'del')
+        md.inlinePatterns.add('strikethrough', pattern, '_end')
+
+    def extendMarkdown(self, md, md_globals):
+        """Extend markdown to Nikola flavours."""
+        self._add_nikola_post_processor(md)
+        self._add_strikethrough_inline_pattern(md)
         md.registerExtension(self)
 
 

--- a/tests/test_compile_markdown.py
+++ b/tests/test_compile_markdown.py
@@ -61,6 +61,13 @@ class CompileMarkdownTests(BaseTestCase):
         actual_output = self.compile(input_str)
         self.assertEquals(actual_output.strip(), expected_output.strip())
 
+    def test_compile_strikethrough(self):
+        input_str = '~~strik text~~'
+        expected_output = '<p><del>strik text</del></p>'
+
+        actual_output = self.compile(input_str)
+        self.assertEquals(actual_output.strip(), expected_output.strip())
+
     def test_compile_html_gist(self):
         input_str = '''\
 Here's a gist file inline:


### PR DESCRIPTION
Now markdown supports PHP-Markdown style strikethrough by default.

For example: ``~~strike~~``.

Related to https://github.com/getnikola/plugins/pull/121#issuecomment-149302549

