### PR TITLE
Allowing cross-classification navigation

### DIFF
--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -582,6 +582,14 @@ class Taxonomy(BasePlugin):
         Whether to include all classifications for all languages in every
         language, or only the classifications for one language in its language's
         pages.
+
+    insert_classification_navigation_links = False:
+        If set to True, inserts links to previous and following
+        classifications (based on the order induced by natsort and
+        modified by Taxonomy.sort_classifications) and, for hierarchical
+        taxonomies, links to the parent (if exists), previous and following
+        siblings, and previous and following classifications on the same
+        hierarchy level.
     """
 
     name = "dummy_taxonomy"
@@ -607,6 +615,7 @@ class Taxonomy(BasePlugin):
     minimum_post_count_per_classification_in_overview = 1
     omit_empty_classifications = False
     also_create_classifications_from_other_languages = True
+    insert_classification_navigation_links = False
 
     def is_enabled(self, lang=None):
         """Return True if this taxonomy is enabled, or False otherwise.

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -52,6 +52,7 @@ class Archive(Taxonomy):
     minimum_post_count_per_classification_in_overview = 1
     omit_empty_classifications = False
     also_create_classifications_from_other_languages = False
+    insert_classification_navigation_links = True
 
     def set_site(self, site):
         """Set Nikola site."""

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -445,7 +445,8 @@ class RenderTaxonomies(Task):
         context = copy(context)
         context["permalink"] = self.site.link(taxonomy.classification_name, classification, lang)
         # Links to previous/next classifications
-        self._add_cross_classification_navigation_links(taxonomy, classification, context, kw, lang, generate_list, generate_rss)
+        if taxonomy.insert_classification_navigation_links:
+            self._add_cross_classification_navigation_links(taxonomy, classification, context, kw, lang, generate_list, generate_rss)
         # Decide what to do
         if taxonomy.has_hierarchy and taxonomy.show_list_as_subcategories_list:
             # Determine whether there are subcategories

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -46,7 +46,7 @@ class RenderTaxonomies(Task):
     name = "render_taxonomies"
 
     def _generate_classification_data(self, taxonomy, lang):
-        """Create context and kw for a classification overview page."""
+        """Prepare lookup tables for cross-classification navigation links."""
         # Collect all relevant classifications
         if taxonomy.has_hierarchy:
             # Create clipped tree
@@ -328,6 +328,7 @@ class RenderTaxonomies(Task):
         return task
 
     def _add_cross_classification_navigation_links(self, taxonomy, classification, context, kw, lang, generate_list, generate_rss):
+        """Add various cross-classification navigation links to kw and context."""
         classifications, classifications_lookup, clipped_root_list, clipped_flat_hierarchy, clipped_flat_lookup, clipped_node_lookup = self.classification_data[taxonomy.classification_name][lang]
         # Get previous and next in (flattened) list of all classifications
         i = classifications_lookup.get(classification)
@@ -388,6 +389,7 @@ class RenderTaxonomies(Task):
         result = {}
 
         def add(name, classification):
+            """Helper for adding variables."""
             result[name] = classification
             if classification is not None:
                 result['{0}_name'.format(name)] = taxonomy.get_classification_friendly_name(classification, lang, only_last_component=False)

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -402,8 +402,8 @@ class RenderTaxonomies(Task):
         add('next_{0}'.format(taxonomy.classification_name), next_classification)
         add('previous_{0}_sibling'.format(taxonomy.classification_name), previous_sibling)
         add('next_{0}_sibling'.format(taxonomy.classification_name), next_sibling)
-        add('previous_{0}_samelevel'.format(taxonomy.classification_name), previous_sibling)
-        add('next_{0}_samelevel'.format(taxonomy.classification_name), next_sibling)
+        add('previous_{0}_samelevel'.format(taxonomy.classification_name), previous_samelevel)
+        add('next_{0}_samelevel'.format(taxonomy.classification_name), next_samelevel)
         add('parent_{0}'.format(taxonomy.classification_name), parent)
         # Update context and kw
         context.update(result)

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -444,6 +444,8 @@ class RenderTaxonomies(Task):
         kw["index_file"] = self.site.config['INDEX_FILE']
         context = copy(context)
         context["permalink"] = self.site.link(taxonomy.classification_name, classification, lang)
+        if taxonomy.has_hierarchy:
+            context["hierarchy_level"] = len(taxonomy.extract_hierarchy(classification))
         # Links to previous/next classifications
         if taxonomy.insert_classification_navigation_links:
             self._add_cross_classification_navigation_links(taxonomy, classification, context, kw, lang, generate_list, generate_rss)


### PR DESCRIPTION
Inserts links to previous/parent/next pages/Atom/RSS to context for taxonomy classification pages.

This allows to implement #1639 with the following variables:
 - `previous_archive*`: whatever archive entry comes before this one (sorted alphabetically; this is more useful for tags or other classifications than for archives);
 - `next_archive*`: whatever archive entry comes before this one (sorted alphabetically; this is more useful for tags or other classifications than for archives);
 - `previous_archive_sibling*`: for months, the previous month in this year (or `None` if there is none); same for years and days;
 - `next_archive_sibling*`: for months, the next month in this year (or `None` if there is none); same for years and days;
 - `previous_archive_samelevel*`: for months, the previous month in this year or the previous years (or `None` if there is none); same for years and days;
 - `next_archive_samelevel*`: for months, the next month in this year or the previous years (or `None` if there is none); same for years and days;
 - `parent_archive*`: for months, the year; for years, the global archive; and for days, the month.

Here, `*` can be replaced with nothing (to get classification identifier), `_name` for a friendly name (like 'May 2015'), `_link` for a link to the classification page, `_atom` for a link to the Atom feed for this classification, and `_rss` for a link to the RSS feed for this classification.

I haven't modified any templates yet; whoever wants to do this, feel free.

Also, nothing is added to Atom feeds (as @da2x suggested in #1639) since I have no idea how it should/could be added there.