### PR TITLE
Remove all uses of `assert` in the codebase

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1365,8 +1365,8 @@ class Nikola(object):
         if output_name is None:
             return data
 
-        assert output_name.startswith(
-            self.config["OUTPUT_FOLDER"])
+        if not output_name.startswith(self.config["OUTPUT_FOLDER"]):
+            raise ValueError("Output path for templates must start with OUTPUT_FOLDER")
         url_part = output_name[len(self.config["OUTPUT_FOLDER"]) + 1:]
 
         # Treat our site as if output/ is "/" and then make all URLs relative,
@@ -1528,7 +1528,8 @@ class Nikola(object):
         if parsed_dst.fragment:
             result += "#" + parsed_dst.fragment
 
-        assert result, (src, dst, i, src_elems, dst_elems)
+        if not result:
+            raise ValueError("Failed to parse link: {0}".format((src, dst, i, src_elems, dst_elems)))
 
         return result
 
@@ -1890,7 +1891,8 @@ class Nikola(object):
         task_dep = []
         for pluginInfo in self.plugin_manager.getPluginsOfCategory(plugin_category):
             for task in flatten(pluginInfo.plugin_object.gen_tasks()):
-                assert 'basename' in task
+                if 'basename' not in task:
+                    raise ValueError("Task {0} does not have a basename".format(task))
                 task = self.clean_task_paths(task)
                 if 'task_dep' not in task:
                     task['task_dep'] = []

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -66,7 +66,8 @@ class TaxonomiesClassifier(SignalHandler):
                     for lang in site.config['TRANSLATIONS'].keys():
                         # Extract classifications for this language
                         classifications[lang] = taxonomy.classify(post, lang)
-                        assert taxonomy.more_than_one_classifications_per_post or len(classifications[lang]) <= 1
+                        if not taxonomy.more_than_one_classifications_per_post and len(classifications[lang]) > 1:
+                            raise ValueError("Too many {0} classifications for post {1}".format(taxonomy.classification_name, post.source_path)
                         # Add post to sets
                         for classification in classifications[lang]:
                             while True:

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -67,7 +67,7 @@ class TaxonomiesClassifier(SignalHandler):
                         # Extract classifications for this language
                         classifications[lang] = taxonomy.classify(post, lang)
                         if not taxonomy.more_than_one_classifications_per_post and len(classifications[lang]) > 1:
-                            raise ValueError("Too many {0} classifications for post {1}".format(taxonomy.classification_name, post.source_path)
+                            raise ValueError("Too many {0} classifications for post {1}".format(taxonomy.classification_name, post.source_path))
                         # Add post to sets
                         for classification in classifications[lang]:
                             while True:

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -922,7 +922,7 @@ def apply_filters(task, filters, skip_ext=None):
                 if ext == key:
                     return value
             else:
-                assert False, key
+                raise ValueError("Cannot find filter match for {0}".format(key))
 
     for target in task.get('targets', []):
         ext = os.path.splitext(target)[-1].lower()
@@ -1100,7 +1100,8 @@ class LocaleBorg(object):
                 locale.setlocale(locale.LC_ALL, locale_n) will succeed
                 locale_n expressed in the string form, like "en.utf8"
         """
-        assert initial_lang is not None and initial_lang in locales
+        if initial_lang is None or initial_lang not in locales:
+            raise ValueError("Unknown initial language {0}".format(initial_lang))
         cls.reset()
         cls.locales = locales
         cls.month_name_handlers = []


### PR DESCRIPTION
The `assert` statement can be disabled (`python -O`) and often does not
explain what went wrong. This replaces all uses of `assert` with an `if`
and a `ValueError`.

This needs a logic review, I had to invert conditions manually.

Signed-off-by: Chris Warrick <kwpolska@gmail.com>