### PR TITLE
Fix tag template (base and base-jinja)

### DIFF
--- a/nikola/data/themes/base-jinja/templates/tag.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tag.tmpl
@@ -43,7 +43,7 @@
     {% if posts %}
     <ul class="postlist">
     {% for post in posts %}
-        <li><time class="listdate" datetime="{{ post.formatted_date('webiso') }}" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time><a href="{{ post.permalink() }}" class="listtitle">{{ post.title()|e }}<a></li>
+		<li><a href="{{ post.permalink() }}" class="listtitle">{{ post.title()|e }}</a> <time class="listdate" datetime="{{ post.date.isoformat() }}" title="{{ post.formatted_date(date_format) }}">{{ post.formatted_date(date_format) }}</time></li>
     {% endfor %}
     </ul>
     {% endif %}

--- a/nikola/data/themes/base/templates/tag.tmpl
+++ b/nikola/data/themes/base/templates/tag.tmpl
@@ -43,7 +43,7 @@
     %if posts:
     <ul class="postlist">
     % for post in posts:
-        <li><time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time><a href="${post.permalink()}" class="listtitle">${post.title()|h}<a></li>
+		<li><a href="${post.permalink()}" class="listtitle">${post.title()|h}</a> <time class="listdate" datetime="${post.date.isoformat()}" title="${post.formatted_date(date_format)}">${post.formatted_date(date_format)}</time></li>
     % endfor
     </ul>
     %endif


### PR DESCRIPTION
Somehow this got broken in the past and now it doesn’t have the right
field order. It has to be first the post title and second, the date.