### PR TITLE
Add <link> even if post is untranslated (to stop Google complaints)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,8 @@ Features
 Bugfixes
 --------
 
+* Add ``<link>`` tags to other languages even if the post is
+  untranslated (Google complained otherwise)
 * Create Persistor directories only if site is configured (Issue #2334)
 * Remove newlines in imported WordPress titles (Issue #2330)
 

--- a/nikola/data/themes/base-jinja/templates/post_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_helper.tmpl
@@ -3,7 +3,7 @@
 {% macro meta_translations(post) %}
     {% if translations|length > 1 %}
         {% for langname in translations|sort %}
-            {% if langname != lang and post.is_translation_available(langname) %}
+            {% if langname != lang and (post.show_untranslated or post.is_translation_available(langname)) %}
                 <link rel="alternate" hreflang="{{ langname }}" href="{{ post.permalink(langname) }}">
             {% endif %}
         {% endfor %}

--- a/nikola/data/themes/base-jinja/templates/post_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_helper.tmpl
@@ -3,7 +3,7 @@
 {% macro meta_translations(post) %}
     {% if translations|length > 1 %}
         {% for langname in translations|sort %}
-            {% if langname != lang and (post.show_untranslated or post.is_translation_available(langname)) %}
+            {% if langname != lang and ((not post.skip_untranslated) or post.is_translation_available(langname)) %}
                 <link rel="alternate" hreflang="{{ langname }}" href="{{ post.permalink(langname) }}">
             {% endif %}
         {% endfor %}

--- a/nikola/data/themes/base/templates/post_helper.tmpl
+++ b/nikola/data/themes/base/templates/post_helper.tmpl
@@ -3,7 +3,7 @@
 <%def name="meta_translations(post)">
     %if len(translations) > 1:
         %for langname in sorted(translations):
-            %if langname != lang and (post.show_untranslated or post.is_translation_available(langname)):
+            %if langname != lang and ((not post.skip_untranslated) or post.is_translation_available(langname)):
                 <link rel="alternate" hreflang="${langname}" href="${post.permalink(langname)}">
             %endif
         %endfor

--- a/nikola/data/themes/base/templates/post_helper.tmpl
+++ b/nikola/data/themes/base/templates/post_helper.tmpl
@@ -3,7 +3,7 @@
 <%def name="meta_translations(post)">
     %if len(translations) > 1:
         %for langname in sorted(translations):
-            %if langname != lang and post.is_translation_available(langname):
+            %if langname != lang and (post.show_untranslated or post.is_translation_available(langname)):
                 <link rel="alternate" hreflang="${langname}" href="${post.permalink(langname)}">
             %endif
         %endfor


### PR DESCRIPTION
Solves this e-mail I received from Google Webmaster Tools today:

> Google has detected that some pages on your site have implemented the rel-alternate-hreflang tag incorrectly. In particular, there seems to be a problem with incorrect language and region codes, or incorrect bi-directional linking (if page A links with hreflang to page B, there must be a link back from B to A as well). Google uses the hreflang attributes to serve the correct language or regional URL to the right users in search results.
> 
> Until you correct the errors on the hreflang links, your website will not benefit from additional language or region targeting.
> 
> Fix this problem now:
> 
> Find incorrect hreflang implementation
> Use the examples provided in the International Targeting feature in Search Console to get a sample of pages with incorrect hreflang implementation.