### PR TITLE
Fix #2455

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Detect dependencies in template strings (Issue #2455)
 * RSS feeds for sections (Issue #2068)
 * New ``data`` metadata that loads data from external files (Issue #2450)
 * Shortcode to escape to the template language (Issue #1227)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1486,9 +1486,7 @@ class Nikola(object):
         for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
             context[k] = context[k](context['lang'])
         output = self.template_system.render_template_to_string(t_data, context)
-        # XXX FIXME: we have no standard way to get dependency information from
-        # a template that's not a file
-        dependencies = []
+        dependencies = self.template_system.get_string_deps(t_data)
         return output, dependencies
 
     def register_shortcode(self, name, f):

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -204,6 +204,14 @@ class TemplateSystem(BasePlugin):
         """Return filenames which are dependencies for a template."""
         raise NotImplementedError()
 
+    def get_deps(self, filename):
+        """Return paths to dependencies for the template loaded from filename."""
+        raise NotImplementedError()
+
+    def get_string_deps(self, text):
+        """Find dependencies for a template string."""
+        raise NotImplementedError()
+
     def render_template(self, template_name, output_name, context):
         """Render template to a file using context.
 

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -55,9 +55,8 @@ class MakoTemplates(TemplateSystem):
     directories = []
     cache_dir = None
 
-    def get_deps(self, filename):
-        """Get paths to dependencies for a template."""
-        text = util.read_file(filename)
+    def get_string_deps(self, text, filename=None):
+        """Find dependencies for a template string."""
         lex = lexer.Lexer(text=text, filename=filename)
         lex.parse()
 
@@ -71,6 +70,11 @@ class MakoTemplates(TemplateSystem):
         for i, d in enumerate(deps):
             deps[i] = self.get_template_path(d)
         return deps
+
+    def get_deps(self, filename):
+        """Get paths to dependencies for a template."""
+        text = util.read_file(filename)
+        return self.get_string_deps(text, filename)
 
     def set_directories(self, directories, cache_folder):
         """Create a new template lookup with set directories."""


### PR DESCRIPTION
Add a method to get the dependencies of a template string (just in case it uses include or whatever) and use it in the right place.