### PR TITLE
Fixed typo in help message of command 'nikola auto'.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,6 @@ New in master
 Bugfixes
 --------
 
-* Fixed typo in help message for command ``nikola auto``. Changed
-  ``Port nummber`` to ``Port number`` (Issue #2571)
 * Make ``data`` from global context available to templated shortcodes
   as ``global_data`` (Issue #2488)
 * Don't crash if plugins is a file (Issue #2539)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Bugfixes
 --------
 
+* Fixed typo in help message for command ``nikola auto``. Changed
+  ``Port nummber`` to ``Port number`` (Issue #2571)
 * Make ``data`` from global context available to templated shortcodes
   as ``global_data`` (Issue #2488)
 * Don't crash if plugins is a file (Issue #2539)

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -94,7 +94,7 @@ class CommandAuto(Command):
             'long': 'port',
             'default': 8000,
             'type': int,
-            'help': 'Port nummber (default: 8000)',
+            'help': 'Port number (default: 8000)',
         },
         {
             'name': 'address',


### PR DESCRIPTION
I changed the description of argument -p from 'Port nummber' to 'Port number'