### PR TITLE
Fix error when run nikola without options.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -870,6 +870,8 @@ class Nikola(object):
                     # FIXME TemplateSystem should not be needed
                     if p[-1].details.get('Nikola', 'PluginCategory') not in {'Command', 'Template'}:
                         bad_candidates.add(p)
+                else:
+                    bad_candidates.add(p)
             elif self.configured:  # Not commands-only, and configured
                 # Remove compilers we don't use
                 if p[-1].name in self.bad_compilers:


### PR DESCRIPTION
When I installed the plugin navstories, run nikola command without options get error:
```
# nikola 
Scanning posts.Cannot find 'rest' compiler; it might require an extra plugin -- do you have it installed?
```
