### PR TITLE
Fixing first part of #2220.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2200,7 +2200,7 @@ class Nikola(object):
 
     def __repr__(self):
         """Representation of a Nikola site."""
-        return '<Nikola Site: {0!r}>'.format(self.config['BLOG_TITLE']())
+        return '<Nikola Site: {0!r}>'.format(self.config['BLOG_TITLE'](self.config['DEFAULT_LANG']))
 
 
 def sanitized_locales(locale_fallback, locale_default, locales, translations):


### PR DESCRIPTION
Fixing `__repr__` representation of a Nikola site object so that the name doesn't depend on `LocaleBorg`'s current language.

Fixes first part of #2220.