### PR TITLE
Fix #2566 -- remove unusual scale_images ignores

### DIFF
--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -46,17 +46,12 @@ class ScaleImage(Task, ImageProcessor):
     def process_tree(self, src, dst):
         """Process all images in a src tree and put the (possibly) rescaled images in the dst folder."""
         thumb_fmt = self.kw['image_thumbnail_format']
-        ignore = set(['.svn'])
         base_len = len(src.split(os.sep))
         for root, dirs, files in os.walk(src, followlinks=True):
             root_parts = root.split(os.sep)
-            if set(root_parts) & ignore:
-                continue
             dst_dir = os.path.join(dst, *root_parts[base_len:])
             utils.makedirs(dst_dir)
             for src_name in files:
-                if src_name in ('.DS_Store', 'Thumbs.db'):
-                    continue
                 if (not src_name.lower().endswith(tuple(self.image_ext_list)) and not src_name.upper().endswith(tuple(self.image_ext_list))):
                     continue
                 dst_file = os.path.join(dst_dir, src_name)


### PR DESCRIPTION
Rationale:

* SVN is basically dead, and the ignore isn’t necessary for modern
versions anyway. (Fixed in 2011)
* .DS_Store and Thumbs.db are not going to be considered image files
due to their extensions anyways.

cc @ralsina, @felixfontein, @blubberdiblub