### PR TITLE
Improving post sorting.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,12 +1,17 @@
+New in master
+=============
+
 Features
 --------
 
-* It is easier to globally modify chronological post sorting.
-  Also, when posts are sorted for taxonomies, the post's title
-  is taken into account before resorting to the post's source path,
-  and the sorting order for title and source path are not reversed
-  anymore. (Issue #2627 / PR #2630)
+* Sort posts chronologically with one unified function (easier to
+  change). (Issue #2627)
+* Sort posts in the following order (most important last): source path
+  (A-Z), title (A-Z), date (reverse chronological order), priority
+  meta number (descending). (Issue #2627)
 
+Bugfixes
+--------
 
 New in v7.8.2
 =============

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,13 @@
+Features
+--------
+
+* It is easier to globally modify chronological post sorting.
+  Also, when posts are sorted for taxonomies, the post's title
+  is taken into account before resorting to the post's source path,
+  and the sorting order for title and source path are not reversed
+  anymore. (Issue #2627 / PR #2630)
+
+
 New in v7.8.2
 =============
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1984,7 +1984,8 @@ class Nikola(object):
         # Next, flatten the hierarchy
         self.category_hierarchy = utils.flatten_tree_structure(root_list)
 
-    def sort_posts_chronologically(self, posts, lang=None):
+    @staticmethod
+    def sort_posts_chronologically(posts, lang=None):
         """Return sorted list of posts."""
         # Last tie breaker: sort by source path
         posts = sorted(posts, key=lambda p: p.source_path)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1984,7 +1984,7 @@ class Nikola(object):
         # Next, flatten the hierarchy
         self.category_hierarchy = utils.flatten_tree_structure(root_list)
 
-    def sort_posts(self, posts, lang=None):
+    def sort_posts_chronologically(self, posts, lang=None):
         """Return sorted list of posts."""
         # Last tie breaker: sort by source path
         posts = sorted(posts, key=lambda p: p.source_path)
@@ -2082,10 +2082,10 @@ class Nikola(object):
 
         # Sort everything.
 
-        self.timeline = self.sort_posts(self.timeline)
-        self.posts = self.sort_posts(self.posts)
-        self.all_posts = self.sort_posts(self.all_posts)
-        self.pages = self.sort_posts(self.pages)
+        self.timeline = self.sort_posts_chronologically(self.timeline)
+        self.posts = self.sort_posts_chronologically(self.posts)
+        self.all_posts = self.sort_posts_chronologically(self.all_posts)
+        self.pages = self.sort_posts_chronologically(self.pages)
         self._sort_category_hierarchy()
 
         for i, p in enumerate(self.posts[1:]):

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1986,15 +1986,18 @@ class Nikola(object):
 
     @staticmethod
     def sort_posts_chronologically(posts, lang=None):
-        """Return sorted list of posts."""
-        # Last tie breaker: sort by source path
+        """Sort a list of posts chronologically.
+
+        This function also takes priority, title and source path into account.
+        """
+        # Last tie breaker: sort by source path (A-Z)
         posts = sorted(posts, key=lambda p: p.source_path)
-        # Next tie breaker: sort by title if language is given
+        # Next tie breaker: sort by title if language is given (A-Z)
         if lang is not None:
             posts = natsort.natsorted(posts, key=lambda p: p.title(lang), alg=natsort.ns.F | natsort.ns.IC)
-        # Next tie breaker: sort by date
+        # Next tie breaker: sort by date (reverse chronological order)
         posts = sorted(posts, key=lambda p: p.date, reverse=True)
-        # Finally, sort by priority
+        # Finally, sort by priority meta value (descending)
         posts = sorted(posts, key=lambda p: int(p.meta('priority')) if p.meta('priority') else 0, reverse=True)
         # Return result
         return posts

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1984,6 +1984,20 @@ class Nikola(object):
         # Next, flatten the hierarchy
         self.category_hierarchy = utils.flatten_tree_structure(root_list)
 
+    def sort_posts(self, posts, lang=None):
+        """Return sorted list of posts."""
+        # Last tie breaker: sort by source path
+        posts = sorted(posts, key=lambda p: p.source_path)
+        # Next tie breaker: sort by title if language is given
+        if lang is not None:
+            posts = natsort.natsorted(posts, key=lambda p: p.title(lang), alg=natsort.ns.F | natsort.ns.IC)
+        # Next tie breaker: sort by date
+        posts = sorted(posts, key=lambda p: p.date, reverse=True)
+        # Finally, sort by priority
+        posts = sorted(posts, key=lambda p: int(p.meta('priority')) if p.meta('priority') else 0, reverse=True)
+        # Return result
+        return posts
+
     def scan_posts(self, really=False, ignore_quit=False, quiet=False):
         """Scan all the posts.
 
@@ -2068,11 +2082,10 @@ class Nikola(object):
 
         # Sort everything.
 
-        for thing in self.timeline, self.posts, self.all_posts, self.pages:
-            thing.sort(key=lambda p:
-                       (int(p.meta('priority')) if p.meta('priority') else 0,
-                        p.date, p.source_path))
-            thing.reverse()
+        self.timeline = self.sort_posts(self.timeline)
+        self.posts = self.sort_posts(self.posts)
+        self.all_posts = self.sort_posts(self.all_posts)
+        self.pages = self.sort_posts(self.pages)
         self._sort_category_hierarchy()
 
         for i, p in enumerate(self.posts[1:]):

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -98,7 +98,7 @@ class TaxonomiesClassifier(SignalHandler):
                 # Convert sets to lists and sort them
                 for classification in list(posts_per_classification.keys()):
                     posts = list(posts_per_classification[classification])
-                    posts = self.site.sort_posts(posts, lang)
+                    posts = self.site.sort_posts_chronologically(posts, lang)
                     taxonomy.sort_posts(posts, classification, lang)
                     posts_per_classification[classification] = posts
             # Create hierarchy information

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -98,7 +98,7 @@ class TaxonomiesClassifier(SignalHandler):
                 # Convert sets to lists and sort them
                 for classification in list(posts_per_classification.keys()):
                     posts = list(posts_per_classification[classification])
-                    posts = self.site.sort_posts(posts)
+                    posts = self.site.sort_posts(posts, lang)
                     taxonomy.sort_posts(posts, classification, lang)
                     posts_per_classification[classification] = posts
             # Create hierarchy information

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -98,10 +98,7 @@ class TaxonomiesClassifier(SignalHandler):
                 # Convert sets to lists and sort them
                 for classification in list(posts_per_classification.keys()):
                     posts = list(posts_per_classification[classification])
-                    posts.sort(key=lambda p:
-                               (int(p.meta('priority')) if p.meta('priority') else 0,
-                                p.date, p.source_path))
-                    posts.reverse()
+                    posts = self.site.sort_posts(posts)
                     taxonomy.sort_posts(posts, classification, lang)
                     posts_per_classification[classification] = posts
             # Create hierarchy information


### PR DESCRIPTION
The current sorting of posts for `site.timeline`, `site.posts`, `site.all_posts`, `site.pages` and the lists of posts per taxonomy has some downsides:

  1. The sorting code is repeated in two different files (`nikola.py` and `taxonomies_classifier.py`) and cannot be replaced easily with monkey patching (you have to catch signals and post-process the lists and hope nobody relies on the order not changing since before you began post-processing).
  2. The sorting is done by priority, date, and the post's source path, and all of this reversed; it would make more sense to sort by the post's source path non-reversed, and even better to sort by the post's title (if possible because the language is known, i.e. for taxonomy post lists which are language-dependent) before resorting to the post's source path.

The current PR fixes both things:

  1. It provides a single function in the Nikola site object (which can be easily monkey-patched if someone wants a different sorting order) which sorts posts and returns a new, sorted list.
  2. All the above named places use this function.
  3. It doesn't reverse sort by the post's source path, and it does sort (in correct order) by the title in case priority and date match before resorting to the post's source path in case the language is known (which is the case for taxonomy post lists, as mentioned above).

This should fix the remaining problems in #2627 (i.e. category listings are not random anymore, but in reversed order as one would expect).