### PR TITLE
Fix #2684 -- prevent writing cache files outside of the cache folder

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ Features
 Bugfixes
 --------
 
+* Prevent writing cache files outside of the cache folder
+  (Issue #2684)
 * Fix mimetype guessing in auto mode (Issue #2645)
 * Fix filters.html5lib_xmllike for laters html5lib (Issue #2648)
 * Skip the current post in post lists (Issue #2666)

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -118,6 +118,9 @@ class Post(object):
         self.pretty_urls = self.config['PRETTY_URLS']
         self.source_path = source_path  # posts/blah.txt
         self.post_name = os.path.splitext(source_path)[0]  # posts/blah
+        _relpath = os.path.relpath(self.post_name)
+        if _relpath != self.post_name:
+            self.post_name = _relpath.replace('..' + os.sep, '_..' + os.sep)
         # cache[\/]posts[\/]blah.html
         self.base_path = os.path.join(self.config['CACHE_FOLDER'], self.post_name + ".html")
         # cache/posts/blah.html


### PR DESCRIPTION
This is #2684. Since those are edge cases, changing the post name/base path won’t hurt anybody.