### PR TITLE
Disable <base> tag by default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ Features
 Bugfixes
 --------
 
+* Remove the (useless) ``<base>`` tag by default; change conf.py to
+  opt in (Issue #2471)
 * Show tag descriptions when TAG_PAGES_ARE_INDEXES is True (Issue #2444)
 * Record template dependencies for post-list shortcut (Issue #2451)
 * Default to English for docutils messages if no translations exist

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1300,8 +1300,9 @@ sure you have ``nikola`` and ``git`` installed on your PATH.  Also, install
 5. If you set ``GITHUB_COMMIT_SOURCE`` to False, you must switch to your source
    branch and commit to it.  Otherwise, this is done for you.
 6. Run ``nikola github_deploy``.  This will build the site, commit the output
-   folder to your deploy branch, and push to GitHub.  Your website should be up
-   and running within a few minutes.
+   folder to your deploy branch, and push to GitHub.
+7. Enable GitHub Pages for this repository from GitHub’s web interface (on the
+   Settings page).
 
 If you want to use a custom domain, create your ``CNAME`` file in
 ``files/CNAME`` on the source branch. Nikola will copy it to the

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -434,9 +434,12 @@ FRONT_INDEX_HEADER = {
 # If USE_BASE_TAG is True, then all HTML files will include
 # something like <base href=http://foo.var.com/baz/bat> to help
 # the browser resolve relative links.
-# In some rare cases, this will be a problem, and you can
-# disable it by setting USE_BASE_TAG to False.
-# USE_BASE_TAG = True
+# Most people don’t need this tag; major websites don’t use it. Use
+# only if you know what you’re doing. If this is True, your website
+# will not be fully usable by manually opening .html files in your web
+# browser (`nikola serve` or `nikola auto` is mandatory). Also, if you
+# have mirrors of your site, they will point to SITE_URL everywhere.
+USE_BASE_TAG = False
 
 # Final location for the blog main RSS feed is:
 # output / TRANSLATION[lang] / RSS_PATH / rss.xml

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -561,7 +561,7 @@ class Nikola(object):
             'THUMBNAIL_SIZE': 180,
             'UNSLUGIFY_TITLES': False,  # WARNING: conf.py.in overrides this with True for backwards compatibility
             'URL_TYPE': 'rel_path',
-            'USE_BASE_TAG': True,
+            'USE_BASE_TAG': False,
             'USE_BUNDLES': True,
             'USE_CDN': False,
             'USE_CDN_WARNING': True,


### PR DESCRIPTION
This disables the `<base>` tag, as discussed on the mailing list recently. Rationale in `conf.py.in`.

I also disabled it for existing sites in `nikola.py` but we could undo that (but why? The tag is completely useless for 99% of people; show me a major website using it!)