### PR TITLE
Allow overriding URL_TYPE via meta

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Bugfixes
 Features
 --------
 
+* Allow posts to set custom ``URL_TYPE`` by using the ``url_type``
+  meta tag (useful for HTML fragments inserted using JavaScript)
 * Plugins can depend on other plugins being installed (Issue #2533)
 * The destination folder in ``POSTS`` and ``PAGES`` can now be
   translated (Issue #2116)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2085,7 +2085,8 @@ class Nikola(object):
                                     uptodate_deps=uptodate_deps,
                                     context=context,
                                     context_deps_remove=['post'],
-                                    post_deps_dict=deps_dict)
+                                    post_deps_dict=deps_dict,
+                                    url_type=post.url_type)
 
     def generic_post_list_renderer(self, lang, posts, output_name, template_name, filters, extra_context):
         """Render pages with lists of posts."""

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -249,6 +249,10 @@ class Post(object):
         self.use_in_feeds = use_in_feeds and not is_draft and not is_private \
             and not self.publish_later
 
+        # Allow overriding URL_TYPE via meta
+        # The check is done here so meta dicts won’t change inside of
+        # generic_post_rendere
+        self.url_type = self.meta('url_type') or None
         # Register potential extra dependencies
         self.compiler.register_extra_dependencies(self)
 

--- a/tests/test_rss_feeds.py
+++ b/tests/test_rss_feeds.py
@@ -3,12 +3,9 @@
 from __future__ import unicode_literals, absolute_import
 
 import os
-import sys
-
 
 from collections import defaultdict
 from io import StringIO
-import os
 import re
 import unittest
 
@@ -50,15 +47,15 @@ class RSSFeedTest(unittest.TestCase):
 
         with mock.patch('nikola.post.get_meta',
                         mock.Mock(return_value=(
-                            ({'title': 'post title',
-                              'slug': 'awesome_article',
-                              'date': '2012-10-01 22:41',
-                              'author': None,
-                              'tags': 'tags',
-                              'link': 'link',
-                              'description': 'description',
-                              'enclosure': 'http://www.example.org/foo.mp3',
-                              'enclosure_length': '5'},
+                            (defaultdict(str, {'title': 'post title',
+                                               'slug': 'awesome_article',
+                                               'date': '2012-10-01 22:41',
+                                               'author': None,
+                                               'tags': 'tags',
+                                               'link': 'link',
+                                               'description': 'description',
+                                               'enclosure': 'http://www.example.org/foo.mp3',
+                                               'enclosure_length': '5'}),
                              True)
                         ))):
             with mock.patch('nikola.nikola.utils.os.path.isdir',


### PR DESCRIPTION
Useful for HTML fragments inserted via JavaScript that contain links.

Use case: nikola-plugins-v2 and its side menu that can be changed
without rebuilding all pages.