### PR TITLE
[WIP] Optionally read rss guid from the post

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1705,7 +1705,7 @@ class Nikola(object):
                             post.date.astimezone(dateutil.tz.tzutc())),
                 'categories': post._tags.get(lang, []),
                 'creator': post.author(lang),
-                'guid': post.permalink(lang, absolute=True),
+                'guid': post.meta[lang].get('guid') or post.permalink(lang, absolute=True),
             }
 
             if post.author(lang):


### PR DESCRIPTION
I'm working on enhancing Nikola to support publishing a podcast RSS feed. Most of this work is going into a "postcast" plugin I'm working on, and will submit or publish eventually; but some of what I'm trying to do requires support in Nikola itself.

This PR aims to support optional explicit (and, thus, static) GUIDs from posts, so that if I move where the podcast posts are they don't flood podcast apps with old episodes.

> [Assign the GUID to an episode only once and never change it. Assigning new GUIDs to existing episodes can cause issues with your podcast’s listing and chart placement in the iTunes Store.](https://help.apple.com/itc/podcasts_connect/#/itcb54353390)

Other related PRs I'm working on:

* #2676 (copyright tag in rss feeds)
* #2674 (iTunes rss tags)

I'd also be interested in direction for where and how to publish a plugin, when that's ready.