### PR TITLE
Fixing dependency generation for jinja templating engine.

### DIFF
--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -112,7 +112,7 @@ class JinjaTemplates(TemplateSystem):
             filename = self.lookup.loader.get_source(self.lookup, dep_name)[1]
             deps.add(filename)
             sub_deps = self.get_deps(filename)
-            self.dependency_cache[dep_name] = sub_deps
+            self.dependency_cache[dep_name] = [filename] + sub_deps
             deps |= set(sub_deps)
         return list(deps)
 

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -110,9 +110,8 @@ class JinjaTemplates(TemplateSystem):
         dep_names = meta.find_referenced_templates(ast)
         for dep_name in dep_names:
             filename = self.lookup.loader.get_source(self.lookup, dep_name)[1]
-            deps.add(filename)
-            sub_deps = self.get_deps(filename)
-            self.dependency_cache[dep_name] = [filename] + sub_deps
+            sub_deps = [filename] + self.get_deps(filename)
+            self.dependency_cache[dep_name] = sub_deps
             deps |= set(sub_deps)
         return list(deps)
 


### PR DESCRIPTION
Jinja template dependencies sometimes miss the main template itself, depending on whether the dependencies where stored in the internal cache in `JinjaTemplates.get_string_deps` or in `JinjaTemplates.template_deps`.