### PR TITLE
Initial implementantion of deps for shortcodes

### DIFF
--- a/docs/extending.txt
+++ b/docs/extending.txt
@@ -577,13 +577,25 @@ So, if you are creating a plugin that generates markup, it may be a good idea
 to register it as a shortcode in addition of to restructured text directive or
 markdown extension, thus making it available to all markup formats.
 
-To implement your own shortcodes from a plugin, you can create a plugin inheriting ``ShortcodePlugin`` and call
+To implement your own shortcodes from a plugin, you can create a plugin inheriting ``ShortcodePlugin`` and 
+from its ``set_site`` method,  call
+
 ``Nikola.register_shortcode(name, func)`` with the following arguments:
 
 ``name``:
     Name of the shortcode ("foo" in the examples above)
 ``func``:
     A function that will handle the shortcode
+
+The shortcode handler **must** return a two-element tuple, ``(output, dependencies)``
+
+``output``:
+    The text that will replace the shortcode in the document.
+
+``dependencies``:
+    A list of all the files on disk which will make the output be considered
+    out of date. For example, if the shortcode uses a template, it should be
+    the path to the template file.
 
 The shortcode handler **must** accept the following named arguments (or
 variable keyword arguments):

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1426,7 +1426,7 @@ class Nikola(object):
 
         return result
 
-    def _make_renderfunc(self, t_data, fname):
+    def _make_renderfunc(self, t_data, fname=None):
         """Return a function that can be registered as a template shortcode.
 
         The returned function has access to the passed template data and
@@ -1443,7 +1443,11 @@ class Nikola(object):
             context['lang'] = utils.LocaleBorg().current_lang
             for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
                 context[k] = context[k](context['lang'])
-            return self.template_system.render_template_to_string(t_data, context), fname
+            output = self.template_system.render_template_to_string(t_data, context)
+            if fname is not None:
+                return output, [fname]
+            else:
+                return output, []
         return render_shortcode
 
     def _register_templated_shortcodes(self):

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1426,7 +1426,7 @@ class Nikola(object):
 
         return result
 
-    def _make_renderfunc(self, t_data):
+    def _make_renderfunc(self, t_data, fname):
         """Return a function that can be registered as a template shortcode.
 
         The returned function has access to the passed template data and
@@ -1443,7 +1443,7 @@ class Nikola(object):
             context['lang'] = utils.LocaleBorg().current_lang
             for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
                 context[k] = context[k](context['lang'])
-            return self.template_system.render_template_to_string(t_data, context)
+            return self.template_system.render_template_to_string(t_data, context), fname
         return render_shortcode
 
     def _register_templated_shortcodes(self):
@@ -1463,7 +1463,8 @@ class Nikola(object):
                     continue
 
                 with open(os.path.join(sc_dir, fname)) as fd:
-                    self.register_shortcode(name, self._make_renderfunc(fd.read()))
+                    self.register_shortcode(name, self._make_renderfunc(
+                        fd.read(), os.path.join(sc_dir, fname)))
 
     def register_shortcode(self, name, f):
         """Register function f to handle shortcode "name"."""
@@ -1472,11 +1473,12 @@ class Nikola(object):
             return
         self.shortcode_registry[name] = f
 
-    def apply_shortcodes(self, data, filename=None, lang=None):
+    # XXX in v8, get rid of with_dependencies
+    def apply_shortcodes(self, data, filename=None, lang=None, with_dependencies=False):
         """Apply shortcodes from the registry on data."""
         if lang is None:
             lang = utils.LocaleBorg().current_lang
