### PR TITLE
Added enclosure lengths so podcast RSS is valid for more/all readers

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -293,9 +293,9 @@ LEGAL_VALUES = {
 
 def _enclosure(post, lang):
     """Add an enclosure to RSS."""
-    enclosure = post.meta('enclosure_url', lang)
+    enclosure = post.meta('enclosure', lang)
     if enclosure:
-        length = post.meta('enclosure_length', lang)
+        length = int(post.meta('enclosure_length', lang) or 0)
         url = enclosure
         mime = mimetypes.guess_type(url)[0]
         return url, length, mime

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -293,9 +293,9 @@ LEGAL_VALUES = {
 
 def _enclosure(post, lang):
     """Add an enclosure to RSS."""
-    enclosure = post.meta('enclosure', lang)
+    enclosure = post.meta('enclosure_url', lang)
     if enclosure:
-        length = 0
+        length = post.meta('enclosure_length', lang)
         url = enclosure
         mime = mimetypes.guess_type(url)[0]
         return url, length, mime


### PR DESCRIPTION
Prior to this change, RSS XML generate included the enclosure URL, but a file length of "0". This causes many podcatchers to reject the feed. This resolves that issue.