### PR TITLE
generic_rss_renderer refactor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Refactor RSS feed generation to allow better plugin access
 * Add ``RSS_COPYRIGHT``, ``RSS_COPYRIGHT_PLAIN``, and
   ``RSS_COPYRIGHT_FORMATS`` options in conf.py which can be disabled
   by specifying ``copyright_=False`` to ``generic_rss_renderer``, or

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1667,6 +1667,7 @@ class Nikola(object):
     def generic_rss_feed(self, lang, title, link, description, timeline,
                          rss_teasers, rss_plain, feed_length=10, feed_url=None,
                          enclosure=_enclosure, rss_links_append_query=None, copyright_=None):
+        """Generate an ExtendedRSS2 feed object for later use."""
         rss_obj = utils.ExtendedRSS2(
             title=title,
             link=utils.encodelink(link),

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1664,10 +1664,9 @@ class Nikola(object):
         else:
             return self.config['RSS_COPYRIGHT'](lang)
 
-    def generic_rss_renderer(self, lang, title, link, description, timeline, output_path,
-                             rss_teasers, rss_plain, feed_length=10, feed_url=None,
-                             enclosure=_enclosure, rss_links_append_query=None, copyright_=None):
-        """Take all necessary data, and render a RSS feed in output_path."""
+    def generic_rss_feed(self, lang, title, link, description, timeline,
+                         rss_teasers, rss_plain, feed_length=10, feed_url=None,
+                         enclosure=_enclosure, rss_links_append_query=None, copyright_=None):
         rss_obj = utils.ExtendedRSS2(
             title=title,
             link=utils.encodelink(link),
@@ -1746,14 +1745,16 @@ class Nikola(object):
         rss_obj.items = items
         rss_obj.self_url = feed_url
         rss_obj.rss_attrs["xmlns:atom"] = "http://www.w3.org/2005/Atom"
+        return rss_obj
 
-        dst_dir = os.path.dirname(output_path)
-        utils.makedirs(dst_dir)
-        with io.open(output_path, "w+", encoding="utf-8") as rss_file:
-            data = rss_obj.to_xml(encoding='utf-8')
-            if isinstance(data, utils.bytes_str):
-                data = data.decode('utf-8')
-            rss_file.write(data)
+    def generic_rss_renderer(self, lang, title, link, description, timeline, output_path,
+                             rss_teasers, rss_plain, feed_length=10, feed_url=None,
+                             enclosure=_enclosure, rss_links_append_query=None, copyright_=None):
+        """Take all necessary data, and render a RSS feed in output_path."""
+        rss_obj = self.generic_rss_feed(lang, title, link, description, timeline,
+                                        rss_teasers, rss_plain, feed_length=feed_length, feed_url=feed_url,
+                                        enclosure=enclosure, rss_links_append_query=rss_links_append_query, copyright_=copyright_)
+        utils.rss_writer(rss_obj, output_path)
 
     def path(self, kind, name, lang=None, is_link=False, **kwargs):
         r"""Build the path to a certain kind of page.

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1279,7 +1279,7 @@ class ExtendedItem(rss.RSSItem):
 
     def __init__(self, **kw):
         """Initialize RSS item."""
-        self.creator = kw.pop('creator')
+        self.creator = kw.pop('creator', None)
 
         # It's an old style class
         rss.RSSItem.__init__(self, **kw)

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -97,7 +97,7 @@ __all__ = ('CustomEncoder', 'get_theme_path', 'get_theme_path_real',
            'clone_treenode', 'flatten_tree_structure',
            'parse_escaped_hierarchical_category_name',
            'join_hierarchical_category_path', 'clean_before_deployment',
-           'sort_posts', 'indent', 'load_data', 'html_unescape',)
+           'sort_posts', 'indent', 'load_data', 'html_unescape', 'rss_writer',)
 
 # Are you looking for 'generic_rss_renderer'?
 # It's defined in nikola.nikola.Nikola (the site object).
@@ -1280,8 +1280,9 @@ class ExtendedItem(rss.RSSItem):
     def __init__(self, **kw):
         """Initialize RSS item."""
         self.creator = kw.pop('creator')
+
         # It's an old style class
-        return rss.RSSItem.__init__(self, **kw)
+        rss.RSSItem.__init__(self, **kw)
 
     def publish_extensions(self, handler):
         """Publish extensions."""
@@ -2040,3 +2041,13 @@ except (AttributeError, ImportError):
         """Convert all named and numeric character references  in the string s to the corresponding unicode characters."""
         h = HTMLParser()
         return h.unescape(s)
+
+
+def rss_writer(rss_obj, output_path):
+    dst_dir = os.path.dirname(output_path)
+    makedirs(dst_dir)
+    with io.open(output_path, "w+", encoding="utf-8") as rss_file:
+        data = rss_obj.to_xml(encoding='utf-8')
+        if isinstance(data, bytes_str):
+            data = data.decode('utf-8')
+        rss_file.write(data)

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -2044,6 +2044,7 @@ except (AttributeError, ImportError):
 
 
 def rss_writer(rss_obj, output_path):
+    """Write an RSS object to an xml file."""
     dst_dir = os.path.dirname(output_path)
     makedirs(dst_dir)
     with io.open(output_path, "w+", encoding="utf-8") as rss_file:


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description

I split actual feed generation into `generic_rss_feed` and writing into `utils.rss_writer`, both of which are now called from the (much smaller) `generic_rss_renderer`. This allows plugins to use `generic_rss_feed`, modify the resultant feed, and then write it out with `utils.rss_writer`.

In my use case, I'm building a "postcast" plugin to generate podcasts from posts. I want to add iTunes-specific tags to the podcast RSS feeds, but I didn't like the feeling of bolting domain-specific tags into the central rss renderer. My WIP plugin can now use the upstream code, but modify the result before it's written out to a file.

I've further made a small change to `ExtendedItem` to make it easier to subclass, as I use subclasses of `ExtendedRSS2` and `ExtendedItem` to actually apply the iTunes tags.