### PR TITLE
Accept a `page` argument for taxonomy paths

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,7 @@ Bugfixes
 Features
 --------
 
+* Accept a ``page`` argument for taxonomy paths (Issue #2585)
 * Query strings in magic links are passed as keyword arguments to path
   handlers (via Issue #2580)
 * Accept arbitrary arguments to path handlers (via Issue #2580)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2386,7 +2386,7 @@ class Nikola(object):
         kw["indexes_pages"] = self.config['INDEXES_PAGES'](lang)
         kw["indexes_pages_main"] = self.config['INDEXES_PAGES_MAIN']
         kw["indexes_static"] = self.config['INDEXES_STATIC']
-        kw['indexes_prety_page_url'] = self.config["INDEXES_PRETTY_PAGE_URL"]
+        kw['indexes_pretty_page_url'] = self.config["INDEXES_PRETTY_PAGE_URL"]
         kw['demote_headers'] = self.config['DEMOTE_HEADERS']
         kw['generate_atom'] = self.config["GENERATE_ATOM"]
         kw['feed_links_append_query'] = self.config["FEED_LINKS_APPEND_QUERY"]
@@ -2511,7 +2511,7 @@ class Nikola(object):
                 }
                 yield utils.apply_filters(atom_task, kw['filters'])
 
-        if kw["indexes_pages_main"] and kw['indexes_prety_page_url'](lang):
+        if kw["indexes_pages_main"] and kw['indexes_pretty_page_url'](lang):
             # create redirection
             output_name = os.path.join(kw['output_folder'], page_path(0, displayed_page_numbers[0], num_pages, True))
             link = page_links[0]

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -269,15 +269,21 @@ class TaxonomiesClassifier(SignalHandler):
         path, append_index, _ = self._parse_path_result(result)
         return self._postprocess_path(path, lang, append_index=append_index, dest_type='list')
 
-    def _taxonomy_path(self, name, lang, taxonomy, dest_type='page'):
+    def _taxonomy_path(self, name, lang, taxonomy, dest_type='page', page=None):
         """Return path to a classification."""
         if taxonomy.has_hierarchy:
             result = taxonomy.get_path(taxonomy.extract_hierarchy(name), lang, dest_type=dest_type)
         else:
             result = taxonomy.get_path(name, lang, dest_type=dest_type)
-        path, append_index, page = self._parse_path_result(result)
+        path, append_index, page_ = self._parse_path_result(result)
+
+        if page is not None:
+            page = int(page)
+        else:
+            page = page_
+
         page_info = None
-        if not taxonomy.show_list_as_index and page is not None:
+        if taxonomy.show_list_as_index and page is not None:
             number_of_pages = self.site.page_count_per_classification[taxonomy.classification_name][lang].get(name)
             if number_of_pages is None:
                 number_of_pages = self._compute_number_of_pages(self._get_filtered_list(taxonomy, name, lang), self.site.config['INDEX_DISPLAY_POST_COUNT'])

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -205,7 +205,7 @@ class TaxonomiesClassifier(SignalHandler):
         """Given a list of posts and the maximal number of posts per page, computes the number of pages needed."""
         return min(1, (len(filtered_posts) + posts_count - 1) // posts_count)
 
-    def _postprocess_path(self, path, lang, append_index='auto', dest_type='page', page_info=None):
+    def _postprocess_path(self, path, lang, append_index='auto', dest_type='page', page_info=None, alternative_path=False):
         """Postprocess a generated path.
 
         Takes the path `path` for language `lang`, and postprocesses it.
@@ -218,11 +218,15 @@ class TaxonomiesClassifier(SignalHandler):
         `site.config['INDEX_FILE']` depending on `dest_type`, which can be
         `'feed'`, `'rss'` or `'page'`.
 
-        Finally, if `dest_type` is `'page'`, `page_info` can be `None` or a tuple
+        If `dest_type` is `'page'`, `page_info` can be `None` or a tuple
         of two integers: the page number and the number of pages. This will
         be used to append the correct page number by calling
         `utils.adjust_name_for_index_path_list` and
         `utils.get_displayed_page_number`.
+
+        If `alternative_path` is set to `True`, `utils.adjust_name_for_index_path_list`
+        is called with `force_addition=True`, resulting in an alternative path for the
+        first page of an index or Atom feed.
         """
         # Forcing extension for Atom feeds and RSS feeds
         force_extension = None
@@ -249,7 +253,7 @@ class TaxonomiesClassifier(SignalHandler):
                                                            page_info[0],
                                                            utils.get_displayed_page_number(page_info[0], page_info[1], self.site),
                                                            lang,
-                                                           self.site, extension=force_extension)
+                                                           self.site, force_addition=alternative_path, extension=force_extension)
         return result
 
     @staticmethod
@@ -269,7 +273,7 @@ class TaxonomiesClassifier(SignalHandler):
         path, append_index, _ = self._parse_path_result(result)
         return self._postprocess_path(path, lang, append_index=append_index, dest_type='list')
 
-    def _taxonomy_path(self, name, lang, taxonomy, dest_type='page', page=None):
+    def _taxonomy_path(self, name, lang, taxonomy, dest_type='page', page=None, alternative_path=False):
         """Return path to a classification."""
         if taxonomy.has_hierarchy:
             result = taxonomy.get_path(taxonomy.extract_hierarchy(name), lang, dest_type=dest_type)
@@ -291,9 +295,9 @@ class TaxonomiesClassifier(SignalHandler):
             page_info = (page, number_of_pages)
         return self._postprocess_path(path, lang, append_index=append_index, dest_type=dest_type, page_info=page_info)
 
-    def _taxonomy_atom_path(self, name, lang, taxonomy, page=None):
+    def _taxonomy_atom_path(self, name, lang, taxonomy, page=None, alternative_path=False):
         """Return path to a classification Atom feed."""
-        return self._taxonomy_path(name, lang, taxonomy, dest_type='feed', page=page)
+        return self._taxonomy_path(name, lang, taxonomy, dest_type='feed', page=page, alternative_path=alternative_path)
 
     def _taxonomy_rss_path(self, name, lang, taxonomy):
         """Return path to a classification RSS feed."""

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -291,9 +291,9 @@ class TaxonomiesClassifier(SignalHandler):
             page_info = (page, number_of_pages)
         return self._postprocess_path(path, lang, append_index=append_index, dest_type=dest_type, page_info=page_info)
 
-    def _taxonomy_atom_path(self, name, lang, taxonomy):
+    def _taxonomy_atom_path(self, name, lang, taxonomy, page=None):
         """Return path to a classification Atom feed."""
-        return self._taxonomy_path(name, lang, taxonomy, dest_type='feed')
+        return self._taxonomy_path(name, lang, taxonomy, dest_type='feed', page=page)
 
     def _taxonomy_rss_path(self, name, lang, taxonomy):
         """Return path to a classification RSS feed."""

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -226,7 +226,7 @@ class TaxonomiesClassifier(SignalHandler):
 
         If `alternative_path` is set to `True`, `utils.adjust_name_for_index_path_list`
         is called with `force_addition=True`, resulting in an alternative path for the
-        first page of an index or Atom feed.
+        first page of an index or Atom feed by including the page number into the path.
         """
         # Forcing extension for Atom feeds and RSS feeds
         force_extension = None

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -28,6 +28,7 @@
 
 from __future__ import unicode_literals
 import blinker
+import functools
 import natsort
 import os
 import sys
@@ -262,7 +263,7 @@ class TaxonomiesClassifier(SignalHandler):
         page_info = result[2] if len(result) > 2 else None
         return path, append_index, page_info
 
-    def _taxonomy_index_path(self, lang, taxonomy):
+    def _taxonomy_index_path(self, name, lang, taxonomy):
         """Return path to the classification overview."""
         result = taxonomy.get_overview_path(lang)
         path, append_index, _ = self._parse_path_result(result)
@@ -293,10 +294,10 @@ class TaxonomiesClassifier(SignalHandler):
         return self._taxonomy_path(name, lang, taxonomy, dest_type='rss')
 
     def _register_path_handlers(self, taxonomy):
-        self.site.register_path_handler('{0}_index'.format(taxonomy.classification_name), lambda name, lang: self._taxonomy_index_path(lang, taxonomy))
-        self.site.register_path_handler('{0}'.format(taxonomy.classification_name), lambda name, lang: self._taxonomy_path(name, lang, taxonomy))
-        self.site.register_path_handler('{0}_atom'.format(taxonomy.classification_name), lambda name, lang: self._taxonomy_atom_path(name, lang, taxonomy))
-        self.site.register_path_handler('{0}_rss'.format(taxonomy.classification_name), lambda name, lang: self._taxonomy_rss_path(name, lang, taxonomy))
+        self.site.register_path_handler('{0}_index'.format(taxonomy.classification_name), functools.partial(self._taxonomy_index_path, taxonomy=taxonomy))
+        self.site.register_path_handler('{0}'.format(taxonomy.classification_name), functools.partial(self._taxonomy_path, taxonomy=taxonomy))
+        self.site.register_path_handler('{0}_atom'.format(taxonomy.classification_name), functools.partial(self._taxonomy_atom_path, taxonomy=taxonomy))
+        self.site.register_path_handler('{0}_rss'.format(taxonomy.classification_name), functools.partial(self._taxonomy_rss_path, taxonomy=taxonomy))
 
     def set_site(self, site):
         """Set site, which is a Nikola instance."""

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -244,12 +244,12 @@ class TaxonomiesClassifier(SignalHandler):
             path[-1] += '.html'
         # Create path
         result = [_f for _f in [self.site.config['TRANSLATIONS'][lang]] + path if _f]
-        if page_info is not None and dest_type == 'page':
+        if page_info is not None and dest_type in ('page', 'feed'):
             result = utils.adjust_name_for_index_path_list(result,
                                                            page_info[0],
                                                            utils.get_displayed_page_number(page_info[0], page_info[1], self.site),
                                                            lang,
-                                                           self.site)
+                                                           self.site, extension=force_extension)
         return result
 
     @staticmethod

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -103,7 +103,7 @@ class ClassifyCategories(Taxonomy):
 
     def get_path(self, classification, lang, dest_type='page'):
         """A path handler for the given classification."""
-        return ([_f for _f in [self.site.config['CATEGORY_PATH'](lang)] if _f] + self.slugify_category_name(classification, lang), 'auto')
+        return [_f for _f in [self.site.config['CATEGORY_PATH'](lang)] if _f] + self.slugify_category_name(classification, lang), 'auto'
 
     def extract_hierarchy(self, classification):
         """Given a classification, return a list of parts in the hierarchy."""

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -230,11 +230,11 @@ class RenderTaxonomies(Task):
 
         def page_link(i, displayed_i, num_pages, force_addition, extension=None):
             feed = "{}_atom" if extension == ".atom" else "{}"
-            return self.site.link(feed.format(kind), classification, lang, page=i)
+            return utils.adjust_name_for_index_link(self.site.link(feed.format(kind), classification, lang), i, displayed_i, lang, self.site, force_addition, extension)
 
         def page_path(i, displayed_i, num_pages, force_addition, extension=None):
             feed = "{}_atom" if extension == ".atom" else "{}"
-            return self.site.path(feed.format(kind), classification, lang, page=i)
+            return utils.adjust_name_for_index_path(self.site.path(feed.format(kind), classification, lang), i, displayed_i, lang, self.site, force_addition, extension)
 
         context = copy(context)
         if "pagekind" not in context:

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -230,11 +230,11 @@ class RenderTaxonomies(Task):
 
         def page_link(i, displayed_i, num_pages, force_addition, extension=None):
             feed = "{}_atom" if extension == ".atom" else "{}"
-            return utils.adjust_name_for_index_link(self.site.link(feed.format(kind), classification, lang), i, displayed_i, lang, self.site, force_addition, extension)
+            return self.site.link(feed.format(kind), classification, lang, alternative_path=force_addition, page=i)
 
         def page_path(i, displayed_i, num_pages, force_addition, extension=None):
             feed = "{}_atom" if extension == ".atom" else "{}"
-            return utils.adjust_name_for_index_path(self.site.path(feed.format(kind), classification, lang), i, displayed_i, lang, self.site, force_addition, extension)
+            return self.site.path(feed.format(kind), classification, lang, alternative_path=force_addition, page=i)
 
         context = copy(context)
         if "pagekind" not in context:

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -230,11 +230,11 @@ class RenderTaxonomies(Task):
 
         def page_link(i, displayed_i, num_pages, force_addition, extension=None):
             feed = "{}_atom" if extension == ".atom" else "{}"
-            return utils.adjust_name_for_index_link(self.site.link(feed.format(kind), classification, lang), i, displayed_i, lang, self.site, force_addition, extension)
+            return self.site.link(feed.format(kind), classification, lang, page=i)
 
         def page_path(i, displayed_i, num_pages, force_addition, extension=None):
             feed = "{}_atom" if extension == ".atom" else "{}"
-            return utils.adjust_name_for_index_path(self.site.path(feed.format(kind), classification, lang), i, displayed_i, lang, self.site, force_addition, extension)
+            return self.site.path(feed.format(kind), classification, lang, page=i)
 
         context = copy(context)
         if "pagekind" not in context:


### PR DESCRIPTION
This is #2585, cc @felixfontein. Note the change in the `if` for pagination — did I just fix a bug or was it intended?