### PR TITLE
Preventing .html to be added when it shouldn't be.

### DIFF
--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -240,10 +240,12 @@ class TaxonomiesClassifier(SignalHandler):
                 path = ['rss']
             elif len(path) == 0 or append_index == 'always':
                 path = path + [os.path.splitext(self.site.config['INDEX_FILE'])[0]]
+            elif len(path) > 0 and append_index == 'never':
+                path[-1] = os.path.splitext(path[-1])[0]
             path[-1] += force_extension
         elif (self.site.config['PRETTY_URLS'] and append_index != 'never') or len(path) == 0 or append_index == 'always':
             path = path + [self.site.config['INDEX_FILE']]
-        else:
+        elif append_index != 'never':
             path[-1] += '.html'
         # Create path
         result = [_f for _f in [self.site.config['TRANSLATIONS'][lang]] + path if _f]

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -139,7 +139,7 @@ class Archive(Taxonomy):
             components.extend(classification)
             add_index = 'always'
         else:
-            components.append(os.path.splitext(self.site.config['ARCHIVE_FILENAME'])[0])
+            components.append(self.site.config['ARCHIVE_FILENAME'])
             add_index = 'never'
         return [_f for _f in components if _f], add_index
 

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -26,7 +26,6 @@
 
 """Classify the posts in archives."""
 
-import os
 import natsort
 import nikola.utils
 import datetime

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -100,7 +100,11 @@ link://category_rss/dogs => /categories/dogs.xml""",
     def get_overview_path(self, lang, dest_type='page'):
         """A path handler for the list of all classifications."""
         if self.site.config['CATEGORIES_INDEX_PATH'](lang):
-            return [_f for _f in [self.site.config['CATEGORIES_INDEX_PATH'](lang)] if _f], 'never'
+            path = self.site.config['CATEGORIES_INDEX_PATH'](lang)
+            if path.endswith('/index'):  # TODO: remove in v8
+                utils.LOGGER.warn("CATEGORIES_INDEX_PATH for language {0} is missing a .html extension. Please update your configuration!".format(lang))
+                path += '.html'
+            return [_f for _f in [path] if _f], 'never'
         else:
             return [_f for _f in [self.site.config['CATEGORY_PATH'](lang)] if _f], 'always'
 

--- a/nikola/plugins/task/sections.py
+++ b/nikola/plugins/task/sections.py
@@ -100,7 +100,7 @@ link://section_index_rss/cars => /cars/rss.xml""",
         """A path handler for the given classification."""
         result = [_f for _f in [section] if _f]
         if dest_type == 'rss':
-            return result + ['rss'], 'never'
+            return result + ['rss.xml'], 'never'
         return result, 'always'
 
     def provide_context_and_uptodate(self, section, lang, node=None):

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -104,7 +104,11 @@ link://tag_rss/cats => /tags/cats.xml""",
     def get_overview_path(self, lang, dest_type='page'):
         """A path handler for the list of all classifications."""
         if self.site.config['TAGS_INDEX_PATH'](lang):
-            return [_f for _f in [self.site.config['TAGS_INDEX_PATH'](lang)] if _f], 'never'
+            path = self.site.config['TAGS_INDEX_PATH'](lang)
+            if path.endswith('/index'):  # TODO: remove in v8
+                utils.LOGGER.warn("TAGS_INDEX_PATH for language {0} is missing a .html extension. Please update your configuration!".format(lang))
+                path += '.html'
+            return [_f for _f in [path] if _f], 'never'
         else:
             return [_f for _f in [self.site.config['TAG_PATH'](lang)] if _f], 'always'
 


### PR DESCRIPTION
Fixes bug described in #2649, when `.html` is added to `TAGS_INDEX_PATH`.