### PR TITLE
Work around conflicts between posts and section indexes (via #2613)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Bugfixes
 --------
 
+* Work around conflicts between posts and sections trying to render
+  index.html files (via Issue #2613)
 * Make ``AUTHOR_PAGES_ARE_INDEXES`` really work (Issue #2600)
 * WordPress importer now correctly handles &amp; etc. in tags.
   (Issue #2557)

--- a/nikola/plugins/task/sections.py
+++ b/nikola/plugins/task/sections.py
@@ -120,3 +120,13 @@ class ClassifySections(Taxonomy):
                         continue
                     sections.add(section)
             self.enable_for_lang[lang] = (len(sections) > 1)
+
+    def should_generate_classification_page(self, dirname, post_list, lang):
+        """Only generates list of posts for classification if this function returns True."""
+        short_destination = dirname + '/' + self.site.config['INDEX_FILE']
+        for post in post_list:
+            # If there is an index.html pending to be created from a page, do not generate the section page.
+            # The section page would be useless anyways. (via Issue #2613)
+            if post.destination_path(lang, sep='/') == short_destination:
+                return False
+        return True


### PR DESCRIPTION
This is a workaround, because it uses the same mechanism `PAGE_INDEXES`
use to prevent generating pages. A real solution would need to figure
out that those pages are not sections.

cc @felixfontein, @ChillarAnand. Via #2613.