### PR TITLE
Improved EXIF orientation handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Features
 Bugfixes
 --------
 
+* Improved EXIF orientation handling
 * Register post list template as a dependency (Issue #2391)
 * Fix section color hashing when using Python 2
 * Use ``en_US`` dictionary name with pyphen for better compatibility

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -33,6 +33,8 @@ import lxml
 import re
 import gzip
 
+import piexif
+
 from nikola import utils
 
 Image = None
@@ -46,7 +48,6 @@ except ImportError:
         Image = _Image
     except ImportError:
         pass
-import piexif
 
 
 class ImageProcessor(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ setuptools>=5.4.1
 natsort>=3.5.2
 requests>=2.2.0
 husl>=4.0.2
+piexif==1.0.4


### PR DESCRIPTION
Improve EXIF orientation handling according to http://www.daveperrett.com/articles/2012/07/28/exif-orientation-handling-is-a-ghetto/

To test IRL, get the test images, put them in a gallery, set PRESERVE_EXIF to True and it should work well.