### PR TITLE
Cache messages that we have already loaded.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Features
 Bugfixes
 --------
 
+* Cache theme messages after loading once (Issue #2344)
 * Add ``<link>`` tags to other languages even if the post is
   untranslated (Google complained otherwise)
 * Don't call sys.exit() from plugins if possible (Issue #1839)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -337,6 +337,7 @@ class Nikola(object):
         self._scanned = False
         self._template_system = None
         self._THEMES = None
+        self._MESSAGES = None
         self.debug = DEBUG
         self.loghandlers = utils.STDERR_HANDLER  # TODO remove on v8
         self.colorful = config.pop('__colorful__', False)
@@ -1069,9 +1070,11 @@ class Nikola(object):
 
     def _get_messages(self):
         try:
-            return utils.load_messages(self.THEMES,
-                                       self.translations,
-                                       self.default_lang)
+            if self._MESSAGES is None:
+                self._MESSAGES = utils.load_messages(self.THEMES,
+                                                     self.translations,
+                                                     self.default_lang)
+            return self._MESSAGES
         except utils.LanguageNotFoundError as e:
             utils.LOGGER.error('''Cannot load language "{0}".  Please make sure it is supported by Nikola itself, or that you have the appropriate messages files in your themes.'''.format(e.lang))
             sys.exit(1)


### PR DESCRIPTION
Messages were being loaded each time the `MESSAGES` attribute of `site`
was accessed. This commit switches to using cached values.