### PR TITLE
[WIP] Basic support for itunes rss tags

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1715,9 +1715,7 @@ class Nikola(object):
                 for tag in ('subtitle', 'duration', 'explicit'):
                     key = 'itunes_{}'.format(tag)
                     args[key] = post.meta[lang].get(key)
-                args['itunes_author'] = (
-                    post.meta[lang].get('itunes_author')
-                    or post.author(lang))
+                args['itunes_author'] = post.meta[lang].get('itunes_author') or post.author(lang)
                 args['itunes_summary'] = post.meta[lang].get('itunes_summary') or data
                 if 'itunes_image' in post.meta[lang]:
                     args['itunes_image'] = self.url_replacer(post.permalink(), post.meta[lang]['itunes_image'], lang, 'absolute')

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1712,15 +1712,15 @@ class Nikola(object):
                 rss_obj.rss_attrs["xmlns:dc"] = "http://purl.org/dc/elements/1.1/"
 
             if itunes:
+                for tag in ('subtitle', 'duration', 'explicit'):
+                    key = 'itunes_{}'.format(tag)
+                    args[key] = post.meta[lang].get(key)
                 args['itunes_author'] = (
                     post.meta[lang].get('itunes_author')
                     or post.author(lang))
-                args['itunes_subtitle'] = post.meta[lang].get('itunes_subtitle')
                 args['itunes_summary'] = post.meta[lang].get('itunes_summary') or data
                 if 'itunes_image' in post.meta[lang]:
-                    args['itunes_image'] = urljoin(self.config['BASE_URL'], post.meta[lang]['itunes_image'])
-                args['itunes_duration'] = post.meta[lang].get('itunes_duration')
-                args['itunes_explicit'] = post.meta[lang].get('itunes_explicit')
+                    args['itunes_image'] = self.url_replacer(post.permalink(), post.meta[lang]['itunes_image'], lang, 'absolute')
 
             if enclosure:
                 # enclosure callback returns None if post has no enclosure, or a

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1739,6 +1739,7 @@ class Nikola(object):
         if itunes:
             rss_obj.rss_attrs["xmlns:itunes"] = "http://www.itunes.com/dtds/podcast-1.0.dtd"
             rss_obj.itunes_author = self.config['BLOG_AUTHOR'](lang)
