### PR TITLE
Don’t use doctests anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
 - if [[ $NMODE == 'nikola' ]]; then pip install .; fi
 - if [[ $NMODE == 'flake8' ]]; then pip install flake8 pydocstyle; fi
 script:
-- if [[ $NMODE == 'nikola' ]]; then py.test --doctest-modules nikola/; fi
 - if [[ $NMODE == 'nikola' ]]; then py.test tests/; fi
 - if [[ $NMODE == 'nikola' ]]; then nikola; fi
 - if [[ $NMODE == 'nikola' ]]; then nikola help; fi

--- a/docs/internals.txt
+++ b/docs/internals.txt
@@ -85,8 +85,8 @@ one of the existing ones.
 .. sidebar:: Tests
 
     While Nikola is not a hardcore TDD project, we like tests. So, please add them if you can.
-    You can do doctests, you can do unit tests, you can do integration tests. There is support
-    for all of them.
+    You can write unit tests or integration tests. (Doctests are not supported
+    anymore due to fragility.)
 
 Posts and Pages
 ---------------

--- a/dodo.py
+++ b/dodo.py
@@ -65,18 +65,10 @@ def task_locale():
     return {'actions': [set_nikola_test_locales], 'verbosity': 2}
 
 
-def task_doctest():
-    """run doctests with py.test"""
-    return {
-        'actions': ['py.test --doctest-modules nikola/'],
-        'verbosity': 2,
-    }
-
-
 def task_test():
     """run unit-tests using py.test"""
     return {
-        'task_dep': ['locale', 'doctest'],
+        'task_dep': ['locale'],
         'actions': ['py.test tests/'],
     }
 
@@ -84,7 +76,7 @@ def task_test():
 def task_coverage():
     """run unit-tests using py.test, with coverage reporting"""
     return {
-        'task_dep': ['locale', 'doctest'],
+        'task_dep': ['locale'],
         'actions': ['py.test --cov nikola --cov-report term-missing tests/'],
         'verbosity': 2,
     }

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -953,26 +953,26 @@ def get_crumbs(path, is_file=False, index_folder=None, lang=None):
     >>> crumbs = get_crumbs('galleries')
     >>> len(crumbs)
     1
-    >>> print('|'.join(crumbs[0]))
-    #|galleries
+    >>> crumbs[0]
+    ['#', 'galleries']
 
     >>> crumbs = get_crumbs(os.path.join('galleries','demo'))
     >>> len(crumbs)
     2
-    >>> print('|'.join(crumbs[0]))
-    ..|galleries
-    >>> print('|'.join(crumbs[1]))
-    #|demo
+    >>> crumbs[0]
+    ['..', 'galleries']
+    >>> crumbs[1]
+    ['#', 'demo']
 
     >>> crumbs = get_crumbs(os.path.join('listings','foo','bar'), is_file=True)
     >>> len(crumbs)
     3
-    >>> print('|'.join(crumbs[0]))
-    ..|listings
-    >>> print('|'.join(crumbs[1]))
-    .|foo
-    >>> print('|'.join(crumbs[2]))
-    #|bar
+    >>> crumbs[0]
+    ['..', 'listings']
+    >>> crumbs[1]
+    ['.', 'foo']
+    >>> crumbs[2]
+    ['#', 'bar']
     """
     crumbs = path.split(os.sep)
     _crumbs = []

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -469,9 +469,8 @@ class TemplateHookRegistry(object):
     >>> r = TemplateHookRegistry('foo', None)
     >>> r.append('Hello!')
     >>> r.append(lambda x: 'Hello ' + x + '!', False, 'world')
-    >>> str(r())  # str() call is not recommended in real use
+    >>> repr(r())
     'Hello!\nHello world!'
-    >>>
     """
 
     def __init__(self, name, site):

--- a/tests/test_compile_markdown.py
+++ b/tests/test_compile_markdown.py
@@ -64,5 +64,12 @@ class CompileMarkdownTests(BaseTestCase):
         actual_output = self.compile(input_str)
         self.assertEquals(actual_output.strip(), expected_output.strip())
 
+    def test_mdx_podcast(self):
+        input_str = "[podcast]https://archive.org/download/Rebeldes_Stereotipos/rs20120609_1.mp3[/podcast]"
+        expected_output = '<p><audio controls=""><source src="https://archive.org/download/Rebeldes_Stereotipos/rs20120609_1.mp3" type="audio/mpeg"></source></audio></p>'
+        actual_output = self.compile(input_str)
+        self.assertEquals(actual_output.strip(), expected_output.strip())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,9 +2,13 @@
 from __future__ import unicode_literals
 import unittest
 import mock
+import os
 import lxml.html
 from nikola.post import get_meta
-from nikola.utils import demote_headers, TranslatableSetting
+from nikola.utils import (demote_headers, TranslatableSetting, get_crumbs,
+                          TemplateHookRegistry, get_asset_path, get_theme_chain,
+                          get_translation_candidate)
+from nikola.plugins.task.sitemap import get_base_path as sitemap_get_base_path
 
 
 class dummy(object):
@@ -326,6 +330,63 @@ def test_get_metadata_from_file():
     assert 'title' in g(["", ".. title: FooBar"])
     assert 'title' in g([".. foo: bar", "", "FooBar", "------"])
 
