### PR TITLE
Moved `<footer>`outside of `<div role='main'>`

### DIFF
--- a/nikola/data/themes/bootstrap3/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base.tmpl
@@ -66,12 +66,11 @@ ${template_hooks['extra_head']()}
             <%block name="content"></%block>
         </div>
         <!--End of body content-->
-
-        <footer id="footer">
-            ${content_footer}
-            ${template_hooks['page_footer']()}
-        </footer>
     </div>
+    <footer id="footer">
+        ${content_footer}
+        ${template_hooks['page_footer']()}
+    </footer>
 </div>
 
 ${base.late_load_js()}


### PR DESCRIPTION
This enhances accessibility, particularly because a footer is not part of
the main content of the page.
Fixes #2309

By the way, I didn't Jinjify the result, because I tried, and a lot of whitespace changes (evil ^m on Windows) apeared everywhere as a result. So I thought you'd prefer a cleaner diff.