### PR TITLE
Set markdown output_format to html5 instead of the default xhtml1

### DIFF
--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -78,7 +78,7 @@ class CompileMarkdown(PageCompiler):
                 data = in_file.read()
             if not is_two_file:
                 _, data = self.split_metadata(data)
-            output = markdown(data, self.extensions)
+            output = markdown(data, self.extensions, output_format="html5")
             output, shortcode_deps = self.site.apply_shortcodes(output, filename=source, with_dependencies=True, extra_context=dict(post=post))
             out_file.write(output)
         if post is None:


### PR DESCRIPTION
Fixes #2522 

Given the markdown library does not make much use of the output_format variable, I don't think this is likely to materially change the output for many people at all - https://github.com/waylan/Python-Markdown/search?utf8=%E2%9C%93&q=output_format)