+            rss_obj.itunes_name = self.config['BLOG_AUTHOR'](lang)
             rss_obj.itunes_email = self.config['BLOG_EMAIL']
             rss_obj.itunes_summary = description
             if 'POSTCAST_IMAGE' in self.config:

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1649,7 +1649,7 @@ class Nikola(object):
 
     def generic_rss_renderer(self, lang, title, link, description, timeline, output_path,
                              rss_teasers, rss_plain, feed_length=10, feed_url=None,
-                             enclosure=_enclosure, rss_links_append_query=None):
+                             enclosure=_enclosure, rss_links_append_query=None, itunes=None):
         """Take all necessary data, and render a RSS feed in output_path."""
         rss_obj = utils.ExtendedRSS2(
             title=title,
@@ -1711,6 +1711,17 @@ class Nikola(object):
             if post.author(lang):
                 rss_obj.rss_attrs["xmlns:dc"] = "http://purl.org/dc/elements/1.1/"
 
+            if itunes:
+                args['itunes_author'] = (
+                    post.meta[lang].get('itunes_author')
+                    or post.author(lang))
+                args['itunes_subtitle'] = post.meta[lang].get('itunes_subtitle')
+                args['itunes_summary'] = post.meta[lang].get('itunes_summary') or data
+                if 'itunes_image' in post.meta[lang]:
+                    args['itunes_image'] = urljoin(self.config['BASE_URL'], post.meta[lang]['itunes_image'])
+                args['itunes_duration'] = post.meta[lang].get('itunes_duration')
+                args['itunes_explicit'] = post.meta[lang].get('itunes_explicit')
+
             if enclosure:
                 # enclosure callback returns None if post has no enclosure, or a
                 # 3-tuple of (url, length (0 is valid), mimetype)
@@ -1722,7 +1733,18 @@ class Nikola(object):
 
         rss_obj.items = items
         rss_obj.self_url = feed_url
+
         rss_obj.rss_attrs["xmlns:atom"] = "http://www.w3.org/2005/Atom"
+
+        if itunes:
+            rss_obj.rss_attrs["xmlns:itunes"] = "http://www.itunes.com/dtds/podcast-1.0.dtd"
+            rss_obj.itunes_author = self.config['BLOG_AUTHOR'](lang)
+            rss_obj.itunes_email = self.config['BLOG_EMAIL']
+            rss_obj.itunes_summary = description
+            if 'POSTCAST_IMAGE' in self.config:
+                rss_obj.itunes_image = urljoin(self.config['BASE_URL'], self.config['POSTCAST_IMAGE'])
+            rss_obj.itunes_categories = self.config.get('POSTCAST_CATEGORIES')
+            rss_obj.itunes_explicit = self.config.get('POSTCAST_EXPLICIT')
 
         dst_dir = os.path.dirname(output_path)
         utils.makedirs(dst_dir)

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1267,7 +1267,8 @@ class ExtendedRSS2(rss.RSS2):
         self.itunes_categories = itunes_categories
         self.itunes_explicit = itunes_explicit
 
-        return rss.RSS2.__init__(self, **kwargs)
+        # It's an old style class
+        rss.RSS2.__init__(self, **kwargs)
 
     def publish(self, handler):
         """Publish a feed."""
@@ -1346,8 +1347,9 @@ class ExtendedItem(rss.RSSItem):
         self.itunes_image = itunes_image
         self.itunes_duration = itunes_duration
         self.itunes_explicit = itunes_explicit
+
         # It's an old style class
-        return rss.RSSItem.__init__(self, **kw)
+        rss.RSSItem.__init__(self, **kw)
 
     def publish_extensions(self, handler):
         """Publish extensions."""

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1255,6 +1255,20 @@ class ExtendedRSS2(rss.RSS2):
 
     xsl_stylesheet_href = None
 
+    def __init__(self, itunes_author=None, itunes_summary=None,
+                 itunes_name=None, itunes_email=None,
+                 itunes_image=None, itunes_categories=None,
+                 itunes_explicit=None, **kwargs):
+        self.itunes_author = itunes_author
+        self.itunes_summary = itunes_summary
+        self.itunes_name = itunes_name
+        self.itunes_email = itunes_email
+        self.itunes_image = itunes_image
+        self.itunes_categories = itunes_categories
+        self.itunes_explicit = itunes_explicit
+
+        return rss.RSS2.__init__(self, **kwargs)
+
     def publish(self, handler):
         """Publish a feed."""
         if self.xsl_stylesheet_href:
@@ -1272,13 +1286,66 @@ class ExtendedRSS2(rss.RSS2):
             })
             handler.endElement("atom:link")
 
+        if self.itunes_author:
+            handler.startElement("itunes:author", {})
+            handler.characters(self.itunes_author)
+            handler.endElement("itunes:author")
+
+        if self.itunes_summary:
+            handler.startElement("itunes:summary", {})
+            handler.characters(self.itunes_summary)
+            handler.endElement("itunes:summary")
+
+        if self.itunes_author or self.itunes_email:
+            handler.startElement("itunes:creator", {})
+            if self.itunes_author:
+                handler.startElement("itunes:name", {})
+                handler.characters(self.itunes_author)
+                handler.endElement("itunes:name")
+            if self.itunes_email:
+                handler.startElement("itunes:email", {})
+                handler.characters(self.itunes_email)
+                handler.endElement("itunes:email")
+            handler.endElement("itunes:creator")
+
+        if self.itunes_image:
+            handler.startElement("itunes:image", {'href': self.itunes_image})
+            handler.endElement("itunes:image")
+
+        if self.itunes_categories:
+            for category_entry in self.itunes_categories:
+                try:
+                    category, subcategories = category_entry
+                except ValueError:
+                    category = category_entry[0]
+                    subcategories = ()
+                handler.startElement("itunes:category", {'text': category})
+                for subcategory in subcategories:
+                    handler.startElement("itunes:category", {'text': subcategory})
+                    handler.endElement("itunes:category")
+                handler.endElement("itunes:category")
+
+        if self.itunes_explicit is not None:
+            handler.startElement("itunes:explicit", {})
+            handler.characters("yes" if self.itunes_explicit else "no")
+            handler.endElement("itunes:explicit")
+
 
 class ExtendedItem(rss.RSSItem):
     """Extended RSS item."""
 
