### PR TITLE
Fix #2422

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Features
 Bugfixes
 --------
 
+* Pass language to docutils so admonitions are translated (Issue #2422)
 * Put 2-file post metadata in the same place as the text file when
   specifying a path in ``new_post``, ``new_page`` (Issue #2420)
 * Register dependencies in post-list shortcode (Issue #2412)

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -40,7 +40,14 @@ import docutils.parsers.rst.directives
 from docutils.parsers.rst import roles
 
 from nikola.plugin_categories import PageCompiler
-from nikola.utils import unicode_str, get_logger, makedirs, write_metadata, STDERR_HANDLER
+from nikola.utils import (
+    unicode_str,
+    get_logger,
+    makedirs,
+    write_metadata,
+    STDERR_HANDLER,
+    LocaleBorg
+)
 from nikola.shortcodes import apply_shortcodes
 
 
@@ -63,16 +70,19 @@ class CompileRest(PageCompiler):
             add_ln = len(m_data.splitlines()) + 1
 
         default_template_path = os.path.join(os.path.dirname(__file__), 'template.txt')
+        settings_overrides = {
+            'initial_header_level': 1,
+            'record_dependencies': True,
+            'stylesheet_path': None,
+            'link_stylesheet': True,
+            'syntax_highlight': 'short',
+            'math_output': 'mathjax',
+            'template': default_template_path,
+        }
+        settings_overrides['language_code'] = LocaleBorg().current_lang
+
         output, error_level, deps = rst2html(
-            data, settings_overrides={
-                'initial_header_level': 1,
-                'record_dependencies': True,
-                'stylesheet_path': None,
-                'link_stylesheet': True,
-                'syntax_highlight': 'short',
-                'math_output': 'mathjax',
-                'template': default_template_path,
-            }, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms)
+            data, settings_overrides=settings_overrides, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms)
         if not isinstance(output, unicode_str):
             # To prevent some weird bugs here or there.
             # Original issue: empty files.  `output` became a bytestring.

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -78,8 +78,8 @@ class CompileRest(PageCompiler):
             'syntax_highlight': 'short',
             'math_output': 'mathjax',
             'template': default_template_path,
+            'language_code': LocaleBorg().current_lang,
         }
-        settings_overrides['language_code'] = LocaleBorg().current_lang
 
         output, error_level, deps = rst2html(
             data, settings_overrides=settings_overrides, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms)


### PR DESCRIPTION
Pass current language to docutils so things lik ```.. contents::``` and admonitions are localized correctly.