### PR TITLE
New require_all_tags for post-list directive

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,10 @@ New in master
 Features
 --------
 
+* Append file name (generated from title) if ``nikola new_post``
+  receives directory name as path (Issue #2651)
 * Add ``META_GENERATOR_TAG`` option in conf.py allowing the meta generator
-  to be disabled if needed. (Issue #2628)
+  tag to be disabled (Issue #2628)
 * Add ``YUI_COMPRESSOR_EXECUTABLE``, ``CLOSURE_COMPILER_EXECUTABLE``,
   ``OPTIPNG_EXECUTABLE``, ``JPEGOPTIM_EXECUTABLE`` and
   ``HTML_TIDY_EXECUTABLE`` to configure executables for built-in filters.

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -567,7 +567,8 @@ The ``new_post`` command supports some options:
 
 The optional ``path`` parameter tells Nikola exactly where to put it instead of guessing from your config.
 So, if you do ``nikola new_post posts/random/foo.txt`` you will have a post in that path, with
-"foo" as its slug.
+"foo" as its slug. You can also provide a directory name, in which case Nikola
+will append the file name for you (generated from title).
 
 The ``-d, --date-path`` option automates creation of ``year/month/day`` or
 similar directory structures. It can be enabled on a per-post basis, or you can

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -311,7 +311,14 @@ class CommandNewPost(Command):
                     path = path.decode(sys.stdin.encoding)
                 except (AttributeError, TypeError):  # for tests
                     path = path.decode('utf-8')
-            slug = utils.slugify(os.path.splitext(os.path.basename(path))[0], lang=self.site.default_lang)
+            if os.path.isdir(path):
+                # If the user provides a directory, add the file name generated from title (Issue #2651)
+                slug = utils.slugify(title, lang=self.site.default_lang)
+                pattern = os.path.basename(entry[0])
+                suffix = pattern[1:]
+                path = os.path.join(path, slug + suffix)
+            else:
+                slug = utils.slugify(os.path.splitext(os.path.basename(path))[0], lang=self.site.default_lang)
 
         if isinstance(author, utils.bytes_str):
                 try:


### PR DESCRIPTION
The default behaviour of post-list directive is to show posts that have at least one of the tags. It could be better if it could be more restrictive.

I suggest this new option 'require_all_tags'. If declared, the post-list will show only posts that have all tags.