### PR TITLE
Make PAGE_INDEX work with PRETTY_URLS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Features
 Bugfixes
 --------
 
+* Make ``PAGE_INDEX`` work with ``PRETTY_URLS`` (Issue #2705)
 * Fix PHP posts/pages not rendering on Windows (Issue #2706)
 
 New in v7.8.4

--- a/nikola/plugins/task/page_index.py
+++ b/nikola/plugins/task/page_index.py
@@ -64,7 +64,7 @@ class PageIndex(Taxonomy):
     def classify(self, post, lang):
         """Classify the given post for the given language."""
         destpath = post.destination_path(lang, sep='/')
-        if post._has_pretty_url(lang):
+        if post.has_pretty_url(lang):
             idx = '/index.html'
             if destpath.endswith(idx):
                 destpath = destpath[:-len(idx)]

--- a/nikola/plugins/task/page_index.py
+++ b/nikola/plugins/task/page_index.py
@@ -64,6 +64,10 @@ class PageIndex(Taxonomy):
     def classify(self, post, lang):
         """Classify the given post for the given language."""
         destpath = post.destination_path(lang, sep='/')
+        if self.site.config["PRETTY_URLS"]:
+            index_len = len(self.site.config["INDEX_FILE"])
+            if destpath[-(1 + index_len):] == '/' + self.site.config["INDEX_FILE"]:
+                destpath = destpath[:-(1 + index_len)]
         i = destpath.rfind('/')
         return [destpath[:i] if i >= 0 else '']
 

--- a/nikola/plugins/task/page_index.py
+++ b/nikola/plugins/task/page_index.py
@@ -65,7 +65,9 @@ class PageIndex(Taxonomy):
         """Classify the given post for the given language."""
         destpath = post.destination_path(lang, sep='/')
         if post._has_pretty_url(lang):
-            destpath = destpath.rstrip('/index.html')
+            idx = '/index.html'
+            if destpath.endswith(idx):
+                destpath = destpath[:-len(idx)]
         i = destpath.rfind('/')
         return [destpath[:i] if i >= 0 else '']
 

--- a/nikola/plugins/task/page_index.py
+++ b/nikola/plugins/task/page_index.py
@@ -64,10 +64,8 @@ class PageIndex(Taxonomy):
     def classify(self, post, lang):
         """Classify the given post for the given language."""
         destpath = post.destination_path(lang, sep='/')
-        if self.site.config["PRETTY_URLS"]:
-            index_len = len(self.site.config["INDEX_FILE"])
-            if destpath[-(1 + index_len):] == '/' + self.site.config["INDEX_FILE"]:
-                destpath = destpath[:-(1 + index_len)]
+        if post._has_pretty_url(lang):
+            destpath = destpath.rstrip('/index.html')
         i = destpath.rfind('/')
         return [destpath[:i] if i >= 0 else '']
 

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -279,7 +279,8 @@ class Post(object):
         m.update(utils.unicode_str(json.dumps(clean_meta, cls=utils.CustomEncoder, sort_keys=True)).encode('utf-8'))
         return '<Post: {0!r} {1}>'.format(self.source_path, m.hexdigest())
 
-    def _has_pretty_url(self, lang):
+    def has_pretty_url(self, lang):
+        """Check if this page has a pretty URL."""
         m = self.meta[lang].get('pretty_url', '')
         if m:
             # match is a non-empty string, overides anything
@@ -287,6 +288,10 @@ class Post(object):
         else:
             # use PRETTY_URLS, unless the slug is 'index'
             return self.pretty_urls and self.meta[lang]['slug'] != 'index'
+
+    def _has_pretty_url(self, lang):
+        """Check if this page has a pretty URL."""
+        return self.has_pretty_url(lang)
 
     @property
     def is_mathjax(self):
@@ -796,7 +801,7 @@ class Post(object):
         if lang is None:
             lang = nikola.utils.LocaleBorg().current_lang
         folder = self.folders[lang]
-        if self._has_pretty_url(lang):
+        if self.has_pretty_url(lang):
             path = os.path.join(self.translations[lang],
                                 folder, self.meta[lang]['slug'], 'index' + extension)
         else:
@@ -874,7 +879,7 @@ class Post(object):
 
         pieces = self.translations[lang].split(os.sep)
         pieces += self.folders[lang].split(os.sep)
-        if self._has_pretty_url(lang):
+        if self.has_pretty_url(lang):
             pieces += [self.meta[lang]['slug'], 'index' + extension]
         else:
             pieces += [self.meta[lang]['slug'] + extension]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -545,14 +545,14 @@ class RedirectionsTest3(TestCheck):
             outf.write("foo")
 
 class PageIndexTest(EmptyBuildTest):
-    """Test if PAGE_INDEX works."""
+    """Test if PAGE_INDEX works, with PRETTY_URLS disabled."""
 
     @classmethod
     def patch_site(self):
         """Enable PAGE_INDEX."""
         conf_path = os.path.join(self.target_dir, "conf.py")
         with io.open(conf_path, "a", encoding="utf8") as outf:
-            outf.write("""\n\nPAGE_INDEX = True\n\n""")
+            outf.write("""\n\nPAGE_INDEX = True\nPRETTY_URLS = False\n\n""")
 
     @classmethod
     def fill_site(self):
@@ -619,6 +619,16 @@ class PageIndexTest(EmptyBuildTest):
         self.assertTrue('Page 3' not in subdir2_index)
         self.assertTrue('This is not the page index.' in subdir2_index)
 
+
+class PageIndexPrettyUrlsTest(EmptyBuildTest):
+    """Test if PAGE_INDEX works, with PRETTY_URLS enabled."""
+
+    @classmethod
+    def patch_site(self):
+        """Enable PAGE_INDEX."""
+        conf_path = os.path.join(self.target_dir, "conf.py")
+        with io.open(conf_path, "a", encoding="utf8") as outf:
+            outf.write("""\n\nPAGE_INDEX = True\nPRETTY_URLS = True\n\n""")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -620,7 +620,7 @@ class PageIndexTest(EmptyBuildTest):
         self.assertTrue('This is not the page index.' in subdir2_index)
 
 
-class PageIndexPrettyUrlsTest(EmptyBuildTest):
+class PageIndexPrettyUrlsTest(PageIndexTest):
     """Test if PAGE_INDEX works, with PRETTY_URLS enabled."""
 
     @classmethod

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -564,7 +564,8 @@ class PageIndexTest(EmptyBuildTest):
         pages = os.path.join(self.target_dir, "pages")
         subdir1 = os.path.join(self.target_dir, "pages", "subdir1")
         subdir2 = os.path.join(self.target_dir, "pages", "subdir2")
-        subdir2 = os.path.join(self.target_dir, "pages", "subdir3")
+        subdir3 = os.path.join(self.target_dir, "pages", "subdir3")
+
         nikola.utils.makedirs(subdir1)
         nikola.utils.makedirs(subdir2)
         nikola.utils.makedirs(subdir3)
@@ -587,6 +588,10 @@ class PageIndexTest(EmptyBuildTest):
         with io.open(os.path.join(subdir3, 'bar.php'), "w+", encoding="utf8") as outf:
             outf.write(".. title: Still not the page index\n.. slug: index\n\nThis is not the page index either.\n")
 
+    def _make_output_path(self, dir, name):
+        """Make a file path to the output."""
+        return os.path.join(dir, name + '.html')
+
     def test_page_index(self):
         """Test PAGE_INDEX."""
         pages = os.path.join(self.target_dir, "output", "pages")
@@ -595,14 +600,15 @@ class PageIndexTest(EmptyBuildTest):
         subdir3 = os.path.join(self.target_dir, "output", "pages", "subdir3")
 
         # Do all files exist?
-        self.assertTrue(os.path.isfile(os.path.join(pages, 'page0.html')))
+        self.assertTrue(os.path.isfile(self._make_output_path(pages, 'page0')))
+        self.assertTrue(os.path.isfile(self._make_output_path(subdir1, 'page1')))
+        self.assertTrue(os.path.isfile(self._make_output_path(subdir1, 'page2')))
+        self.assertTrue(os.path.isfile(self._make_output_path(subdir2, 'page3')))
+        self.assertTrue(os.path.isfile(self._make_output_path(subdir3, 'page4')))
+
         self.assertTrue(os.path.isfile(os.path.join(pages, 'index.html')))
-        self.assertTrue(os.path.isfile(os.path.join(subdir1, 'page1.html')))
-        self.assertTrue(os.path.isfile(os.path.join(subdir1, 'page2.html')))
         self.assertTrue(os.path.isfile(os.path.join(subdir1, 'index.html')))
-        self.assertTrue(os.path.isfile(os.path.join(subdir2, 'page3.html')))
         self.assertTrue(os.path.isfile(os.path.join(subdir2, 'index.html')))
-        self.assertTrue(os.path.isfile(os.path.join(subdir3, 'page4.html')))
         self.assertTrue(os.path.isfile(os.path.join(subdir3, 'index.php')))
         self.assertFalse(os.path.isfile(os.path.join(subdir3, 'index.html')))
 
@@ -653,6 +659,11 @@ class PageIndexPrettyUrlsTest(PageIndexTest):
         conf_path = os.path.join(self.target_dir, "conf.py")
         with io.open(conf_path, "a", encoding="utf8") as outf:
             outf.write("""\n\nPAGE_INDEX = True\nPRETTY_URLS = True\nPAGES = PAGES + (('pages/*.php', 'pages', 'story.tmpl'),)\n\n""")
+
+    def _make_output_path(self, dir, name):
+        """Make a file path to the output."""
+        return os.path.join(dir, name + '/index.html')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -544,6 +544,7 @@ class RedirectionsTest3(TestCheck):
         with io.open(target_path, "w+", encoding="utf8") as outf:
             outf.write("foo")
 
+
 class PageIndexTest(EmptyBuildTest):
     """Test if PAGE_INDEX works, with PRETTY_URLS disabled."""
 


### PR DESCRIPTION
This should end the PAGE_INDEX saga for good. PRETTY_URLS and some corner cases, including `.php` are supported (and I also unearthed a bug in #2706).