### PR TITLE
New option to skip DocTitle transform in docutils (Fix #2382)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,8 +3,9 @@ New in master
 
 Features
 --------
-* Update options of chart directive to Pygal 2.2.3
 
+* New NO_DOCUTILS_TITLE_TRANSFORM (Issue #2382)
+* Update options of chart directive to Pygal 2.2.3
 
 New in v7.7.12
 ==============

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1117,6 +1117,12 @@ UNSLUGIFY_TITLES = True
 # (defaults to 1.)
 # DEMOTE_HEADERS = 1
 
+# Docutils, by default, will perform a transform in your documents
+# extracting unique titles at the top of your document and turning
+# them into metadata. This surprises a lot of people, and setting
+# this option to True will prevent it.
+# NO_DOCUTILS_TITLE_TRANSFORM = False
+
 # If you don’t like slugified file names ([a-z0-9] and a literal dash),
 # and would prefer to use all the characters your file system allows.
 # USE WITH CARE!  This is also not guaranteed to be perfect, and may

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -180,7 +180,7 @@ class NikolaReader(docutils.readers.standalone.Reader):
         """Initialize the reader."""
         self.transforms = kwargs.pop('transforms', [])
         self.no_title_transform = kwargs.pop('no_title_transform', False)
-        super(NikolaReader, self).__init__(*args, **kwargs)
+        docutils.readers.standalone.Reader.__init__(self, *args, **kwargs)
 
     def get_transforms(self):
         """Get docutils transforms."""


### PR DESCRIPTION
Add a new option, defaulting to False, to skip the DocTitle transform in docutils, which has a very unexpected behaviour for most people.