### PR TITLE
Avoid replicating compiler detection logic.

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2173,7 +2173,7 @@ class Nikola(object):
 
     def generic_page_renderer(self, lang, post, filters, context=None):
         """Render post fragments to final HTML pages."""
-        extension = self.get_compiler(post.source_path).extension()
+        extension = post.compiler.extension()
         output_name = os.path.join(self.config['OUTPUT_FOLDER'],
                                    post.destination_path(lang, extension))
 


### PR DESCRIPTION
The compiler is already decided in the `scan_posts` plugin and shouldn't be re-decided here.