+
+def test_get_asset_path():
+    assert get_asset_path('assets/css/rst.css', get_theme_chain('bootstrap3', ['themes'])).endswith('nikola/data/themes/base/assets/css/rst.css')
+    assert get_asset_path('assets/css/theme.css', get_theme_chain('bootstrap3', ['themes'])).endswith('nikola/data/themes/bootstrap3/assets/css/theme.css')
+    assert get_asset_path('nikola.py', get_theme_chain('bootstrap3', ['themes']), {'nikola': ''}).endswith('nikola/nikola.py')
+    assert get_asset_path('nikola.py', get_theme_chain('bootstrap3', ['themes']), {'nikola': 'nikola'}) is None
+    assert get_asset_path('nikola/nikola.py', get_theme_chain('bootstrap3', ['themes']), {'nikola': 'nikola'}).endswith('nikola/nikola.py')
+
+
+def test_get_crumbs():
+    crumbs = get_crumbs('galleries')
+    assert len(crumbs) == 1
+    assert crumbs[0] == ['#', 'galleries']
+
+    crumbs = get_crumbs(os.path.join('galleries', 'demo'))
+    assert len(crumbs) == 2
+    assert crumbs[0] == ['..', 'galleries']
+    assert crumbs[1] == ['#', 'demo']
+
+    crumbs = get_crumbs(os.path.join('listings', 'foo', 'bar'), is_file=True)
+    assert len(crumbs) == 3
+    assert crumbs[0] == ['..', 'listings']
+    assert crumbs[1] == ['.', 'foo']
+    assert crumbs[2] == ['#', 'bar']
+
+
+def test_get_translation_candidate():
+    config = {'TRANSLATIONS_PATTERN': '{path}.{lang}.{ext}', 'DEFAULT_LANG': 'en', 'TRANSLATIONS': {'es': '1', 'en': 1}}
+    assert get_translation_candidate(config, '*.rst', 'es') == '*.es.rst'
+    assert get_translation_candidate(config, 'fancy.post.rst', 'es') == 'fancy.post.es.rst'
+    assert get_translation_candidate(config, '*.es.rst', 'es') == '*.es.rst'
+    assert get_translation_candidate(config, '*.es.rst', 'en') == '*.rst'
+    assert get_translation_candidate(config, 'cache/posts/fancy.post.es.html', 'en') == 'cache/posts/fancy.post.html'
+    assert get_translation_candidate(config, 'cache/posts/fancy.post.html', 'es') == 'cache/posts/fancy.post.es.html'
+    assert get_translation_candidate(config, 'cache/pages/charts.html', 'es') == 'cache/pages/charts.es.html'
+    assert get_translation_candidate(config, 'cache/pages/charts.html', 'en') == 'cache/pages/charts.html'
+
+    config = {'TRANSLATIONS_PATTERN': '{path}.{ext}.{lang}', 'DEFAULT_LANG': 'en', 'TRANSLATIONS': {'es': '1', 'en': 1}}
+    assert get_translation_candidate(config, '*.rst', 'es') == '*.rst.es'
+    assert get_translation_candidate(config, '*.rst.es', 'es') == '*.rst.es'
+    assert get_translation_candidate(config, '*.rst.es', 'en') == '*.rst'
+    assert get_translation_candidate(config, 'cache/posts/fancy.post.html.es', 'en') == 'cache/posts/fancy.post.html'
+    assert get_translation_candidate(config, 'cache/posts/fancy.post.html', 'es') == 'cache/posts/fancy.post.html.es'
+
+
+def test_TemplateHookRegistry():
+    r = TemplateHookRegistry('foo', None)
+    r.append('Hello!')
+    r.append(lambda x: 'Hello ' + x + '!', False, 'world')
+    assert r() == 'Hello!\nHello world!'
+
+
+def test_sitemap_get_base_path():
+    assert sitemap_get_base_path('http://some.site') == '/'
+    assert sitemap_get_base_path('http://some.site/') == '/'
+    assert sitemap_get_base_path('http://some.site/some/sub-path') == '/some/sub-path/'
+    assert sitemap_get_base_path('http://some.site/some/sub-path/') == '/some/sub-path/'
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -332,11 +332,11 @@ def test_get_metadata_from_file():
 
 
 def test_get_asset_path():
-    assert get_asset_path('assets/css/rst.css', get_theme_chain('bootstrap3', ['themes'])).endswith('nikola/data/themes/base/assets/css/rst.css')
-    assert get_asset_path('assets/css/theme.css', get_theme_chain('bootstrap3', ['themes'])).endswith('nikola/data/themes/bootstrap3/assets/css/theme.css')
-    assert get_asset_path('nikola.py', get_theme_chain('bootstrap3', ['themes']), {'nikola': ''}).endswith('nikola/nikola.py')
+    assert get_asset_path('assets/css/rst.css', get_theme_chain('bootstrap3', ['themes'])).replace('\\', '/').endswith('nikola/data/themes/base/assets/css/rst.css')
+    assert get_asset_path('assets/css/theme.css', get_theme_chain('bootstrap3', ['themes'])).replace('\\', '/').endswith('nikola/data/themes/bootstrap3/assets/css/theme.css')
+    assert get_asset_path('nikola.py', get_theme_chain('bootstrap3', ['themes']), {'nikola': ''}).replace('\\', '/').endswith('nikola/nikola.py')
     assert get_asset_path('nikola.py', get_theme_chain('bootstrap3', ['themes']), {'nikola': 'nikola'}) is None
-    assert get_asset_path('nikola/nikola.py', get_theme_chain('bootstrap3', ['themes']), {'nikola': 'nikola'}).endswith('nikola/nikola.py')
+    assert get_asset_path('nikola/nikola.py', get_theme_chain('bootstrap3', ['themes']), {'nikola': 'nikola'}).replace('\\', '/').endswith('nikola/nikola.py')
 
 
 def test_get_crumbs():


### PR DESCRIPTION
Doctests are pretty fragile, require string trickery, and are frowned upon by many other people. Let’s drop them. This commit disables doctests and re-adds all the useful ones as regular unit tests.