### PR TITLE
Fix for gallery image rotation

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -87,6 +87,7 @@
 * `Thibauld Nion <https://github.com/tibonihoo>`_
 * `Thomas Burette <https://github.com/tburette>`_
 * `Tim Chase <https://github.com/Gumnos>`_
+* `Timo Kankare <https://github.com/tikank>`_
 * `Tolu Sonaike <https://github.com/tolusonaike>`_
 * `Troy Toman <https://github.com/troytoman>`_
 * `Udo Spallek <https://github.com/udono>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,7 @@ Bugfixes
   (Issue #2406)
 * Don’t remove ``<!DOCTYPE html>`` if typogrify filters are in use
 * Avoid infinite loop if bootstrap3 can't be loaded (Issue #2402)
+* Fixed image rotation to update image size correctly (Issue #2418)
 
 New in v7.7.11
 ==============

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -39,12 +39,11 @@ from nikola import utils
 
 Image = None
 try:
-    from PIL import ExifTags, Image, ImageOps  # NOQA
+    from PIL import ExifTags, Image  # NOQA
 except ImportError:
     try:
         import ExifTags
         import Image as _Image
-        import ImageOps
         Image = _Image
     except ImportError:
         pass

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -117,11 +117,11 @@ class ImageProcessor(object):
             # Rotate according to EXIF
             value = exif['0th'].get(piexif.ImageIFD.Orientation, 1)
             if value in (3, 4):
-                im = im.rotate(180)
+                im = im.transpose(Image.ROTATE_180)
             elif value in (5, 6):
-                im = im.rotate(270)
+                im = im.transpose(Image.ROTATE_270)
             elif value in (7, 8):
-                im = im.rotate(90)
+                im = im.transpose(Image.ROTATE_90)
             if value in (2, 4, 5, 7):
                 im = ImageOps.mirror(im)
             exif['0th'][piexif.ImageIFD.Orientation] = 1

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -123,7 +123,7 @@ class ImageProcessor(object):
             elif value in (7, 8):
                 im = im.transpose(Image.ROTATE_90)
             if value in (2, 4, 5, 7):
-                im = ImageOps.mirror(im)
+                im = im.transpose(Image.FLIP_LEFT_RIGHT)
             exif['0th'][piexif.ImageIFD.Orientation] = 1
 
         try:


### PR DESCRIPTION
Fix for issue #2418. Rotate is replaced with transpose which sets image size correctly.