-        return shortcodes.apply_shortcodes(data, self.shortcode_registry, self, filename, lang=lang)
+        return shortcodes.apply_shortcodes(data, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies)
 
     def generic_rss_renderer(self, lang, title, link, description, timeline, output_path,
                              rss_teasers, rss_plain, feed_length=10, feed_url=None,

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1445,6 +1445,7 @@ class Nikola(object):
                 context[k] = context[k](context['lang'])
             output = self.template_system.render_template_to_string(t_data, context)
             if fname is not None:
+                # FIXME get_deps returns filenames, it needs to be full paths
                 dependencies = [fname] + self.template_system.get_deps(fname)
             else:
                 dependencies = []

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1445,7 +1445,6 @@ class Nikola(object):
                 context[k] = context[k](context['lang'])
             output = self.template_system.render_template_to_string(t_data, context)
             if fname is not None:
-                # FIXME get_deps returns filenames, it needs to be full paths
                 dependencies = [fname] + self.template_system.get_deps(fname)
             else:
                 dependencies = []
@@ -1467,7 +1466,6 @@ class Nikola(object):
 
                 if ext != '.tmpl':
                     continue
-
                 with open(os.path.join(sc_dir, fname)) as fd:
                     self.register_shortcode(name, self._make_renderfunc(
                         fd.read(), os.path.join(sc_dir, fname)))

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1445,9 +1445,10 @@ class Nikola(object):
                 context[k] = context[k](context['lang'])
             output = self.template_system.render_template_to_string(t_data, context)
             if fname is not None:
-                return output, [fname]
+                dependencies = [fname] + self.template_system.get_deps(fname)
             else:
-                return output, []
+                dependencies = []
+            return output, dependencies
         return render_shortcode
 
     def _register_templated_shortcodes(self):

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -86,6 +86,7 @@ class BasePlugin(IPlugin):
         """Find the dependencies for a file."""
         return []
 
+
 class PostScanner(BasePlugin):
     """The scan method of these plugins is called by Nikola.scan_posts."""
 

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -82,6 +82,9 @@ class BasePlugin(IPlugin):
         """Add 'dependency' to the target task's task_deps."""
         self.site.injected_deps[target].append(dependency)
 
+    def get_deps(self, filename):
+        """Find the dependencies for a file."""
+        return []
 
 class PostScanner(BasePlugin):
     """The scan method of these plugins is called by Nikola.scan_posts."""

--- a/nikola/plugins/compile/html.py
+++ b/nikola/plugins/compile/html.py
@@ -54,7 +54,7 @@ class CompileHtml(PageCompiler):
         try:
             post = self.site.post_per_input_file[source]
         except KeyError:
-            if deps.list:
+            if shortcode_deps:
                 self.logger.error(
                     "Cannot save dependencies for post {0} due to unregistered source file name",
                     source)

--- a/nikola/plugins/compile/html.py
+++ b/nikola/plugins/compile/html.py
@@ -49,8 +49,17 @@ class CompileHtml(PageCompiler):
                 data = in_file.read()
             if not is_two_file:
                 _, data = self.split_metadata(data)
-            data = self.site.apply_shortcodes(source)
+            data, shortcode_deps = self.site.apply_shortcodes(source, with_dependencies=True)
             out_file.write(data)
+        try:
+            post = self.site.post_per_input_file[source]
+        except KeyError:
+            if deps.list:
+                self.logger.error(
+                    "Cannot save dependencies for post {0} due to unregistered source file name",
+                    source)
+        else:
+            post._depfile[dest] += shortcode_deps
         return True
 
     def create_post(self, path, **kw):

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -98,7 +98,7 @@ class CompileIPynb(PageCompiler):
         try:
             post = self.site.post_per_input_file[source]
         except KeyError:
-            if deps.list:
+            if shortcode_deps:
                 self.logger.error(
                     "Cannot save dependencies for post {0} due to unregistered source file name",
                     source)

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -93,8 +93,17 @@ class CompileIPynb(PageCompiler):
         makedirs(os.path.dirname(dest))
         with io.open(dest, "w+", encoding="utf8") as out_file:
             output = self.compile_html_string(source, is_two_file)
-            output = self.site.apply_shortcodes(output, filename=source)
+            output, shortcode_deps = self.site.apply_shortcodes(output, filename=source, with_dependencies=True)
             out_file.write(output)
+        try:
+            post = self.site.post_per_input_file[source]
+        except KeyError:
+            if deps.list:
+                self.logger.error(
+                    "Cannot save dependencies for post {0} due to unregistered source file name",
+                    source)
+        else:
+            post._depfile[dest] += shortcode_deps
 
     def read_metadata(self, post, file_metadata_regexp=None, unslugify_titles=False, lang=None):
         """Read metadata directly from ipynb file.

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -75,8 +75,17 @@ class CompileMarkdown(PageCompiler):
             if not is_two_file:
                 _, data = self.split_metadata(data)
             output = markdown(data, self.extensions)
-            output = self.site.apply_shortcodes(output, filename=source)
+            output, shortcode_deps = self.site.apply_shortcodes(output, filename=source, with_dependencies=True)
             out_file.write(output)
+        try:
+            post = self.site.post_per_input_file[source]
+        except KeyError:
+            if deps.list:
+                self.logger.error(
+                    "Cannot save dependencies for post {0} due to unregistered source file name",
+                    source)
+        else:
+            post._depfile[dest] += shortcode_deps
 
     def create_post(self, path, **kw):
         """Create a new post."""

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -80,7 +80,7 @@ class CompileMarkdown(PageCompiler):
         try:
             post = self.site.post_per_input_file[source]
         except KeyError:
-            if deps.list:
+            if shortcode_deps:
                 self.logger.error(
                     "Cannot save dependencies for post {0} due to unregistered source file name",
                     source)

--- a/nikola/plugins/compile/pandoc.py
+++ b/nikola/plugins/compile/pandoc.py
@@ -62,7 +62,7 @@ class CompilePandoc(PageCompiler):
             try:
                 post = self.site.post_per_input_file[source]
             except KeyError:
-                if deps.list:
+                if shortcode_deps:
                     self.logger.error(
                         "Cannot save dependencies for post {0} due to unregistered source file name",
                         source)

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -97,7 +97,7 @@ class CompileRest(PageCompiler):
             with io.open(source, "r", encoding="utf8") as in_file:
                 data = in_file.read()
                 output, error_level, deps = self.compile_html_string(data, source, is_two_file)
-                output = self.site.apply_shortcodes(output, filename=source)
+                output, shortcode_deps = self.site.apply_shortcodes(output, filename=source, with_dependencies=True)
                 out_file.write(output)
             try:
                 post = self.site.post_per_input_file[source]
@@ -108,6 +108,7 @@ class CompileRest(PageCompiler):
                         source)
             else:
                 post._depfile[dest] += deps.list
+                post._depfile[dest] += shortcode_deps
         if error_level < 3:
             return True
         else:

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -31,7 +31,6 @@ from __future__ import unicode_literals
 import os
 import io
 import json
-from collections import deque
 try:
     import jinja2
     from jinja2 import meta
@@ -48,6 +47,7 @@ class JinjaTemplates(TemplateSystem):
     name = "jinja"
     lookup = None
     dependency_cache = {}
+    per_file_cache = {}
 
     def __init__(self):
         """Initialize Jinja2 environment with extended set of filters."""
@@ -103,31 +103,25 @@ class JinjaTemplates(TemplateSystem):
         """Render template to a string using context."""
         return self.lookup.from_string(template).render(**context)
 
+    def get_deps(self, filename):
+        deps = set([])
+        with open(filename) as fd:
+            source = fd.read()
+            ast = self.lookup.parse(source)
+            dep_names = meta.find_referenced_templates(ast)
+            for dep_name in dep_names:
+                filename = self.lookup.loader.get_source(self.lookup, dep_name)[1]
+                deps.add(filename)
+                sub_deps = self.get_deps(filename)
+                self.dependency_cache[dep_name] = sub_deps
+                deps |= set(sub_deps)
+        return list(deps)
+
     def template_deps(self, template_name):
         """Generate list of dependencies for a template."""
-        # XXX FIXME: if we could split this into a get_deps that
-        # takes a filename, it would be more compatible with
-        # shortcode template dependencies
-
-        # Cache the lists of dependencies for each template name.
         if self.dependency_cache.get(template_name) is None:
-            # Use a breadth-first search to find all templates this one
-            # depends on.
-            queue = deque([template_name])
-            visited_templates = set([template_name])
-            deps = []
-            while len(queue) > 0:
-                curr = queue.popleft()
-                source, filename = self.lookup.loader.get_source(self.lookup,
-                                                                 curr)[:2]
-                deps.append(filename)
-                ast = self.lookup.parse(source)
-                dep_names = meta.find_referenced_templates(ast)
-                for dep_name in dep_names:
-                    if (dep_name not in visited_templates and dep_name is not None):
-                        visited_templates.add(dep_name)
-                        queue.append(dep_name)
-            self.dependency_cache[template_name] = deps
+            filename = self.lookup.loader.get_source(self.lookup, template_name)[1]
+            self.dependency_cache[template_name] = self.get_deps(filename)
         return self.dependency_cache[template_name]
 
     def get_template_path(self, template_name):

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -105,6 +105,10 @@ class JinjaTemplates(TemplateSystem):
 
     def template_deps(self, template_name):
         """Generate list of dependencies for a template."""
+        # XXX FIXME: if we could split this into a get_deps that
+        # takes a filename, it would be more compatible with
+        # shortcode template dependencies
+
         # Cache the lists of dependencies for each template name.
         if self.dependency_cache.get(template_name) is None:
             # Use a breadth-first search to find all templates this one

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -122,7 +122,7 @@ class JinjaTemplates(TemplateSystem):
         """Generate list of dependencies for a template."""
         if self.dependency_cache.get(template_name) is None:
             filename = self.lookup.loader.get_source(self.lookup, template_name)[1]
-            self.dependency_cache[template_name] = self.get_deps(filename)
+            self.dependency_cache[template_name] = [filename] + self.get_deps(filename)
         return self.dependency_cache[template_name]
 
     def get_template_path(self, template_name):

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -104,6 +104,7 @@ class JinjaTemplates(TemplateSystem):
         return self.lookup.from_string(template).render(**context)
 
     def get_deps(self, filename):
+        """Return paths to dependencies for the template loaded from filename."""
         deps = set([])
         with open(filename) as fd:
             source = fd.read()

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -56,7 +56,7 @@ class MakoTemplates(TemplateSystem):
     cache_dir = None
 
     def get_deps(self, filename):
-        """Get dependencies for a template."""
+        """Get paths to dependencies for a template."""
         text = util.read_file(filename)
         lex = lexer.Lexer(text=text, filename=filename)
         lex.parse()
@@ -66,6 +66,11 @@ class MakoTemplates(TemplateSystem):
             keyword = getattr(n, 'keyword', None)
             if keyword in ["inherit", "namespace"] or isinstance(n, parsetree.IncludeTag):
                 deps.append(n.attributes['file'])
+        # Some templates will include "foo.tmpl" and we need paths, so normalize them
+        # using the template lookup
+        for i, d in enumerate(deps):
+            if os.sep not in d:
+                deps[i] = self.get_template_path(d)
         return deps
 
     def set_directories(self, directories, cache_folder):
@@ -116,7 +121,7 @@ class MakoTemplates(TemplateSystem):
     def render_template_to_string(self, template, context):
         """Render template to a string using context."""
         context.update(self.filters)
-        return Template(template).render(**context)
+        return Template(template, lookup=self.lookup).render(**context)
 
     def template_deps(self, template_name):
         """Generate list of dependencies for a template."""
@@ -127,8 +132,8 @@ class MakoTemplates(TemplateSystem):
             dep_filenames = self.get_deps(template.filename)
             deps = [template.filename]
             for fname in dep_filenames:
-                deps += self.template_deps(fname)
-            self.cache[template_name] = tuple(deps)
+                deps += self.get_deps(fname)
+            self.cache[template_name] = deps
         return list(self.cache[template_name])
 
     def get_template_path(self, template_name):

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -56,7 +56,7 @@ class MakoTemplates(TemplateSystem):
     cache_dir = None
 
     def get_deps(self, filename):
-        """Get dependencies for a template (internal function)."""
+        """Get dependencies for a template."""
         text = util.read_file(filename)
         lex = lexer.Lexer(text=text, filename=filename)
         lex.parse()

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -323,7 +323,7 @@ def apply_shortcodes(data, registry, site=None, filename=None, raise_exceptions=
                     LOGGER.error('Unknown shortcode {0} (started at {1})', name, _format_position(data, current[2]))
                     res = ('', [])
                 result.append(res[0])
-                dependencies.append(res[1])
+                dependencies += res[1]
         if with_dependencies:
             return empty_string.join(result), dependencies
         return empty_string.join(result)

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -256,7 +256,8 @@ def _split_shortcodes(data):
     return result
 
 
-def apply_shortcodes(data, registry, site=None, filename=None, raise_exceptions=False, lang=None):
+# FIXME: in v8, get rid of with_dependencies
+def apply_shortcodes(data, registry, site=None, filename=None, raise_exceptions=False, lang=None, with_dependencies=False):
     """Apply Hugo-style shortcodes on data.
 
     {{% name parameters %}} will end up calling the registered "name" function with the given parameters.
@@ -279,6 +280,7 @@ def apply_shortcodes(data, registry, site=None, filename=None, raise_exceptions=
         sc_data = _split_shortcodes(data)
         # Now process data
         result = []
+        dependencies = []
         pos = 0
         while pos < len(sc_data):
             current = sc_data[pos]
@@ -315,10 +317,15 @@ def apply_shortcodes(data, registry, site=None, filename=None, raise_exceptions=
                     if getattr(f, 'nikola_shortcode_pass_filename', None):
                         kw['filename'] = filename
                     res = f(*args, **kw)
+                    if not isinstance(res, tuple):  # For backards compatibility
+                        res = (res, [])
                 else:
                     LOGGER.error('Unknown shortcode {0} (started at {1})', name, _format_position(data, current[2]))
-                    res = ''
-                result.append(res)
+                    res = ('', [])
+                result.append(res[0])
+                dependencies.append(res[1])
+        if with_dependencies:
+            return empty_string.join(result), dependencies
         return empty_string.join(result)
     except ParsingError as e:
         if raise_exceptions:

--- a/tests/base.py
+++ b/tests/base.py
@@ -229,4 +229,4 @@ class FakeSite(object):
 
     def apply_shortcodes(self, data, *a, **kw):
         """Apply shortcodes from the registry on data."""
-        return nikola.shortcodes.apply_shortcodes(data, self.shortcode_registry), []
+        return nikola.shortcodes.apply_shortcodes(data, self.shortcode_registry, **kw)

--- a/tests/base.py
+++ b/tests/base.py
@@ -229,4 +229,4 @@ class FakeSite(object):
 
     def apply_shortcodes(self, data, *a, **kw):
         """Apply shortcodes from the registry on data."""
-        return nikola.shortcodes.apply_shortcodes(data, self.shortcode_registry)
+        return nikola.shortcodes.apply_shortcodes(data, self.shortcode_registry), []

--- a/tests/test_rst_compiler.py
+++ b/tests/test_rst_compiler.py
@@ -4,7 +4,7 @@
 
 
 """ Test cases for Nikola ReST extensions.
-A base class ReSTExtensionTestCase provides the tests basic behaivor.
+A base class ReSTExtensionTestCase provides the tests basic behaviour.
 Subclasses must override the "sample" class attribute with the ReST markup.
 The sample will be rendered as HTML using publish_parts() by setUp().
 One method is provided for checking the resulting HTML:


### PR DESCRIPTION
Initial attempt at supporting file dependencies from shortcodes.

- [x] Added optional with_dependencies arg for apply_shortcodes, which makes it return (output, dependencies)
- [x] Added dependency tracking for templated shortcodes
- [x] Track template dependencies usint the template plugin
- [x] Changed the reSt compiler to support shortcodes with dependencies
- [x] Changed all included compilers to support shortcodes with dependencies
- [ ] ~~Change all compiler plugins to support shortcodes + dependencies~~ will be handled in a separate branch
- [x] Change docs to describe shortcode dep tracking
- [x] Change shortcode plugin class to help with dependencies