### PR TITLE
Don't use Post.source_path directly to determine translated post's source file name.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2094,7 +2094,8 @@ class Nikola(object):
                     quit = True
                 self.post_per_file[dest] = post
                 self.post_per_file[src_dest] = post
-                self.post_per_input_file[src_file] = post
+                if src_file is not None:
+                    self.post_per_input_file[src_file] = post
                 # deduplicate tags_per_language
                 self.tags_per_language[lang] = list(set(self.tags_per_language[lang]))
 

--- a/nikola/plugins/task/sources.py
+++ b/nikola/plugins/task/sources.py
@@ -61,12 +61,8 @@ class Sources(Task):
                     # do not publish PHP sources
                     if post.source_ext(True) == post.compiler.extension():
                         continue
-                    source = post.source_path
-                    if lang != kw["default_lang"]:
-                        source_lang = utils.get_translation_candidate(self.site.config, source, lang)
-                        if os.path.exists(source_lang):
-                            source = source_lang
-                    if os.path.isfile(source):
+                    source = post.translated_source_path(lang)
+                    if source is not None and os.path.isfile(source):
                         yield {
                             'basename': 'render_sources',
                             'name': os.path.normpath(output_name),


### PR DESCRIPTION
Allowing Post.translated_source_path() to return None.

Helping with one aspect of #2659.