### PR TITLE
Fix #2537 - Build fails on bad image file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Features
 Bugfixes
 --------
 
+* Catch OSError while opening a damaged image file. (Issue #2537)
+
 New in v7.8.3
 =============
 

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -97,7 +97,13 @@ class ImageProcessor(object):
         if not Image or os.path.splitext(src)[1] in ['.svg', '.svgz']:
             self.resize_svg(src, dst, max_size, bigger_panoramas)
             return
-        im = Image.open(src)
+        try:
+            im = Image.open(src)
+        except OSError as e:
+            self.logger.warn("Can't process {0}. Image cannot be opened and identified."
+                             "({1})".format(src, e))
+            # Returning here as further processing makes no sense
+            return
         size = w, h = im.size
         if w > max_size or h > max_size:
             size = max_size, max_size


### PR DESCRIPTION
Catch OSError and return. 
Log the exception as a warning. The warning message is consistent with that in Pillow docs: 	

IOError – If the file cannot be found, or the image cannot be opened and identified. 