### PR TITLE
Avoid empty subarchives

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,8 @@ Features
 Bugfixes
 --------
 
+* No longer creates empty subarchive pages, and no longer create broken
+  archive navigation links on day level (Issue #2734)
 * Fixes post scanner plugin order (Issue #2720)
 * Rename ``POSTS_SECTION_ARE_INDEXES`` to ``POSTS_SECTIONS_ARE_INDEXES``
 * Make date ranges work in shortcode-based post lists (Issue #2690)

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -219,7 +219,7 @@ class Archive(Taxonomy):
         kw.update(context)
         return context, kw
 
-    def postprocess_posts_per_classification(self, posts_per_section_per_language, flat_hierarchy_per_lang=None, hierarchy_lookup_per_lang=None):
+    def postprocess_posts_per_classification(self, posts_per_archive_per_language, flat_hierarchy_per_lang=None, hierarchy_lookup_per_lang=None):
         """Rearrange, modify or otherwise use the list of posts per classification and per language."""
         # Build a lookup table for archive navigation, if we’ll need one.
         if self.site.config['CREATE_ARCHIVE_NAVIGATION']:
@@ -229,14 +229,17 @@ class Archive(Taxonomy):
             for lang, flat_hierarchy in flat_hierarchy_per_lang.items():
                 self.archive_navigation[lang] = defaultdict(list)
                 for node in flat_hierarchy:
+                    if not self.site.config["SHOW_UNTRANSLATED_POSTS"]:
+                        if not [x for x in posts_per_archive_per_language[lang][node.classification_name] if x.is_translation_available(lang)]:
+                            continue
                     self.archive_navigation[lang][len(node.classification_path)].append(node.classification_name)
 
                 # We need to sort it. Natsort means it’s year 10000 compatible!
                 for k, v in self.archive_navigation[lang].items():
                     self.archive_navigation[lang][k] = natsort.natsorted(v, alg=natsort.ns.F | natsort.ns.IC)
 
-        return super(Archive, self).postprocess_posts_per_classification(posts_per_section_per_language, flat_hierarchy_per_lang, hierarchy_lookup_per_lang)
+        return super(Archive, self).postprocess_posts_per_classification(posts_per_archive_per_language, flat_hierarchy_per_lang, hierarchy_lookup_per_lang)
 
     def should_generate_classification_page(self, classification, post_list, lang):
         """Only generates list of posts for classification if this function returns True."""
-        return len(classification.split('/')) < 3 or len(post_list) > 0
+        return classification = '' or len(post_list) > 0

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -242,4 +242,4 @@ class Archive(Taxonomy):
 
     def should_generate_classification_page(self, classification, post_list, lang):
         """Only generates list of posts for classification if this function returns True."""
-        return classification = '' or len(post_list) > 0
+        return classification == '' or len(post_list) > 0


### PR DESCRIPTION
Fixes #2734.

Some archive pages are no longer created (more precisely: empty pages on month and year level), so strictly speaking this is breaking backwards compatibility.