### PR TITLE
Fix #2681 -- fix crashes when rendering subcategories

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,7 @@ Features
 Bugfixes
 --------
 
+* Fix crashes when rendering subcategories (Issue #2681)
 * Prevent writing cache files outside of the cache folder
   (Issue #2684)
 * Fix mimetype guessing in auto mode (Issue #2645)

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -170,7 +170,7 @@ link://category_rss/dogs => /categories/dogs.xml""",
         }
         posts = self.site.posts_per_classification[self.classification_name][lang]
         children = [child for child in node.children if len([post for post in posts.get(child.classification_name, []) if self.site.config['SHOW_UNTRANSLATED_POSTS'] or post.is_translation_available(lang)]) > 0]
-        subcats = [(child.name, self.site.link(self.classification_name, child.classification_name, lang), child.classification_name, child.classification_path) for child in children]
+        subcats = [(child.name, self.site.link(self.classification_name, child.classification_name, lang)) for child in children]
         friendly_name = self.get_classification_friendly_name(cat, lang)
         context = {
             "title": self.site.config['CATEGORY_PAGES_TITLES'].get(lang, {}).get(cat, self.site.MESSAGES[lang]["Posts about %s"] % friendly_name),


### PR DESCRIPTION
This is #2681.

@felixfontein: I decided to remove the two extra variables, because this way we don’t have to change templates and break backwards compatibility, and those variables don’t seem useful to me — is that okay?