### PR TITLE
Add horizontal scrollbar to listings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Features
 Bugfixes
 --------
 
+* Add horizontal scrollbar to listings (via getnikola/nikola-themes#86)
 * Copy files when importing two-file posts instead of reading and
   writing (useful for binary formats, eg. docx) (Issue #2380)
 

--- a/nikola/data/themes/bootstrap3/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap3/assets/css/theme.css
@@ -177,6 +177,14 @@ article.post-micro {
     border-top: 1px solid #e5e5e5;
 }
 
+.codetable {
+    table-layout: fixed;
+}
+
+.codetable pre {
+    overflow-x: scroll;
+}
+
 /* hat tip bootstrap/html5 boilerplate */
 @media print {
     *, *:before, *:after {


### PR DESCRIPTION
This replaces code tables that would go beyond screen width with code tables that always have horizontal scrollbars. This is not a perfect solution, though — it looks uglier when there is no overflow:

![image](https://cloud.githubusercontent.com/assets/327323/16371471/0f030276-3c47-11e6-8730-0eb937b349ce.png)

There’s also `overflow-x: overlay;` which looks like this and partially covers text:

![image](https://cloud.githubusercontent.com/assets/327323/16371508/477fc972-3c47-11e6-97bc-a0f64448a62c.png)

Which one is better for most users? Opinions welcome.

cc @iAmMrinal0 — via getnikola/nikola-themes#86 (pending)