### PR TITLE
Make authors plugin use a signal to avoid race conditions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,7 @@ Features
 Bugfixes
 --------
 
+* Avoid some random file rebuilds (Issue #2220)
 * Display tags and archives in a unified format, with the date on the
   left, instead of a misplaced dash in tags (Issue #2212)
 * Decide is_mathjax based on current language tags (Issue #2205)


### PR DESCRIPTION
Like @felixfontein suggested, a signal here so things are more consistent and we avoid part of #2220 