### PR TITLE
Fix #1889 -- support dates in post_list

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Support ``date`` filtering in the post list directive
+  (Issue #1889)
 * Added Albanian translation by Vango Stavro
 * Added ``post-(type)`` class to ``story.tmpl`` (uses the ``type``
   meta field, defaults to ``post-text`` — same behavior as posts)

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1964,6 +1964,15 @@ The following options are recognized:
       Sort post list by one of each post's attributes, usually ``title`` or a
       custom ``priority``.  Defaults to None (chronological sorting).
 
+* ``date``: string
+  Show posts that match date range specified by this option. Format:
+
+  * comma-separated clauses (AND)
+  * clause: attribute comparison_operator value (spaces optional)
+      * attribute: year, month, day, hour, month, second, weekday, isoweekday; or empty for full datetime
+      * comparison_operator: == != <= >= < >
+      * value: integer or dateutil-compatible date input
+
 * ``tags`` : string [, string...]
       Filter posts to show only posts having at least one of the ``tags``.
       Defaults to None.

--- a/nikola/packages/README.md
+++ b/nikola/packages/README.md
@@ -3,3 +3,5 @@ We ship some third-party things with Nikola.  They live here, along with their l
 Packages:
 
  * tzlocal by Lennart Regebro, CC0 license (modified)
+ * datecond by Chris Warrick (Nikola contributor), 3-clause BSD license
+   (modified)

--- a/nikola/packages/datecond/__init__.py
+++ b/nikola/packages/datecond/__init__.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+# Date Conditionals (datecond)
+# Version 0.1.2
+# Copyright © 2015-2016, Chris Warrick.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions, and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions, and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the author of this software nor the names of
+#    contributors to this software may be used to endorse or promote
+#    products derived from this software without specific prior written
+#    consent.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Date range parser."""
+
+from __future__ import print_function, unicode_literals
+import dateutil.parser
+import re
+import operator
+
+
+__all__ = ('date_in_range',)
+CLAUSE = re.compile('(year|month|day|hour|minute|second|weekday|isoweekday)?'
+                    ' ?(==|!=|<=|>=|<|>) ?(.*)')
+OPERATORS = {
+    '==': operator.eq,
+    '!=': operator.ne,
+    '<=': operator.le,
+    '>=': operator.ge,
+    '<': operator.lt,
+    '>': operator.gt,
+}
+
+
+def date_in_range(date_range, date, debug=True):
+    """Check if date is in the range specified.
+
+    Format:
+    * comma-separated clauses (AND)
+    * clause: attribute comparison_operator value (spaces optional)
+        * attribute: year, month, day, hour, month, second, weekday, isoweekday
+          or empty for full datetime
+        * comparison_operator: == != <= >= < >
+        * value: integer or dateutil-compatible date input
+    """
+    out = True
+
+    for item in date_range.split(','):
+        attribute, comparison_operator, value = CLAUSE.match(
+            item.strip()).groups()
+        if attribute in ('weekday', 'isoweekday'):
+            left = getattr(date, attribute)()
+            right = int(value)
+        elif attribute:
+            left = getattr(date, attribute)
+            right = int(value)
+        else:
+            left = date
+            right = dateutil.parser.parse(value)
+        if debug:  # pragma: no cover
+            print("    <{0} {1} {2}>".format(left, comparison_operator, right))
+        out = out and OPERATORS[comparison_operator](left, right)
+    return out


### PR DESCRIPTION
This adds support for date filtering in post_list using a set of filters. I vendored in my [datecond](https://github.com/Kwpolska/datecond) library, under the 3-clause BSD license (but if anyone objects, we could make it an optional external dependency, or I could even agree to switch to dual-licensing)

Example:

```rst
.. post-list::
   :date: year < 2016, month != 5
```

Shows all posts written before 2016 and not written in May.

cc @erdgeist (reporter of #1889)