### PR TITLE
Make HUSL an optional requirement

### DIFF
--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1827,20 +1827,17 @@ def colorize_str_from_base_color(string, base_color):
     def degreediff(dega, degb):
         return min(abs(dega - degb), abs((degb - dega) + 360))
 
-    def husl_similar_from_base(string, base_color):
-        if husl is None:
-            req_missing(['husl'], 'Use color mixing (section colors)',
-                        optional=True)
-            return base_color
-        h, s, l = husl.hex_to_husl(base_color)
-        old_h = h
-        idx = 0
-        while degreediff(old_h, h) < 27 and idx < 16:
-            h = 360.0 * (float(hash_str(string, idx)) / 255)
-            idx += 1
-        return husl.husl_to_hex(h, s, l)
-
-    return husl_similar_from_base(string, base_color)
+    if husl is None:
+        req_missing(['husl'], 'Use color mixing (section colors)',
+                    optional=True)
+        return base_color
+    h, s, l = husl.hex_to_husl(base_color)
+    old_h = h
+    idx = 0
+    while degreediff(old_h, h) < 27 and idx < 16:
+        h = 360.0 * (float(hash_str(string, idx)) / 255)
+        idx += 1
+    return husl.husl_to_hex(h, s, l)
 
 
 def color_hsl_adjust_hex(hexstr, adjust_h=None, adjust_s=None, adjust_l=None):

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -31,7 +31,6 @@ import calendar
 import datetime
 import dateutil.tz
 import hashlib
-import husl
 import io
 import locale
 import logging
@@ -64,6 +63,11 @@ try:
     import yaml
 except ImportError:
     yaml = None
+try:
+    import husl
+except ImportError:
+    husl = None
+
 from collections import defaultdict, Callable, OrderedDict
 from logbook.compat import redirect_logging
 from logbook.more import ExceptionHandler, ColorizedStderrHandler
@@ -1824,6 +1828,10 @@ def colorize_str_from_base_color(string, base_color):
         return min(abs(dega - degb), abs((degb - dega) + 360))
 
     def husl_similar_from_base(string, base_color):
+        if husl is None:
+            req_missing(['husl'], 'Use color mixing (section colors)',
+                        optional=True)
+            return base_color
         h, s, l = husl.hex_to_husl(base_color)
         old_h = h
         idx = 0

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 Markdown>=2.4.0
 Jinja2>=2.7.2
+husl>=4.0.2
 pyphen>=0.9.1
 micawber>=0.3.0
 pygal>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,4 @@ blinker>=1.3
 setuptools>=5.4.1
 natsort>=3.5.2
 requests>=2.2.0
-husl>=4.0.2
 piexif>=1.0.3


### PR DESCRIPTION
Rationale: it’s used for one minor function that doesn’t even get
called by built-in templates (at least now). Pretty unnecessary if you
ask me. And so, this will work much better in the -extras file.