### PR TITLE
Improve markdown compiler performance

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -25,6 +25,7 @@
 * `Daniel Aleksandersen <https://github.com/Aeyoun>`_
 * `Daniel Devine <https://github.com/DDevine>`_
 * `Daniel F. Moisset <https://github.com/dmoisset>`_
+* `Daniel Harding <https://github.com/living180>`_
 * `dastagg <https://github.com/dastagg>`_
 * `dastagg <https://github.com/dastagg>`_
 * `David Barragán Merino <https://github.com/bameda>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ Bugfixes
   ``INDEXES_STATIC`` is ``False``. (Issue #2654)
 * Make ``NEW_POST_DATE_PATH`` follow ``rrule`` if it exists (issue #2653)
 * Fix crash if ``PAGE_INDEX`` is enabled (Issue #2646)
+* Fix poor performance when compiling multiple markdown documents with
+  the markdown compiler. (Issue #2660)
 
 New in v7.8.3
 =============

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -47,7 +47,8 @@ from nikola.utils import makedirs, req_missing, write_metadata
 class ThreadLocalMarkdown(threading.local):
     """Convert Markdown to HTML using per-thread Markdown objects.
 
-    See discussion in #2661."""
+    See discussion in #2661.
+    """
 
     def __init__(self, extensions):
         """Create a Markdown instance."""

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -30,11 +30,12 @@ from __future__ import unicode_literals
 
 import io
 import os
+import threading
 
 try:
-    from markdown import markdown
+    from markdown import Markdown
 except ImportError:
-    markdown = None  # NOQA
+    Markdown = None  # NOQA
     nikola_extension = None
     gist_extension = None
     podcast_extension = None
@@ -43,41 +44,56 @@ from nikola.plugin_categories import PageCompiler
 from nikola.utils import makedirs, req_missing, write_metadata
 
 
+class ThreadLocalMarkdown(threading.local):
+    """Convert to markdown using per-thread Markdown objects."""
+
+    def __init__(self, extensions):
+        self.markdown = Markdown(extensions=extensions, output_format="html5")
+
+    def convert(self, data):
+        """Convert data to HTML and reset internal state."""
+        result = self.markdown.convert(data)
+        self.markdown.reset()
+        return result
+
+
 class CompileMarkdown(PageCompiler):
     """Compile Markdown into HTML."""
 
     name = "markdown"
     friendly_name = "Markdown"
     demote_headers = True
-    extensions = []
     site = None
 
     def set_site(self, site):
         """Set Nikola site."""
         super(CompileMarkdown, self).set_site(site)
         self.config_dependencies = []
+        extensions = []
         for plugin_info in self.get_compiler_extensions():
             self.config_dependencies.append(plugin_info.name)
-            self.extensions.append(plugin_info.plugin_object)
+            extensions.append(plugin_info.plugin_object)
             plugin_info.plugin_object.short_help = plugin_info.description
 
         site_extensions = self.site.config.get("MARKDOWN_EXTENSIONS")
         self.config_dependencies.append(str(sorted(site_extensions)))
-        self.extensions.extend(site_extensions)
+        extensions.extend(site_extensions)
+        if Markdown is not None:
+            self.converter = ThreadLocalMarkdown(extensions)
 
     def compile_string(self, data, source_path=None, is_two_file=True, post=None, lang=None):
         """Compile Markdown into HTML strings."""
-        if markdown is None:
+        if Markdown is None:
             req_missing(['markdown'], 'build this site (compile Markdown)')
         if not is_two_file:
             _, data = self.split_metadata(data)
-        output = markdown(data, self.extensions, output_format="html5")
+        output = self.converter.convert(data)
         output, shortcode_deps = self.site.apply_shortcodes(output, filename=source_path, with_dependencies=True, extra_context={'post': post})
         return output, shortcode_deps
 
     def compile(self, source, dest, is_two_file=True, post=None, lang=None):
         """Compile the source file into HTML and save as dest."""
-        if markdown is None:
+        if Markdown is None:
             req_missing(['markdown'], 'build this site (compile Markdown)')
         makedirs(os.path.dirname(dest))
         with io.open(dest, "w+", encoding="utf8") as out_file:

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -45,9 +45,12 @@ from nikola.utils import makedirs, req_missing, write_metadata
 
 
 class ThreadLocalMarkdown(threading.local):
-    """Convert to markdown using per-thread Markdown objects."""
+    """Convert Markdown to HTML using per-thread Markdown objects.
+
+    See discussion in #2661."""
 
     def __init__(self, extensions):
+        """Create a Markdown instance."""
         self.markdown = Markdown(extensions=extensions, output_format="html5")
 
     def convert(self, data):

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -61,13 +61,14 @@ class CompileMarkdown(PageCompiler):
             self.extensions.append(plugin_info.plugin_object)
             plugin_info.plugin_object.short_help = plugin_info.description
 
-        self.config_dependencies.append(str(sorted(site.config.get("MARKDOWN_EXTENSIONS"))))
+        site_extensions = self.site.config.get("MARKDOWN_EXTENSIONS")
+        self.config_dependencies.append(str(sorted(site_extensions)))
+        self.extensions.extend(site_extensions)
 
     def compile_string(self, data, source_path=None, is_two_file=True, post=None, lang=None):
         """Compile Markdown into HTML strings."""
         if markdown is None:
             req_missing(['markdown'], 'build this site (compile Markdown)')
-        self.extensions += self.site.config.get("MARKDOWN_EXTENSIONS")
         if not is_two_file:
             _, data = self.split_metadata(data)
         output = markdown(data, self.extensions, output_format="html5")


### PR DESCRIPTION
This PR fixes issue #2660.

The first commit eliminates pathological performance when compiling a large number of markdown files at one time but preventing the markdown extensions list from growing each time a markdown file was compiled.  On my machine this reduced the time required to compile 1000 markdown files from over 11 minutes to under 55 seconds.

The second commit provides a further incremental improvement by creating and reusing a single Markdown object instead of creating a separate Markdown object for each file that is compiled. This further reduces the compilation time for 1000 markdown files to under 34 seconds.