### PR TITLE
Keyword arguments in path handlers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ Bugfixes
 Features
 --------
 
+* Query strings in magic links are passed as keyword arguments to path
+  handlers (via Issue #2580)
 * Accept arbitrary arguments to path handlers (via Issue #2580)
 * Added new ``typogrify_oldschool`` filter (Issue #2574)
 * Improving handling of .dep files, and allowing compilers to specify

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Bugfixes
 Features
 --------
 
+* Accept arbitrary arguments to path handlers (via Issue #2580)
 * Added new ``typogrify_oldschool`` filter (Issue #2574)
 * Improving handling of .dep files, and allowing compilers to specify
   additional targets for the render_posts task (Issue #2536)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -39,9 +39,9 @@ import sys
 import natsort
 import mimetypes
 try:
-    from urlparse import urlparse, urlsplit, urlunsplit, urljoin, unquote
+    from urlparse import urlparse, urlsplit, urlunsplit, urljoin, unquote, parse_qs
 except ImportError:
-    from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote  # NOQA
+    from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote, parse_qs  # NOQA
 
 try:
     import pyphen
@@ -1433,7 +1433,14 @@ class Nikola(object):
         # Refuse to replace links that are full URLs.
         if dst_url.netloc:
             if dst_url.scheme == 'link':  # Magic link
-                dst = self.link(dst_url.netloc, dst_url.path.lstrip('/'), lang)
+                if dst_url.query:
+                    # If query strings are used in magic link, they will be
+                    # passed to the path handler as keyword arguments (strings)
+                    link_kwargs = {k: v[-1] for k, v in parse_qs(dst_url.query).items()}
+                else:
+                    link_kwargs = {}
+
+                dst = self.link(dst_url.netloc, dst_url.path.lstrip('/'), lang, **link_kwargs)
             # Assuming the site is served over one of these, and
             # since those are the only URLs we want to rewrite...
             else:

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1688,7 +1688,7 @@ class Nikola(object):
                 data = data.decode('utf-8')
             rss_file.write(data)
 
-    def path(self, kind, name, lang=None, is_link=False):
+    def path(self, kind, name, lang=None, is_link=False, **kwargs):
         r"""Build the path to a certain kind of page.
 
         These are mostly defined by plugins by registering via the
@@ -1725,7 +1725,7 @@ class Nikola(object):
             lang = utils.LocaleBorg().current_lang
 
         try:
-            path = self.path_handlers[kind](name, lang)
+            path = self.path_handlers[kind](name, lang, **kwargs)
             path = [os.path.normpath(p) for p in path if p != '.']  # Fix Issue #1028
             if is_link:
                 link = '/' + ('/'.join(path))
@@ -1804,9 +1804,9 @@ class Nikola(object):
         else:
             self.path_handlers[kind] = f
 
-    def link(self, *args):
+    def link(self, *args, **kwargs):
         """Create a link."""
-        url = self.path(*args, is_link=True)
+        url = self.path(*args, is_link=True, **kwargs)
         url = utils.encodelink(url)
         return url
 

--- a/scripts/document_path_handlers.py
+++ b/scripts/document_path_handlers.py
@@ -9,8 +9,10 @@ print(""".. title: Path Handlers for Nikola
 .. slug: path-handlers
 .. author: The Nikola Team
 
-Nikola supports special links with the syntax ``link://kind/name``. In the templates you can also
-use ``_link(kind, name)`` Here is the description for all the supported kinds.
+Nikola supports special links with the syntax ``link://kind/name``. In the templates you can also use ``_link(kind, name)``.
+You can also add query strings (``?key=value``) for extra arguments, or pass keyword arguments to ``_link`` in templates (support and behavior depends on path handlers themselves)
+
+Here are the descriptions for all the supported kinds.
 
 .. class:: dl-horizontal
 """)


### PR DESCRIPTION
This implements the generic functionality needed for #2580. I’ll try to do it for the Taxonomy stuff in a future PR (first, I need to understand the thing)

cc @felixfontein 