### PR TITLE
Default to English for docutils messages if no translations exist

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,8 +3,14 @@ New in master
 
 Features
 --------
+
 * Update options of chart directive to Pygal 2.2.3
 
+Bugfixes
+--------
+
+* Default to English for docutils messages if no translations exist
+  (Issues #2422, #2437)
 
 New in v7.7.12
 ==============

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -316,6 +316,27 @@ LEGAL_VALUES = {
         'te': 'te',
         'uk': 'uk',
     },
+    'DOCUTILS_LOCALES': {
+        'ca': 'ca',
+        'da': 'da',
+        'de': 'de',
+        'en': 'en',
+        'eo': 'eo',
+        'es': 'es',
+        'fi': 'fi',
+        'fr': 'fr',
+        'gl': 'gl',
+        'it': 'it',
+        'ja': 'ja',
+        'lt': 'lt',
+        'pl': 'pl',
+        'pt': 'pt_br',  # hope nobody will mind
+        'pt_br': 'pt_br',
+        'ru': 'ru',
+        'sk': 'sk',
+        'sv': 'sv',
+        'zh_cn': 'zh_cn'
+    }
 }
 
 

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -39,6 +39,7 @@ import docutils.writers.html4css1
 import docutils.parsers.rst.directives
 from docutils.parsers.rst import roles
 
+from nikola.nikola import LEGAL_VALUES
 from nikola.plugin_categories import PageCompiler
 from nikola.utils import (
     unicode_str,
@@ -77,7 +78,7 @@ class CompileRest(PageCompiler):
             'syntax_highlight': 'short',
             'math_output': 'mathjax',
             'template': default_template_path,
-            'language_code': LocaleBorg().current_lang,
+            'language_code': LEGAL_VALUES['DOCUTILS_LOCALES'].get(LocaleBorg().current_lang, 'en')
         }
 
         output, error_level, deps = rst2html(


### PR DESCRIPTION
This is a fix for #2437 that prevents displaying the message by only providing known-good languages to docutils.

cc @ralsina, @shahinism