### PR TITLE
Fix #2331 -- fix folder handling/redirects in auto

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Features
 Bugfixes
 --------
 
+* Fix folder handling and redirects in ``nikola auto`` (Issue #2331)
 * Use state files in ``nikola github_deploy`` and ``nikola status``
   (Issue #2317)
 * Add ``align`` options for ``youtube``, ``vimeo``, ``soundcloud``

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -302,8 +302,8 @@ class CommandAuto(Command):
         mimetype = 'text/html' if uri.endswith('/') else mimetypes.guess_type(uri)[0] or 'application/octet-stream'
 
         if os.path.isdir(f_path):
-            if not f_path.endswith('/'):  # Redirect to avoid breakage
-                start_response('301 Redirect', [('Location', p_uri.path + '/')])
+            if not p_uri.path.endswith('/'):  # Redirect to avoid breakage
+                start_response('301 Moved Permanently', [('Location', p_uri.path + '/')])
                 return []
             f_path = os.path.join(f_path, self.site.config['INDEX_FILE'])
             mimetype = 'text/html'


### PR DESCRIPTION
This patch:

* works on URLs and not file system path (was messing up Windows)
* uses canonical HTTP status description

Signed-off-by: Chris Warrick <kwpolska@gmail.com>