### PR TITLE
Pass global context to template shortcodes (#2424)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Pass global context to template shortcodes (Issue #2424)
 * Update options of chart directive to Pygal 2.2.3
 
 Bugfixes

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1432,8 +1432,14 @@ class Nikola(object):
 
         """
         def render_shortcode(*args, **kw):
-            kw['_args'] = args
-            return self.template_system.render_template_to_string(t_data, kw)
+            context = {}
+            context.update(self.GLOBAL_CONTEXT)
+            context.update(kw)
+            context['_args'] = args
+            context['lang'] = utils.LocaleBorg().current_lang
+            for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
+                context[k] = context[k](context['lang'])
+            return self.template_system.render_template_to_string(t_data, context)
         return render_shortcode
 
     def _register_templated_shortcodes(self):


### PR DESCRIPTION
Fixes parts of #2424, leaves only the dependency parts.