### PR TITLE
fix #2146

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 New in Master
 =============
 
+Features
+--------
+
+* Automatically open gallery images colorbox based on URL fragment (Issue #2146)
+
 Bugfixes
 --------
 

--- a/nikola/data/themes/bootstrap3/templates/gallery.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/gallery.tmpl
@@ -90,5 +90,6 @@ $("#gallery_container").flowr({
         }
     });
 $("a.image-reference").colorbox({rel:"gal", maxWidth:"100%",maxHeight:"100%",scalePhotos:true});
+$('a.image-reference[href="'+window.location.hash.substring(1,1000)+'"]').click();
 </script>
 </%block>


### PR DESCRIPTION
If there is a ```foo.jpg``` in the gallery at ```/galleries/bar``` then ```galleries/bar#foo.jpg``` will open with that image's colorbox open.