### PR TITLE
Allow setting custom GUID in feeds (fixes #2378)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,7 @@ Features
   ``OPTIPNG_EXECUTABLE``, ``JPEGOPTIM_EXECUTABLE`` and
   ``HTML_TIDY_EXECUTABLE`` to configure executables for built-in filters.
   (Issue #2615)
+* Allow setting custom GUID in feeds (Issue #2378)
 
 Bugfixes
 --------

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -310,6 +310,10 @@ category
     Like tags, except each post can have only one, and they usually have
     more descriptive names.
 
+guid
+    String used as GUID in RSS feeds and as ID in Atom feeds instead of the
+    permalink.
+
 link
     Link to original source for content. May be displayed by some themes.
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1728,7 +1728,7 @@ class Nikola(object):
                             post.date.astimezone(dateutil.tz.tzutc())),
                 'categories': post._tags.get(lang, []),
                 'creator': post.author(lang),
-                'guid': post.permalink(lang, absolute=True),
+                'guid': post.guid(lang),
             }
 
             if post.author(lang):
@@ -2397,7 +2397,7 @@ class Nikola(object):
             entry_title = lxml.etree.SubElement(entry_root, "title")
             entry_title.text = post.title(lang)
             entry_id = lxml.etree.SubElement(entry_root, "id")
-            entry_id.text = post.permalink(lang, absolute=True)
+            entry_id.text = post.guid(lang)
             entry_updated = lxml.etree.SubElement(entry_root, "updated")
             entry_updated.text = post.formatted_updated('webiso')
             entry_published = lxml.etree.SubElement(entry_root, "published")

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -405,6 +405,17 @@ class Post(object):
             lang = nikola.utils.LocaleBorg().current_lang
         return self.meta[lang]['description']
 
+    def guid(self, lang=None):
+        """Return localized GUID."""
+        if lang is None:
+            lang = nikola.utils.LocaleBorg().current_lang
+        if self.meta[lang]['guid']:
+            guid = self.meta[lang]['guid']
+        else:
+            guid = self.permalink(lang, absolute=True)
+
+        return guid
+
     def add_dependency(self, dependency, add='both', lang=None):
         """Add a file dependency for tasks using that post.
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Allows to set a custom GUID for RSS/Atom feeds from the post metadata.

Fixes #2378; closes #2675.