### PR TITLE
Fix misplaced regexp flags arguments 

### DIFF
--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -341,7 +341,7 @@ class CommandAuto(Command):
 
     def remove_base_tag(self, data):
         """Comment out any <base> to allow local resolution of relative URLs."""
-        data = re.sub(r'<base\s([^>]*)>', '<!--base \g<1>-->', data, re.IGNORECASE)
+        data = re.sub(r'<base\s([^>]*)>', '<!--base \g<1>-->', data, flags=re.IGNORECASE)
         return data
 
 

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -253,7 +253,7 @@ class OurHTTPRequestHandler(SimpleHTTPRequestHandler):
             # Comment out any <base> to allow local resolution of relative URLs.
             data = f.read().decode('utf8')
             f.close()
-            data = re.sub(r'<base\s([^>]*)>', '<!--base \g<1>-->', data, re.IGNORECASE)
+            data = re.sub(r'<base\s([^>]*)>', '<!--base \g<1>-->', data, flags=re.IGNORECASE)
             data = data.encode('utf8')
             f = StringIO()
             f.write(data)

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -768,8 +768,8 @@ def remove_file(source):
 # slugify is adopted from
 # http://code.activestate.com/recipes/
 # 577257-slugify-make-a-string-usable-in-a-url-or-filename/
-_slugify_strip_re = re.compile(r'[^+\w\s-]')
-_slugify_hyphenate_re = re.compile(r'[-\s]+')
+_slugify_strip_re = re.compile(r'[^+\w\s-]', re.UNICODE)
+_slugify_hyphenate_re = re.compile(r'[-\s]+', re.UNICODE)
 
 
 def slugify(value, lang=None, force=False):
@@ -794,8 +794,8 @@ def slugify(value, lang=None, force=False):
         # This is the standard state of slugify, which actually does some work.
         # It is the preferred style, especially for Western languages.
         value = unicode_str(unidecode(value))
-        value = _slugify_strip_re.sub('', value, re.UNICODE).strip().lower()
-        return _slugify_hyphenate_re.sub('-', value, re.UNICODE)
+        value = _slugify_strip_re.sub('', value).strip().lower()
+        return _slugify_hyphenate_re.sub('-', value)
     else:
         # This is the “disarmed” state of slugify, which lets the user
         # have any character they please (be it regular ASCII with spaces,


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [ ] I tested my changes.

(I don't plan to complete this checklist myself. Sorry!)

### Description

This fixes multiple invalid uses of flags in `re.sub()` and `re.compile(...).sub()` calls.
Some of these problems were found using [pydiatra](https://github.com/jwilk/pydiatra).