### PR TITLE
Show post's location even when it exists.

### DIFF
--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -343,6 +343,9 @@ class CommandNewPost(Command):
             signal('existing_' + content_type).send(self, **event)
 
             LOGGER.error("The title already exists!")
+            LOGGER.info("Existing {0}'s text is at: {1}".format(content_type, txt_path))
+            if not onefile:
+                LOGGER.info("Existing {0}'s metadata is at: {1}".format(content_type, meta_path))
             return 8
 
         d_name = os.path.dirname(txt_path)


### PR DESCRIPTION
It is useful to print the post's location even when it already exists, similar to how it is printed when we create a new post.  This is especially useful when the command is being called from a script, and the post's location needs to be parsed. 