### PR TITLE
Don’t store timestamp in github_deploy

### DIFF
--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -27,7 +27,6 @@
 """Deploy site to GitHub Pages."""
 
 from __future__ import print_function
-from datetime import datetime
 import os
 import subprocess
 from textwrap import dedent
@@ -166,7 +165,3 @@ class CommandGitHubDeploy(Command):
             return e.args[0]
 
         self.logger.info("Successful deployment")
-
-        # Store timestamp of successful deployment
-        new_deploy = datetime.utcnow()
-        self.site.state.set('last_deploy', new_deploy.isoformat())


### PR DESCRIPTION
Rationale: the Git repo will *never* be clean, because the state file
will be created after we push everything.

Moving it before we commit to the source branch means we’d store
timestamp of last deployment attempt.