### PR TITLE
Offer global_data everywhere (#2488)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ New in master
 Bugfixes
 --------
 
-* Make "data" from global context available to templated shortcodes (Issue #2488)
+* Make ``data`` from global context available to templated shortcodes
+  as ``global_data`` (Issue #2488)
 * Don't crash if plugins is a file (Issue #2539)
 
 Features

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1086,9 +1086,10 @@ In that case, the template engine used will be your theme's and the arguments yo
 as well as the global context from your ``conf.py``, are available to the template you
 are creating.
 
-You can use anything defined in your confguration's ``GLOBAL_CONTEXT`` as variables in your
-shortcode template, with a caveat: Because of an unfortunate implementation detail, data is called
-"global_data" when used in a shortcode.
+You can use anything defined in your confguration's ``GLOBAL_CONTEXT`` as
+variables in your shortcode template, with a caveat: Because of an unfortunate
+implementation detail (a name conflict), ``data`` is called ``global_data``
+when used in a shortcode.
 
 The Global Context and Data files
 ---------------------------------
@@ -1119,6 +1120,8 @@ JSON/YAML/TOML files and Nikola generates a large page with data from all data
 files. (This is especially useful with some automatic rebuild feature, like
 those documented in `Deployment`_)
 
+Data files are also available as ``global_data``, to avoid name conflicts in
+shortcodes. (``global_data`` works everywhere.)
 
 Redirections
 ------------

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1165,6 +1165,8 @@ class Nikola(object):
                 data = utils.load_data(fname)
                 key = os.path.splitext(fname.split(os.sep, 1)[1])[0]
                 self._GLOBAL_CONTEXT['data'][key] = data
+        # Offer global_data as an alias for data (Issue #2488)
+        self._GLOBAL_CONTEXT['global_data'] = self._GLOBAL_CONTEXT['data']
 
     def _activate_plugins_of_category(self, category):
         """Activate all the plugins of a given category and return them."""
@@ -1492,13 +1494,12 @@ class Nikola(object):
         Global context keys are made available as part of the context,
         respecting locale.
 
-        As a special quirk, the "data" key from global_context is made
-        available as "global_data" because of name clobbering.
+        As a special quirk, the "data" key from global_context is
+        available only as "global_data" because of name clobbering.
 
         """
         def render_shortcode(*args, **kw):
             context = self.GLOBAL_CONTEXT.copy()
-            context['global_data'] = context['data']
             context.update(kw)
             context['_args'] = args
             context['lang'] = utils.LocaleBorg().current_lang


### PR DESCRIPTION
The `global_data` name will be usable everywhere. `data` will still
work outside of shortcodes.

This is an alternate fix for #2488.
