### PR TITLE
Make thumbnail naming configurable with IMAGE_THUMBNAIL_FORMAT.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,7 @@ Features
   translated (Issue #2116)
 * Pass ``post`` object and ``lang`` to post compilers (Issue #2531)
 * Pass ``url_type`` into template's context.
+* Make thumbnail naming configurable with ``IMAGE_THUMBNAIL_FORMAT``.
 
 New in v7.8.1
 =============

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1641,8 +1641,10 @@ The ``conf.py`` options affecting images and gallery pages are these:
 
     # Images will be scaled down according to IMAGE_THUMBNAIL_SIZE and MAX_IMAGE_SIZE
     # options, but will have to be referenced manually to be visible on the site
-    # (the thumbnail has ``.thumbnail`` added before the file extension).
+    # (the thumbnail has ``.thumbnail`` added before the file extension by default,
+    # but a different naming template can be configured with IMAGE_THUMBNAIL_FORMAT).
     IMAGE_THUMBNAIL_SIZE = 400
+    IMAGE_THUMBNAIL_FORMAT = '{stem}.thumbnail{ext}'
 
 If you add a reST file in ``galleries/gallery_name/index.txt`` its contents will be
 converted to HTML and inserted above the images in the gallery page. The

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1644,7 +1644,7 @@ The ``conf.py`` options affecting images and gallery pages are these:
     # (the thumbnail has ``.thumbnail`` added before the file extension by default,
     # but a different naming template can be configured with IMAGE_THUMBNAIL_FORMAT).
     IMAGE_THUMBNAIL_SIZE = 400
-    IMAGE_THUMBNAIL_FORMAT = '{stem}.thumbnail{ext}'
+    IMAGE_THUMBNAIL_FORMAT = '{name}.thumbnail{ext}'
 
 If you add a reST file in ``galleries/gallery_name/index.txt`` its contents will be
 converted to HTML and inserted above the images in the gallery page. The

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -641,7 +641,7 @@ GITHUB_COMMIT_SOURCE = True
 
 IMAGE_FOLDERS = {'images': 'images'}
 # IMAGE_THUMBNAIL_SIZE = 400
-# IMAGE_THUMBNAIL_FORMAT = '{stem}.thumbnail{ext}'
+# IMAGE_THUMBNAIL_FORMAT = '{name}.thumbnail{ext}'
 
 # #############################################################################
 # HTML fragments and diverse things that are used by the templates

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -636,10 +636,12 @@ GITHUB_COMMIT_SOURCE = True
 
 # Images will be scaled down according to IMAGE_THUMBNAIL_SIZE and MAX_IMAGE_SIZE
 # options, but will have to be referenced manually to be visible on the site
-# (the thumbnail has ``.thumbnail`` added before the file extension).
+# (the thumbnail has ``.thumbnail`` added before the file extension by default,
+# but a different naming template can be configured with IMAGE_THUMBNAIL_FORMAT).
 
 IMAGE_FOLDERS = {'images': 'images'}
 # IMAGE_THUMBNAIL_SIZE = 400
+# IMAGE_THUMBNAIL_FORMAT = '{stem}.thumbnail{ext}'
 
 # #############################################################################
 # HTML fragments and diverse things that are used by the templates

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -501,7 +501,7 @@ class Nikola(object):
             'INDEX_FILE': 'index.html',
             'INDEX_TEASERS': False,
             'IMAGE_THUMBNAIL_SIZE': 400,
-            'IMAGE_THUMBNAIL_FORMAT': '{stem}.thumbnail{ext}',
+            'IMAGE_THUMBNAIL_FORMAT': '{name}.thumbnail{ext}',
             'INDEXES_TITLE': "",
             'INDEXES_PAGES': "",
             'INDEXES_PAGES_MAIN': False,

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -501,6 +501,7 @@ class Nikola(object):
             'INDEX_FILE': 'index.html',
             'INDEX_TEASERS': False,
             'IMAGE_THUMBNAIL_SIZE': 400,
+            'IMAGE_THUMBNAIL_FORMAT': '{stem}.thumbnail{ext}',
             'INDEXES_TITLE': "",
             'INDEXES_PAGES': "",
             'INDEXES_PAGES_MAIN': False,

--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -45,6 +45,7 @@ class ScaleImage(Task, ImageProcessor):
 
     def process_tree(self, src, dst):
         """Process all images in a src tree and put the (possibly) rescaled images in the dst folder."""
+        thumb_fmt = self.kw['image_thumbnail_format']
         ignore = set(['.svn'])
         base_len = len(src.split(os.sep))
         for root, dirs, files in os.walk(src, followlinks=True):
@@ -60,7 +61,11 @@ class ScaleImage(Task, ImageProcessor):
                     continue
                 dst_file = os.path.join(dst_dir, src_name)
                 src_file = os.path.join(root, src_name)
-                thumb_file = '.thumbnail'.join(os.path.splitext(dst_file))
+                thumb_stem, thumb_ext = os.path.splitext(src_name)
+                thumb_file = os.path.join(dst_dir, thumb_fmt.format(
+                    stem=thumb_stem,
+                    ext=thumb_ext,
+                ))
                 yield {
                     'name': dst_file,
                     'file_dep': [src_file],
@@ -78,6 +83,7 @@ class ScaleImage(Task, ImageProcessor):
         """Copy static files into the output folder."""
         self.kw = {
             'image_thumbnail_size': self.site.config['IMAGE_THUMBNAIL_SIZE'],
+            'image_thumbnail_format': self.site.config['IMAGE_THUMBNAIL_FORMAT'],
             'max_image_size': self.site.config['MAX_IMAGE_SIZE'],
             'image_folders': self.site.config['IMAGE_FOLDERS'],
             'output_folder': self.site.config['OUTPUT_FOLDER'],

--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -61,9 +61,9 @@ class ScaleImage(Task, ImageProcessor):
                     continue
                 dst_file = os.path.join(dst_dir, src_name)
                 src_file = os.path.join(root, src_name)
-                thumb_stem, thumb_ext = os.path.splitext(src_name)
+                thumb_name, thumb_ext = os.path.splitext(src_name)
                 thumb_file = os.path.join(dst_dir, thumb_fmt.format(
-                    stem=thumb_stem,
+                    name=thumb_name,
                     ext=thumb_ext,
                 ))
                 yield {


### PR DESCRIPTION
This will make it possible to deviate from the hard-coded thumbnail naming scheme of `original_image_name.thumbnail.extension`.

Coincidentally, it also allows to force all thumbnails to a particular image format (say JPEG) by putting that extension into the template literally instead of using the `{ext}` placeholder.

The default template `'{stem}.thumbnail{ext}'` corresponds to the current hard-coded naming scheme, so it's backwards compatible.

My personal use case is getting `.jpg` thumbnails out of source `.png` images, as my source material mainly consists of paletted 4 and 16 color images, which compress extremely well as PNG images, but when scaled down as thumbnails, they gain all kinds of extra shades of colors due to interpolation (which I want to keep, this is really fine and makes the thumbnails very nice to look at despite their smaller size), so the thumbnail files get __significantly__ larger than the actual images. Considering that the primary blog article (before following the links to the original images) should be lean and mean, this is somewhat disappointing. So generating JPEG thumbnails is my way of counteracting the file size increase somewhat:

     41818 images/tfmx-tutorial-1/17-tfmx-load-song.png
     21586 output/images/tfmx-tutorial-1/17-tfmx-load-song.png
    148790 output/images/tfmx-tutorial-1/17-tfmx-load-song.thumbnail.png
     86125 output/images/tfmx-tutorial-1/17-tfmx-load-song.thumbnail.jpg

Also, I don't particularly like the `.thumbnail` string, as it's a bit too long for my taste. Making the naming configurable enables me to change that in my blog's `conf.py` later to whatever I desire.
