### PR TITLE
Fix #2690 — make date ranges work in shortcode post lists

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Features
 Bugfixes
 --------
 
+* Make date ranges work in shortcode-based post lists (Issue #2690)
 * Read data files only if Nikola configuration exists (Issue #2708)
 * Make ``PAGE_INDEX`` work with ``PRETTY_URLS`` (Issue #2705)
 * Fix PHP posts/pages not rendering on Windows (Issue #2706)

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -274,7 +274,7 @@ def _do_post_list(start=None, stop=None, reverse=False, tags=None, require_all_t
 
     if date:
         _now = utils.current_time()
-        filtered_timeline = [p for p in filtered_timeline if date_in_range(date, p.date, now=_now)]
+        filtered_timeline = [p for p in filtered_timeline if date_in_range(utils.html_unescape(date), p.date, now=_now)]
 
     for post in filtered_timeline[start:stop:step]:
         if slugs:

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -2032,12 +2032,12 @@ try:
     html_unescape = html.unescape
 except (AttributeError, ImportError):
     try:
-        from HTMLParser import HTMLParser  # Python 2.6 and 2.7
+        from HTMLParser import HTMLParser  # Python 2.7
     except ImportError:
         from html.parser import HTMLParser  # Python 3 (up to 3.4)
 
     def html_unescape(s):
-        """Convert all named and numeric character references  in the string s to the corresponding unicode characters."""
+        """Convert all named and numeric character references in the string s to the corresponding unicode characters."""
         h = HTMLParser()
         return h.unescape(s)
 


### PR DESCRIPTION
I implemented this as a special case in shortcodes as opposed to making
global changes, because other shortcodes may break, and I’d say that
more shortcodes would want escapes and processing done for them.

cc @felixfontein, @ralsina, @gkabbe