### PR TITLE
update KaTeX version and introduce KATEX_AUTO_RENDER label

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -31,6 +31,7 @@
 * `Dhruv Baldawa <https://github.com/dhruvbaldawa>`_
 * `Dirk Engling <https://github.com/erdgeist>`_
 * `Dmitry Verkhoturov <https://github.com/paskal>`_
+* `Du Phan <https://github.com/fehiepsi>`_
 * `Duncan Lock <https://github.com/dflock>`_
 * `Edinei Cavalcanti <https://github.com/neiesc>`_
 * `Eduardo Schettino <https://github.com/schettino72>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Bugfixes
 Features
 --------
 
+* Introduce the new KATEX_AUTO_RENDER label
+* Update KaTeX version to 0.6.0: support aligned math display
 * Better support for a tree of files in ``data/``
 
 New in v7.8.0

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -904,8 +904,21 @@ PRETTY_URLS = ${PRETTY_URLS}
 # it's faster and the output looks better.
 # If you set USE_KATEX to True, you also need to add an extra CSS file
 # like this:
-# EXTRA_HEAD_DATA = """<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.css">"""
+# EXTRA_HEAD_DATA = """<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.css">"""
 # USE_KATEX = False
+
+# If you want to use the old (buggy) inline math $.$ with KaTeX, then
+# you might want to use this feature. In particular, if you build your
+# posts from Jupyter notebook and there are a lot of inline math in
+# your notebook, then it is recommended to activate it.
+# KATEX_AUTO_RENDER = """
+# delimiters: [
+#     {left: "$$", right: "$$", display: true},
+#     {left: "\\\[", right: "\\\]", display: true},
+#     {left: "$", right: "$", display: false},
+#     {left: "\\\(", right: "\\\)", display: false}
+# ]
+# """
 
 # Do you want to customize the nbconversion of your IPython notebook?
 # IPYNB_CONFIG = {}

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -908,9 +908,7 @@ PRETTY_URLS = ${PRETTY_URLS}
 # USE_KATEX = False
 
 # If you want to use the old (buggy) inline math $.$ with KaTeX, then
-# you might want to use this feature. In particular, if you build your
-# posts from Jupyter notebook and there are a lot of inline math in
-# your notebook, then it is recommended to activate it.
+# you might want to use this feature.
 # KATEX_AUTO_RENDER = """
 # delimiters: [
 #     {left: "$$", right: "$$", display: true},

--- a/nikola/data/themes/base-jinja/templates/index_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index_helper.tmpl
@@ -21,8 +21,8 @@
 {% macro mathjax_script(posts) %}
     {% if posts|selectattr("is_mathjax")|list %}
         {% if use_katex %}
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/contrib/auto-render.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
             {% if katex_auto_render %}
                 <script>
                     renderMathInElement(document.body,

--- a/nikola/data/themes/base-jinja/templates/index_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index_helper.tmpl
@@ -23,9 +23,19 @@
         {% if use_katex %}
             <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/contrib/auto-render.min.js"></script>
-            <script>
-                renderMathInElement(document.body);
-            </script>
+            {% if katex_auto_render %}
+                <script>
+                    renderMathInElement(document.body,
+                        {
+                            {{ katex_auto_render }}
+                        }
+                    );
+                </script>
+            {% else %}
+                <script>
+                    renderMathInElement(document.body);
+                </script>
+            {% endif %}
         {% else %}
             <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
             {% if mathjax_config %}

--- a/nikola/data/themes/base-jinja/templates/post_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_helper.tmpl
@@ -89,9 +89,19 @@
         {% if use_katex %}
             <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.js"></script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/contrib/auto-render.min.js"></script>
-            <script>
-                renderMathInElement(document.body);
-            </script>
+            {% if katex_auto_render %}
+                <script>
+                    renderMathInElement(document.body,
+                        {
+                            {{ katex_auto_render }}
+                        }
+                    );
+                </script>
+            {% else %}
+                <script>
+                    renderMathInElement(document.body);
+                </script>
+            {% endif %}
         {% else %}
             <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
             {% if mathjax_config %}

--- a/nikola/data/themes/base-jinja/templates/post_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_helper.tmpl
@@ -87,8 +87,8 @@
 {% macro mathjax_script(post) %}
     {% if post.is_mathjax %}
         {% if use_katex %}
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/contrib/auto-render.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
             {% if katex_auto_render %}
                 <script>
                     renderMathInElement(document.body,

--- a/nikola/data/themes/base/templates/index_helper.tmpl
+++ b/nikola/data/themes/base/templates/index_helper.tmpl
@@ -21,11 +21,21 @@
 <%def name="mathjax_script(posts)">
     %if any(post.is_mathjax for post in posts):
         %if use_katex:
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/contrib/auto-render.min.js"></script>
-            <script>
-                renderMathInElement(document.body);
-            </script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+            % if katex_auto_render:
+                <script>
+                    renderMathInElement(document.body,
+                        {
+                            ${katex_auto_render}
+                        }
+                    );
+                </script>
+            % else:
+                <script>
+                    renderMathInElement(document.body);
+                </script>
+            % endif
         %else:
             <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
             % if mathjax_config:

--- a/nikola/data/themes/base/templates/post_helper.tmpl
+++ b/nikola/data/themes/base/templates/post_helper.tmpl
@@ -87,11 +87,21 @@
 <%def name="mathjax_script(post)">
     %if post.is_mathjax:
         %if use_katex:
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/katex.min.js"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.5.1/contrib/auto-render.min.js"></script>
-            <script>
-                renderMathInElement(document.body);
-            </script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/katex.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/contrib/auto-render.min.js"></script>
+            % if katex_auto_render:
+                <script>
+                    renderMathInElement(document.body,
+                        {
+                            ${katex_auto_render}
+                        }
+                    );
+                </script>
+            % else:
+                <script>
+                    renderMathInElement(document.body);
+                </script>
+            % endif
         %else:
             <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
             % if mathjax_config:

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -497,6 +497,7 @@ class Nikola(object):
             'INDEXES_STATIC': True,
             'INDEX_PATH': '',
             'IPYNB_CONFIG': {},
+            'KATEX_AUTO_RENDER': '',
             'LESS_COMPILER': 'lessc',
             'LESS_OPTIONS': [],
             'LICENSE': '',
@@ -1090,6 +1091,7 @@ class Nikola(object):
         self._GLOBAL_CONTEXT['mathjax_config'] = self.config.get(
             'MATHJAX_CONFIG')
         self._GLOBAL_CONTEXT['use_katex'] = self.config.get('USE_KATEX')
+        self._GLOBAL_CONTEXT['katex_auto_render'] = self.config.get('KATEX_AUTO_RENDER')
         self._GLOBAL_CONTEXT['subtheme'] = self.config.get('THEME_REVEAL_CONFIG_SUBTHEME')
         self._GLOBAL_CONTEXT['transition'] = self.config.get('THEME_REVEAL_CONFIG_TRANSITION')
         self._GLOBAL_CONTEXT['content_footer'] = self.config.get(


### PR DESCRIPTION
The new KaTeX version 0.6.0 supports aligned math display, which is useful. In addition, this pull request introduces the new KATEX_AUTO_RENDER label, which is useful for people who wants to create posts by using Jupyter Notebook. In particular, it will support the inline math $.$, which is the default math delimiter in Jupyter Notebook. More on KaTeX auto render can be seen from this [link](https://github.com/Khan/KaTeX/tree/master/contrib/auto-render).

This pull request will add the following code to the html source file of the post.
```javascript
<script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.6.0/contrib/auto-render.min.js"></script><script>
                renderMathInElement(document.body,
                {
                    delimiters: [
                        {left: "$$", right: "$$", display: true},
                        {left: "\\[", right: "\\]", display: true},
                        {left: "$", right: "$", display: false},
                        {left: "\\(", right: "\\)", display: false}
                    ]
                }
                );
</script>