### PR TITLE
Write nikola serve -d PID to file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Write PID of detached ``nikola serve`` process to a file called
+  ``nikolaserve.pid``
 * Append file name (generated from title) if ``nikola new_post``
   receives directory name as path (Issue #2651)
 * Add a ``require_all_tags`` parameter to the ``post-list`` directive to


### PR DESCRIPTION
Write the PID of the detached `nikola serve` process to a file. If the user forgets to write the PID down, or it scrolls away, going to `htop` is not necessary anymore.

As an added bonus, clean up if `nikola serve` is killed with SIGTERM.