### PR TITLE
Completely rewrote shortcode parser.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1316,9 +1316,9 @@ class Nikola(object):
             return
         self.shortcode_registry[name] = f
 
-    def apply_shortcodes(self, data):
+    def apply_shortcodes(self, data, filename=None):
         """Apply shortcodes from the registry on data."""
-        return shortcodes.apply_shortcodes(data, self.shortcode_registry)
+        return shortcodes.apply_shortcodes(data, self.shortcode_registry, self, filename)
 
     def generic_rss_renderer(self, lang, title, link, description, timeline, output_path,
                              rss_teasers, rss_plain, feed_length=10, feed_url=None,

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -76,7 +76,7 @@ class CompileMarkdown(PageCompiler):
             if not is_two_file:
                 _, data = self.split_metadata(data)
             output = markdown(data, self.extensions)
-            output = apply_shortcodes(output, self.site.shortcode_registry, self.site)
+            output = apply_shortcodes(output, self.site.shortcode_registry, self.site, source)
             out_file.write(output)
 
     def create_post(self, path, **kw):

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -245,7 +245,7 @@ def _split_shortcodes(data):
     return result
 
 
-def apply_shortcodes(data, registry, site=None):
+def apply_shortcodes(data, registry, site=None, filename=None):
     """Apply Hugo-style shortcodes on data.
 
     {{% name parameters %}} will end up calling the registered "name" function with the given parameters.
@@ -303,5 +303,5 @@ def apply_shortcodes(data, registry, site=None):
                 result.append(res)
         return empty_string.join(result)
     except ParsingError as e:
-        LOGGER.error("{0}".format(e))
+        LOGGER.error("Shortcode error in file {0}: {1}".format(filename, e))
         sys.exit(1)

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -186,7 +186,10 @@ def _parse_shortcode_args(data, start, shortcode_name, start_pos):
         try:
             pos = _skip_whitespace(data, pos, must_be_nontrivial=True)
         except ParsingError:
-            raise ParsingError("Shortcode '{0}' starting at {1} is not terminated correctly with '%}}}}'!".format(shortcode_name, _format_position(data, start_pos)))
+            if not args and not kwargs:
+                raise ParsingError("Shortcode '{0}' starting at {1} is not terminated correctly with '%}}}}'!".format(shortcode_name, _format_position(data, start_pos)))
+            else:
+                raise ParsingError("Syntax error in shortcode '{0}' at {1}: expecting whitespace!".format(shortcode_name, _format_position(data, pos)))
         if pos == len(data):
             break
         # Check for end of shortcode

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -258,6 +258,7 @@ def apply_shortcodes(data, registry, site=None):
     >>> apply_shortcodes('==> {{% foo bar=baz %}}some data{{% /foo %}} <==', {'foo': lambda *a, **k: k['bar']+k['data']})
     '==> bazsome data <=='
     """
+    empty_string = data[:0]  # same string type as data; to make Python 2 happy
     try:
         # Split input data into text, shortcodes and shortcode endings
         sc_data = _split_shortcodes(data)
@@ -284,7 +285,7 @@ def apply_shortcodes(data, registry, site=None):
                     data_arg = []
                     for p in range(pos + 1, found):
                         data_arg.append(sc_data[p][1])
-                    data_arg = u''.join(data_arg)
+                    data_arg = empty_string.join(data_arg)
                     pos = found + 1
                 else:
                     # Single shortcode
@@ -299,7 +300,7 @@ def apply_shortcodes(data, registry, site=None):
                     LOGGER.error('Unknown shortcode {0} (started at {1})', name, _format_position(data, current[2]))
                     res = ''
                 result.append(res)
-        return u''.join(result)
+        return empty_string.join(result)
     except ParsingError as e:
         LOGGER.error("{0}".format(e))
         sys.exit(1)

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -254,10 +254,10 @@ def apply_shortcodes(data, registry, site=None, filename=None):
 
     The site parameter is passed with the same name to the shortcodes so they can access Nikola state.
 
-    >>> apply_shortcodes('==> {{% foo bar=baz %}} <==', {'foo': lambda *a, **k: k['bar']})
-    '==> baz <=='
-    >>> apply_shortcodes('==> {{% foo bar=baz %}}some data{{% /foo %}} <==', {'foo': lambda *a, **k: k['bar']+k['data']})
-    '==> bazsome data <=='
+    >>> print(apply_shortcodes('==> {{% foo bar=baz %}} <==', {'foo': lambda *a, **k: k['bar']}))
+    ==> baz <==
+    >>> print(apply_shortcodes('==> {{% foo bar=baz %}}some data{{% /foo %}} <==', {'foo': lambda *a, **k: k['bar']+k['data']}))
+    ==> bazsome data <==
     """
     empty_string = data[:0]  # same string type as data; to make Python 2 happy
     try:

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -284,7 +284,7 @@ def apply_shortcodes(data, registry, site=None):
                     data_arg = []
                     for p in range(pos + 1, found):
                         data_arg.append(sc_data[p][1])
-                    data_arg = ''.join(data_arg)
+                    data_arg = u''.join(data_arg)
                     pos = found + 1
                 else:
                     # Single shortcode
@@ -299,7 +299,7 @@ def apply_shortcodes(data, registry, site=None):
                     LOGGER.error('Unknown shortcode {0} (started at {1})', name, _format_position(data, current[2]))
                     res = ''
                 result.append(res)
-        return ''.join(result)
+        return u''.join(result)
     except ParsingError as e:
         LOGGER.error("{0}".format(e))
         sys.exit(1)

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -184,7 +184,7 @@ def _parse_shortcode_args(data, start, name, start_pos):
         if pos == len(data):
             break
         # Check for end of shortcode
-        if pos + 3 < len(data) and data[pos:pos + 3] == '%}}':
+        if pos + 3 <= len(data) and data[pos:pos + 3] == '%}}':
             return pos + 3, (args, kwargs)
         # Read name
         pos, name, next_is_equals = _parse_string(data, pos, stop_at_equals=True, must_have_content=True)

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -162,7 +162,7 @@ def _parse_string(data, start, stop_at_equals=False, must_have_content=False):
         end, value = _parse_unquoted_string(data, start, stop_at_equals)
         has_content = len(value) > 0
     if must_have_content and not has_content:
-        raise ParsingError("String starting at {0} must have non-trivial length!".format(_format_position(data, start)))
+        raise ParsingError("String starting at {0} must be non-empty!".format(_format_position(data, start)))
 
     next_is_equals = False
     if stop_at_equals and end + 1 < len(data):

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -44,7 +44,10 @@ class ParsingError(Exception):
 
 
 def _format_position(data, pos):
-    """Return position formatted as line/column."""
+    """Return position formatted as line/column.
+
+    This is used for prettier error messages.
+    """
     line = 0
     col = 0
     llb = ''  # last line break

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -26,6 +26,7 @@
 
 """Support for Hugo-style shortcodes."""
 
+from __future__ import unicode_literals
 from .utils import LOGGER
 import sys
 

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -303,5 +303,8 @@ def apply_shortcodes(data, registry, site=None, filename=None):
                 result.append(res)
         return empty_string.join(result)
     except ParsingError as e:
-        LOGGER.error("Shortcode error in file {0}: {1}".format(filename, e))
+        if filename:
+            LOGGER.error("Shortcode error in file {0}: {1}".format(filename, e))
+        else:
+            LOGGER.error("Shortcode error: {0}".format(e))
         sys.exit(1)

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -170,7 +170,7 @@ def _parse_string(data, start, stop_at_equals=False, must_have_content=False):
     return end, value, next_is_equals
 
 
-def _parse_shortcode_args(data, start, name, start_pos):
+def _parse_shortcode_args(data, start, shortcode_name, start_pos):
     """When pointed to after a shortcode's name in a shortcode tag, parses the shortcode's arguments until '%}}'.
 
     Returns the position after '%}}', followed by a tuple (args, kw).
@@ -183,7 +183,10 @@ def _parse_shortcode_args(data, start, name, start_pos):
     pos = start
     while True:
         # Skip whitespaces
-        pos = _skip_whitespace(data, pos, must_be_nontrivial=True)
+        try:
+            pos = _skip_whitespace(data, pos, must_be_nontrivial=True)
+        except ParsingError:
+            raise ParsingError("Shortcode '{0}' starting at {1} is not terminated correctly with '%}}}}'!".format(shortcode_name, _format_position(data, start_pos)))
         if pos == len(data):
             break
         # Check for end of shortcode
@@ -200,7 +203,7 @@ def _parse_shortcode_args(data, start, name, start_pos):
             # Store positional argument
             args.append(name)
 
-    raise ParsingError("Shortcode '{0}' starting at {1} is not terminated correctly with '%}}}}'!".format(name, _format_position(data, start_pos)))
+    raise ParsingError("Shortcode '{0}' starting at {1} is not terminated correctly with '%}}}}'!".format(shortcode_name, _format_position(data, start_pos)))
 
 
 def _split_shortcodes(data):
@@ -230,7 +233,7 @@ def _split_shortcodes(data):
         name_end = _skip_nonwhitespace(data, name_start)
         name = data[name_start:name_end]
         if not name:
-            raise ParsingError("Syntax error: '{{{{%' must be followed by shortcode name ({1})!".format(_format_position(data, start)))
+            raise ParsingError("Syntax error: '{{{{%' must be followed by shortcode name ({0})!".format(_format_position(data, start)))
         # Finish shortcode
         if name[0] == '/':
             # This is a closing shortcode

--- a/tests/test_shortcodes.py
+++ b/tests/test_shortcodes.py
@@ -62,7 +62,7 @@ class TestErrors(BaseTestCase):
         self.assertRaisesRegexp(shortcodes.ParsingError, "^Syntax error in shortcode 'wrong' at .*: expecting whitespace!", shortcodes.apply_shortcodes, '{{% wrong ending %%}', self.fakesite.shortcode_registry, raise_exceptions=True)
         self.assertRaisesRegexp(shortcodes.ParsingError, "^Found shortcode ending '{{% /end %}}' which isn't closing a started shortcode", shortcodes.apply_shortcodes, '{{% start %}} {{% /end %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
         self.assertRaisesRegexp(shortcodes.ParsingError, "^Unexpected end of unquoted string", shortcodes.apply_shortcodes, '{{% start "asdf %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
-        self.assertRaisesRegexp(shortcodes.ParsingError, "^String starting at .* must have non-trivial length!", shortcodes.apply_shortcodes, '{{% start =b %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^String starting at .* must be non-empty!", shortcodes.apply_shortcodes, '{{% start =b %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
         self.assertRaisesRegexp(shortcodes.ParsingError, "^Unexpected end of data while escaping", shortcodes.apply_shortcodes, '{{% start "a\\', self.fakesite.shortcode_registry, raise_exceptions=True)
         self.assertRaisesRegexp(shortcodes.ParsingError, "^Unexpected end of data while escaping", shortcodes.apply_shortcodes, '{{% start a\\', self.fakesite.shortcode_registry, raise_exceptions=True)
         self.assertRaisesRegexp(shortcodes.ParsingError, "^Unexpected quotation mark in unquoted string", shortcodes.apply_shortcodes, '{{% start a"b" %}}', self.fakesite.shortcode_registry, raise_exceptions=True)

--- a/tests/test_shortcodes.py
+++ b/tests/test_shortcodes.py
@@ -6,7 +6,7 @@ u"""Test shortcodes."""
 from __future__ import unicode_literals
 import pytest
 from nikola import shortcodes
-from .base import FakeSite
+from .base import FakeSite, BaseTestCase
 import sys
 
 def noargs(site, data=''):
@@ -39,6 +39,7 @@ def test_arg_pos(fakesite):
     assert shortcodes.apply_shortcodes('test({{% arg 1 2aa %}})', fakesite.shortcode_registry) == "test(arg ('1', '2aa')/[]/)"
     assert shortcodes.apply_shortcodes('test({{% arg "hello world" %}})', fakesite.shortcode_registry) == "test(arg ('hello world',)/[]/)"
     assert shortcodes.apply_shortcodes('test({{% arg back\ slash arg2 %}})', fakesite.shortcode_registry) == "test(arg ('back slash', 'arg2')/[]/)"
+    assert shortcodes.apply_shortcodes('test({{% arg "%}}" %}})', fakesite.shortcode_registry) == "test(arg ('%}}',)/[]/)"
 
 def test_arg_keyword(fakesite):
     assert shortcodes.apply_shortcodes('test({{% arg 1a=2b %}})', fakesite.shortcode_registry) == "test(arg ()/[('1a', '2b')]/)"
@@ -50,3 +51,25 @@ def test_data(fakesite):
     assert shortcodes.apply_shortcodes('test({{% arg 123 456 foo=bar %}}Hello world!{{% /arg %}})', fakesite.shortcode_registry) == "test(arg ('123', '456')/[('foo', 'bar')]/Hello world!)"
     assert shortcodes.apply_shortcodes('test({{% arg 123 456 foo=bar baz="quotes rock." %}}Hello test suite!{{% /arg %}})', fakesite.shortcode_registry) == "test(arg ('123', '456')/[('baz', 'quotes rock.'), ('foo', 'bar')]/Hello test suite!)"
     assert shortcodes.apply_shortcodes('test({{% arg "123 foo" foobar foo=bar baz="quotes rock." %}}Hello test suite!!{{% /arg %}})', fakesite.shortcode_registry) == "test(arg ('123 foo', 'foobar')/[('baz', 'quotes rock.'), ('foo', 'bar')]/Hello test suite!!)"
+
+
+class TestErrors(BaseTestCase):
+    def setUp(self):
+        self.fakesite = fakesite()
+
+    def test_errors(self):
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Shortcode 'start' starting at .* is not terminated correctly with '%}}'!", shortcodes.apply_shortcodes, '{{% start', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Syntax error in shortcode 'wrong' at .*: expecting whitespace!", shortcodes.apply_shortcodes, '{{% wrong ending %%}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Found shortcode ending '{{% /end %}}' which isn't closing a started shortcode", shortcodes.apply_shortcodes, '{{% start %}} {{% /end %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Unexpected end of unquoted string", shortcodes.apply_shortcodes, '{{% start "asdf %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^String starting at .* must have non-trivial length!", shortcodes.apply_shortcodes, '{{% start =b %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Unexpected end of data while escaping", shortcodes.apply_shortcodes, '{{% start "a\\', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Unexpected end of data while escaping", shortcodes.apply_shortcodes, '{{% start a\\', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Unexpected quotation mark in unquoted string", shortcodes.apply_shortcodes, '{{% start a"b" %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Syntax error in shortcode 'start' at .*: expecting whitespace!", shortcodes.apply_shortcodes, '{{% start "a"b %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Syntax error: '{{%' must be followed by shortcode name", shortcodes.apply_shortcodes, '{{% %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Syntax error: '{{%' must be followed by shortcode name", shortcodes.apply_shortcodes, '{{%', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Syntax error: '{{%' must be followed by shortcode name", shortcodes.apply_shortcodes, '{{% ', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Found shortcode ending '{{% / %}}' which isn't closing a started shortcode", shortcodes.apply_shortcodes, '{{% / %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Syntax error: '{{% /' must be followed by ' %}}'", shortcodes.apply_shortcodes, '{{% / a %}}', self.fakesite.shortcode_registry, raise_exceptions=True)
+        self.assertRaisesRegexp(shortcodes.ParsingError, "^Shortcode '<==' starting at .* is not terminated correctly with '%}}'!", shortcodes.apply_shortcodes, '==> {{% <==', self.fakesite.shortcode_registry, raise_exceptions=True)


### PR DESCRIPTION
This PR fixes some shortcomings in the current shortcode parsers:

  * `{{% a "%}}" %}}` is parsed as expected;
  * better error messages are produced for various malformed situations;
  * no more infinite loops in cases such as `==> {{% <==`;
  * strange constructs such as `{{% a "b"c"d" %}}` aren't allowed anymore.
