### PR TITLE
Adding dependency on render_posts for Atom feed.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2293,6 +2293,7 @@ class Nikola(object):
                     "basename": basename,
                     "name": atom_output_name,
                     "file_dep": sorted([_.base_path for _ in post_list]),
+                    "task_dep": ['render_posts'],
                     "targets": [atom_output_name],
                     "actions": [(self.atom_feed_renderer,
                                 (lang,


### PR DESCRIPTION
The task dependency is specified in the `tags` plugin, but not here. This sometimes causes dependency errors for me (with the earlytask_impl branch).