### PR TITLE
Rename POSTS_SECTION_ARE_INDEXES to POSTS_SECTIONS_ARE_INDEXES

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,7 @@ Features
 Bugfixes
 --------
 
+* Rename ``POSTS_SECTION_ARE_INDEXES`` to ``POSTS_SECTIONS_ARE_INDEXES``
 * Make date ranges work in shortcode-based post lists (Issue #2690)
 * Read data files only if Nikola configuration exists (Issue #2708)
 * Make ``PAGE_INDEX`` work with ``PRETTY_URLS`` (Issue #2705)

--- a/docs/template-variables.rst
+++ b/docs/template-variables.rst
@@ -80,7 +80,8 @@ Name                                Type                                Descript
 ``navigation_links``                TranslatableSetting                 ``NAVIGATION_LINKS`` setting
 ``needs_ipython_css``               bool                                whether or not IPython CSS is needed by this site
 ``posts_sections``                  bool                                ``POSTS_SECTIONS`` setting
-``posts_section_are_indexes``       bool                                ``POSTS_SECTION_ARE_INDEXES`` setting
+``posts_section_are_indexes``       bool                                ``POSTS_SECTIONS_ARE_INDEXES`` setting
+``posts_sections_are_indexes``      bool                                ``POSTS_SECTIONS_ARE_INDEXES`` setting
 ``posts_section_colors``            TranslatableSetting                 ``POSTS_SECTION_COLORS`` setting
 ``posts_section_descriptions``      Tss                                 ``POSTS_SECTION_DESCRIPTIONS`` setting
 ``posts_section_from_meta``         bool                                ``POSTS_SECTION_FROM_META`` setting

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -548,7 +548,7 @@ class Nikola(object):
             'POSTS': (("posts/*.txt", "posts", "post.tmpl"),),
             'POSTS_SECTIONS': True,
             'POSTS_SECTION_COLORS': {},
-            'POSTS_SECTION_ARE_INDEXES': True,
+            'POSTS_SECTIONS_ARE_INDEXES': True,
             'POSTS_SECTION_DESCRIPTIONS': "",
             'POSTS_SECTION_FROM_META': False,
             'POSTS_SECTION_NAME': "",
@@ -941,6 +941,10 @@ class Nikola(object):
             utils.LOGGER.warn('The STORY_INDEX option is deprecated, use PAGE_INDEX instead.')
             self.config['PAGE_INDEX'] = config['STORY_INDEX']
 
+        if 'POSTS_SECTION_ARE_INDEXES' in config:
+            utils.LOGGER.warn('The POSTS_SECTION_ARE_INDEXES option is deprecated, use POSTS_SECTIONS_ARE_INDEXES instead.')
+            self.config['POSTS_SECTIONS_ARE_INDEXES'] = config['POSTS_SECTION_ARE_INDEXES']
+
         # Configure filters
         for actions in self.config['FILTERS'].values():
             for i, f in enumerate(actions):
@@ -1254,7 +1258,8 @@ class Nikola(object):
         self._GLOBAL_CONTEXT['hidden_authors'] = self.config.get('HIDDEN_AUTHORS')
         self._GLOBAL_CONTEXT['url_replacer'] = self.url_replacer
         self._GLOBAL_CONTEXT['posts_sections'] = self.config.get('POSTS_SECTIONS')
-        self._GLOBAL_CONTEXT['posts_section_are_indexes'] = self.config.get('POSTS_SECTION_ARE_INDEXES')
+        self._GLOBAL_CONTEXT['posts_section_are_indexes'] = self.config.get('POSTS_SECTIONS_ARE_INDEXES')
+        self._GLOBAL_CONTEXT['posts_sections_are_indexes'] = self.config.get('POSTS_SECTIONS_ARE_INDEXES')
         self._GLOBAL_CONTEXT['posts_section_colors'] = self.config.get('POSTS_SECTION_COLORS')
         self._GLOBAL_CONTEXT['posts_section_descriptions'] = self.config.get('POSTS_SECTION_DESCRIPTIONS')
         self._GLOBAL_CONTEXT['posts_section_from_meta'] = self.config.get('POSTS_SECTION_FROM_META')

--- a/nikola/plugins/task/sections.py
+++ b/nikola/plugins/task/sections.py
@@ -68,7 +68,7 @@ link://section_index_rss/cars => /cars/rss.xml""",
 
     def set_site(self, site):
         """Set Nikola site."""
-        self.show_list_as_index = site.config["POSTS_SECTION_ARE_INDEXES"]
+        self.show_list_as_index = site.config["POSTS_SECTIONS_ARE_INDEXES"]
         self.template_for_single_list = "sectionindex.tmpl" if self.show_list_as_index else "list.tmpl"
         self.enable_for_lang = {}
         return super(ClassifySections, self).set_site(site)


### PR DESCRIPTION
This fixes a grammar mistake in the setting name. Note that conf.py
contained the “new” name all along, so some people might have thought
this setting was broken. (It certainly was unused or we would’ve heard
about that.)