### PR TITLE
add option require_all_tags to post-list directive.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@ Features
   ``OPTIPNG_EXECUTABLE``, ``JPEGOPTIM_EXECUTABLE`` and
   ``HTML_TIDY_EXECUTABLE`` to configure executables for built-in filters.
   (Issue #2615)
+* Add a ``require_all_tags`` parameter to the ``post-list`` directive to
+  show only posts that have all specified tags.
+
 
 Bugfixes
 --------

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -2355,6 +2355,10 @@ The following options are recognized:
       Filter posts to show only posts having at least one of the ``tags``.
       Defaults to None.
 
+* ``require_all_tags`` : flag
+    Change tag filter behaviour to show only posts that have all specified ``tags``.
+    Defaults to False.
+
 * ``categories`` : string [, string...]
       Filter posts to show only posts having one of the ``categories``.
       Defaults to None.

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -31,6 +31,7 @@ from __future__ import unicode_literals
 import os
 import uuid
 import natsort
+import operator
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
@@ -254,9 +255,9 @@ def _do_post_list(start=None, stop=None, reverse=False, tags=None, require_all_t
     if tags:
         tags = {t.strip().lower() for t in tags.split(',')}
         if require_all_tags:
-            compare = lambda x, y: x.issubset(y)
+            compare = set.issubset
         else:
-            compare = lambda x, y: x & y
+            compare = operator.and_
         for post in timeline:
             post_tags = {t.lower() for t in post.tags}
             if compare(tags, post_tags):

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -261,6 +261,8 @@ def _do_post_list(start=None, stop=None, reverse=False, tags=None, require_all_t
             post_tags = {t.lower() for t in post.tags}
             if compare(tags, post_tags):
                 filtered_timeline.append(post)
+    else:
+        filtered_timeline = timeline
 
     if sort:
         filtered_timeline = natsort.natsorted(filtered_timeline, key=lambda post: post.meta[lang][sort], alg=natsort.ns.F | natsort.ns.IC)


### PR DESCRIPTION
If declared it changes the tag filter behaviour to show only posts that have *all* specified tags.