### PR TITLE
Fix #2289

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,7 @@ Bugfixes
 * Don’t display “Good link” messages in ``nikola check -l`` by default,
   can be re-enabled with ``-v`` option (Issue #2268)
 * Fix a format string in ``nikola check`` (Issue #2267)
+* Don't put untranslated and nonexistant posts in sitemap (Issue #2289)
 
 New in v7.7.6
 =============

--- a/nikola/plugins/task/sitemap/__init__.py
+++ b/nikola/plugins/task/sitemap/__init__.py
@@ -158,7 +158,7 @@ class Sitemap(LateTask):
                         continue
                     alternates = []
                     if post:
-                        for lang in kw['translations']:
+                        for lang in post.translated_to:
                             alt_url = post.permalink(lang=lang, absolute=True)
                             if encodelink(loc) == alt_url:
                                 continue
@@ -215,7 +215,7 @@ class Sitemap(LateTask):
                         loc = urljoin(base_url, base_path + path)
                         alternates = []
                         if post:
-                            for lang in kw['translations']:
+                            for lang in post.translated_to:
                                 alt_url = post.permalink(lang=lang, absolute=True)
                                 if encodelink(loc) == alt_url:
                                     continue


### PR DESCRIPTION
Change how sitemap alternates are generated. Suppose there is a site with en / es translations, and a post with only "en" version.

If SHOW_UNTRANSLATED, because we have a spanish version file, even if untranslated:

```xml
 <url>
  <loc>https://example.com/es/posts/foo.html</loc>
  <lastmod>2016-03-07T13:35:00Z</lastmod>
  <xhtml:link rel="alternate" hreflang="en" href="https://example.com/posts/foo.html" />
 </url>
 <url>
  <loc>https://example.com/posts/foo.html</loc>
  <lastmod>2016-03-07T13:35:00Z</lastmod>
 </url>
```

If SHOW_UNTRANSLATED is False:

```xml
 <url>
  <loc>https://example.com/posts/foo.html</loc>
  <lastmod>2016-03-07T13:38:00Z</lastmod>
 </url>
```