-    def __init__(self, **kw):
+    def __init__(self, itunes_author=None, itunes_subtitle=None,
+                 itunes_summary=None, itunes_image=None, itunes_duration=None,
+                 itunes_explicit=None, **kw):
         """Initialize RSS item."""
         self.creator = kw.pop('creator')
+
+        self.itunes_author = itunes_author
+        self.itunes_subtitle = itunes_subtitle
+        self.itunes_summary = itunes_summary
+        self.itunes_image = itunes_image
+        self.itunes_duration = itunes_duration
+        self.itunes_explicit = itunes_explicit
         # It's an old style class
         return rss.RSSItem.__init__(self, **kw)
 
@@ -1288,6 +1355,35 @@ class ExtendedItem(rss.RSSItem):
             handler.startElement("dc:creator", {})
             handler.characters(self.creator)
             handler.endElement("dc:creator")
+
+        if self.itunes_author:
+            handler.startElement("itunes:author", {})
+            handler.characters(self.itunes_author)
+            handler.endElement("itunes:author")
+
+        if self.itunes_subtitle:
+            handler.startElement("itunes:subtitle", {})
+            handler.characters(self.itunes_subtitle)
+            handler.endElement("itunes:subtitle")
+
+        if self.itunes_summary:
+            handler.startElement("itunes:summary", {})
+            handler.characters(self.itunes_summary)
+            handler.endElement("itunes:summary")
+
+        if self.itunes_image:
+            handler.startElement("itunes:image", {'href': self.itunes_image})
+            handler.endElement("itunes:image")
+
+        if self.itunes_duration:
+            handler.startElement("itunes:duration", {})
+            handler.characters(self.itunes_duration)
+            handler.endElement("itunes:duration")
+
+        if self.itunes_explicit is not None:
+            handler.startElement("itunes:explicit", {})
+            handler.characters("yes" if self.itunes_explicit else "no")
+            handler.endElement("itunes:explicit")
 
 
 # \x00 means the "<" was backslash-escaped

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1363,7 +1363,7 @@ def _itunes_explicit_tag(src, handler):
         handler.characters("yes" if src.itunes_explicit else "no")
         handler.endElement("itunes:explicit")
 
-        
+
 def _itunes_image_tag(src, handler):
     if src.itunes_image:
         handler.startElement("itunes:image", {'href': src.itunes_image})

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1270,7 +1270,7 @@ class ExtendedRSS2(rss.RSS2):
         # It's an old style class
         rss.RSS2.__init__(self, **kwargs)
 
-    def _itunes_attributes (self):
+    def _itunes_attributes(self):
         for tag in ('author', 'summary', 'name', 'email', 'image', 'categories', 'explicit'):
             yield 'itunes:{}'.format(tag), getattr(self, 'itunes_{}'.format(tag))
 


### PR DESCRIPTION
I'm working on enhancing Nikola to support publishing a podcast RSS feed. Most of this work is going into a "postcast" plugin I'm working on, and will submit or publish eventually; but some of what I'm trying to do requires support in Nikola itself.

This PR aims to support [iTunes-specific tags](https://help.apple.com/itc/podcasts_connect/#/itcb54353390) in RSS feeds.

Other related PRs I'm working on:

* #2676 (copyright tag in rss feeds)
* #2675 (explicit / static guids)

I'd also be interested in direction for where and how to publish a plugin, when that's ready.

## todo

* remove references to postcast