### PR TITLE
Fix typo in the default optipng executable name

### DIFF
--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -167,7 +167,7 @@ def closure_compiler(infile, executable='closure-compiler'):
 
 
 @_ConfigurableFilter(executable='OPTIPNG_EXECUTABLE')
-def optipng(infile, executable='optiong'):
+def optipng(infile, executable='optipng'):
     """Run optipng on a file."""
     return runinplace("{} -preserve -o2 -quiet %1".format(executable), infile)
 


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description
