### PR TITLE
Update ghp import

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -41,7 +41,7 @@ def task_locale():
             locales = []
             languages = set()
             for line in out.splitlines():
-                if line.endswith('.utf8') and '_' in line:
+                if (line.endswith('.utf8') or line.endswith('.UTF-8')) and '_' in line:
                     lang = line.split('_')[0]
                     if lang not in languages:
                         try:

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -8,6 +8,6 @@ typogrify>=2.0.4
 phpserialize>=1.3
 webassets>=0.10.1
 ipython[notebook]>=2.0.0
-ghp-import>=0.4.1
+ghp-import2>=1.0.0
 ws4py==0.3.4
 watchdog==0.8.3


### PR DESCRIPTION
In my use on OSX, python3, there were encoding issues in setup.py for the older ghp-import during pip install.   ghp-import2 is supposed to fix that and other packaging issues so I'm hoping you can upgrade.

I've made the appropriate change in requirements-extras.txt, and tried to run tests. I immediately hit a problem related to parsing the results of `locale -a`, which are different on OSX, so fixed that issue.

I see other test failures due to temporary directories ('/var/folders') and hyphenator. 

Can you test this PR in your environment, and merge it if it works for you.  Sorry, don't have time to fix anymore tests at the moment.