### PR TITLE
Added 'compiled' signal

### DIFF
--- a/docs/extending.txt
+++ b/docs/extending.txt
@@ -447,6 +447,16 @@ Currently Nikola emits the following signals:
          'undeployed': # all files not deployed since they are either future posts/drafts
         }
 
+``compiled``
+    When a post/page is compiled from its source to html, before anything else is done with it.  The signal
+    data is in the form::
+
+        {
+         'source': # the path to the source file
+         'dest': # the path to the cache file for the post/page
+         'post': # the nikola.post.Post object for the post/page
+        }
+
 One example is the `deploy_hooks plugin. <https://github.com/getnikola/plugins/tree/master/v6/deploy_hooks>`__
 
 ConfigPlugin Plugins

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -43,6 +43,7 @@ except ImportError:
 
 from . import utils
 
+from blinker import signal
 import dateutil.tz
 import lxml.html
 import natsort
@@ -490,6 +491,12 @@ class Post(object):
             self.translated_source_path(lang),
             dest,
             self.is_two_file),
+
+        signal('compiled').send(dict(
+            source=self.translated_source_path(lang),
+            dest=dest,
+            post=self,
+        ))
 
         if self.meta('password'):
             # TODO: get rid of this feature one day (v8?; warning added in v7.3.0.)


### PR DESCRIPTION
Adds a signal to ``nikola.post.Post().compile()`` after the page is compiled, before anything is done with the compiled file.

addresses #2369 