### PR TITLE
Don't crash on 'empty' wordpress posts (Issue #2263)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,7 @@ Bugfixes
 * Don’t display “Good link” messages in ``nikola check -l`` by default,
   can be re-enabled with ``-v`` option (Issue #2268)
 * Fix a format string in ``nikola check`` (Issue #2267)
+* Don't crash wordpress importer when posts are "empty" (Issue #2263)
 
 New in v7.7.6
 =============

--- a/nikola/plugins/basic_import.py
+++ b/nikola/plugins/basic_import.py
@@ -127,9 +127,12 @@ class ImportMixin(object):
     def write_content(cls, filename, content, rewrite_html=True):
         """Write content to file."""
         if rewrite_html:
-            doc = html.document_fromstring(content)
-            doc.rewrite_links(replacer)
-            content = html.tostring(doc, encoding='utf8')
+            try:
+                doc = html.document_fromstring(content)
+                doc.rewrite_links(replacer)
+                content = html.tostring(doc, encoding='utf8')
+            except etree.ParserError:
+                content = content.encode('utf-8')
         else:
             content = content.encode('utf-8')
 


### PR DESCRIPTION
Fix #2263