### PR TITLE
Update MathJax CDN link.

### DIFF
--- a/nikola/data/themes/base-jinja/templates/index_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index_helper.tmpl
@@ -37,7 +37,7 @@
                 </script>
             {% endif %}
         {% else %}
-            <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
+            <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
             {% if mathjax_config %}
             {{ mathjax_config }}
             {% else %}

--- a/nikola/data/themes/base-jinja/templates/post_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_helper.tmpl
@@ -103,7 +103,7 @@
                 </script>
             {% endif %}
         {% else %}
-            <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
+            <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
             {% if mathjax_config %}
             {{ mathjax_config }}
             {% else %}

--- a/nikola/data/themes/base/templates/index_helper.tmpl
+++ b/nikola/data/themes/base/templates/index_helper.tmpl
@@ -37,7 +37,7 @@
                 </script>
             % endif
         %else:
-            <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
+            <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
             % if mathjax_config:
             ${mathjax_config}
             % else:

--- a/nikola/data/themes/base/templates/post_helper.tmpl
+++ b/nikola/data/themes/base/templates/post_helper.tmpl
@@ -103,7 +103,7 @@
                 </script>
             % endif
         %else:
-            <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
+            <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
             % if mathjax_config:
             ${mathjax_config}
             % else:


### PR DESCRIPTION
### Description

This fixes #2713 by updating the MathJax links to cdnjs and fixing it to version 2.7.0 (instead of latest).