### PR TITLE
Fix #2380 -- copy imported two-file posts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ Features
 Bugfixes
 --------
 
+* Copy files when importing two-file posts instead of reading and
+  writing (useful for binary formats, eg. docx) (Issue #2380)
+
 New in v7.7.9
 =============
 


### PR DESCRIPTION
This is #2380.

cc @tritium21, @ralsina