### PR TITLE
Post is scheduled only if not draft or private

### DIFF
--- a/nikola/plugins/command/status.py
+++ b/nikola/plugins/command/status.py
@@ -134,7 +134,10 @@ class CommandStatus(Command):
         posts_drafts = sorted(posts_drafts, key=lambda post: post.source_path)
 
         # find all scheduled posts with offset from now until publishing time
-        posts_scheduled = [(post.date - now, post) for post in self.site.all_posts if post.publish_later]
+        posts_scheduled = [
+            (post.date - now, post) for post in self.site.all_posts
+            if post.publish_later and not (post.is_draft or post.is_private)
+        ]
         posts_scheduled = sorted(posts_scheduled, key=lambda offset_post: (offset_post[0], offset_post[1].source_path))
 
         if len(posts_scheduled) > 0:


### PR DESCRIPTION

Even if the date for a post is in the future, if it is marked as a draft
or a private post, it shouldn't be shown as a scheduled post since it's
not really going to be published when we cross that date.

