### PR TITLE
Use shortcodes in a more robust manner

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,8 @@ Features
 Bugfixes
 --------
 
+* More robust shortcodes, no need to escape URLs in reSt, work better
+  with LaTeX, etc.
 * Fixes post scanner plugin order (Issue #2720)
 * Rename ``POSTS_SECTION_ARE_INDEXES`` to ``POSTS_SECTIONS_ARE_INDEXES``
 * Make date ranges work in shortcode-based post lists (Issue #2690)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1692,6 +1692,17 @@ class Nikola(object):
             lang = utils.LocaleBorg().current_lang
         return shortcodes.apply_shortcodes(data, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)
 
+    def apply_shortcodes2(self, data, shortcodes, filename=None, lang=None, with_dependencies=False, extra_context={}):
+        """Apply shortcodes from the registry on data."""
+        if lang is None:
+            lang = utils.LocaleBorg().current_lang
+        deps = []
+        for k, v in shortcodes:
+            replacement, _deps = shortcodes.apply_shortcodes(v, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)
+            data.replace(k, replacement)
+            deps.extend(_deps)
+        return data
+
     def _get_rss_copyright(self, lang, rss_plain):
         if rss_plain:
             return (

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1703,7 +1703,7 @@ class Nikola(object):
         deps = []
         for k, v in _shortcodes.items():
             replacement, _deps = shortcodes.apply_shortcodes(v, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)
-            data.replace(k, replacement)
+            data = data.replace(k, replacement)
             deps.extend(_deps)
         return data, deps
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1694,7 +1694,7 @@ class Nikola(object):
             lang = utils.LocaleBorg().current_lang
         return shortcodes.apply_shortcodes(data, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)
 
-    def apply_shortcodes2(self, data, shortcodes, filename=None, lang=None, with_dependencies=False, extra_context=None):
+    def apply_shortcodes_uuid(self, data, shortcodes, filename=None, lang=None, with_dependencies=False, extra_context=None):
         """Apply shortcodes from the registry on data."""
         if lang is None:
             lang = utils.LocaleBorg().current_lang

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1705,7 +1705,7 @@ class Nikola(object):
             replacement, _deps = shortcodes.apply_shortcodes(v, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)
             data.replace(k, replacement)
             deps.extend(_deps)
-        return data
+        return data, deps
 
     def _get_rss_copyright(self, lang, rss_plain):
         if rss_plain:

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1694,14 +1694,14 @@ class Nikola(object):
             lang = utils.LocaleBorg().current_lang
         return shortcodes.apply_shortcodes(data, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)
 
-    def apply_shortcodes_uuid(self, data, shortcodes, filename=None, lang=None, with_dependencies=False, extra_context=None):
+    def apply_shortcodes_uuid(self, data, _shortcodes, filename=None, lang=None, with_dependencies=False, extra_context=None):
         """Apply shortcodes from the registry on data."""
         if lang is None:
             lang = utils.LocaleBorg().current_lang
         if extra_context is None:
             extra_context = {}
         deps = []
-        for k, v in shortcodes:
+        for k, v in _shortcodes.items():
             replacement, _deps = shortcodes.apply_shortcodes(v, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)
             data.replace(k, replacement)
             deps.extend(_deps)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1686,16 +1686,20 @@ class Nikola(object):
         self.shortcode_registry[name] = f
 
     # XXX in v8, get rid of with_dependencies
-    def apply_shortcodes(self, data, filename=None, lang=None, with_dependencies=False, extra_context={}):
+    def apply_shortcodes(self, data, filename=None, lang=None, with_dependencies=False, extra_context=None):
         """Apply shortcodes from the registry on data."""
+        if extra_context is None:
+            extra_context = {}
         if lang is None:
             lang = utils.LocaleBorg().current_lang
         return shortcodes.apply_shortcodes(data, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)
 
-    def apply_shortcodes2(self, data, shortcodes, filename=None, lang=None, with_dependencies=False, extra_context={}):
+    def apply_shortcodes2(self, data, shortcodes, filename=None, lang=None, with_dependencies=False, extra_context=None):
         """Apply shortcodes from the registry on data."""
         if lang is None:
             lang = utils.LocaleBorg().current_lang
+        if extra_context is None:
+            extra_context = {}
         deps = []
         for k, v in shortcodes:
             replacement, _deps = shortcodes.apply_shortcodes(v, self.shortcode_registry, self, filename, lang=lang, with_dependencies=with_dependencies, extra_context=extra_context)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -58,6 +58,7 @@ import lxml.html
 from yapsy.PluginManager import PluginManager
 from blinker import signal
 
+
 from .post import Post  # NOQA
 from .state import Persistor
 from . import DEBUG, utils, shortcodes

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -82,7 +82,7 @@ class CompileRest(PageCompiler):
         }
 
         from nikola import shortcodes as sc
-        new_data, shortcodes = sc._extract_shortcodes(data)
+        new_data, shortcodes = sc.extract_shortcodes(data)
         output, error_level, deps = rst2html(
             new_data, settings_overrides=settings_overrides, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms,
             no_title_transform=self.site.config.get('NO_DOCUTILS_TITLE_TRANSFORM', False))
@@ -91,7 +91,7 @@ class CompileRest(PageCompiler):
             # Original issue: empty files.  `output` became a bytestring.
             output = output.decode('utf-8')
 
-        output, shortcode_deps = self.site.apply_shortcodes2(output, shortcodes, filename=source_path, with_dependencies=True, extra_context=dict(post=post))
+        output, shortcode_deps = self.site.apply_shortcodes_uuid(output, shortcodes, filename=source_path, with_dependencies=True, extra_context=dict(post=post))
         return output, error_level, deps, shortcode_deps
 
     # TODO remove in v8

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -84,7 +84,7 @@ class CompileRest(PageCompiler):
         from nikola import shortcodes as sc
         new_data, shortcodes = sc._extract_shortcodes(data)
         output, error_level, deps = rst2html(
-            data, settings_overrides=settings_overrides, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms,
+            new_data, settings_overrides=settings_overrides, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms,
             no_title_transform=self.site.config.get('NO_DOCUTILS_TITLE_TRANSFORM', False))
         if not isinstance(output, unicode_str):
             # To prevent some weird bugs here or there.

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -81,6 +81,8 @@ class CompileRest(PageCompiler):
             'language_code': LEGAL_VALUES['DOCUTILS_LOCALES'].get(LocaleBorg().current_lang, 'en')
         }
 
+        from nikola import shortcodes as sc
+        new_data, shortcodes = sc._extract_shortcodes(data)
         output, error_level, deps = rst2html(
             data, settings_overrides=settings_overrides, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms,
             no_title_transform=self.site.config.get('NO_DOCUTILS_TITLE_TRANSFORM', False))
@@ -88,7 +90,8 @@ class CompileRest(PageCompiler):
             # To prevent some weird bugs here or there.
             # Original issue: empty files.  `output` became a bytestring.
             output = output.decode('utf-8')
-        output, shortcode_deps = self.site.apply_shortcodes(output, filename=source_path, with_dependencies=True, extra_context=dict(post=post))
+
+        output, shortcode_deps = self.site.apply_shortcodes2(output, shortcodes, filename=source_path, with_dependencies=True, extra_context=dict(post=post))
         return output, error_level, deps, shortcode_deps
 
     # TODO remove in v8

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -116,9 +116,6 @@ link://category_rss/dogs => /categories/dogs.xml""",
 
     def slugify_category_name(self, path, lang):
         """Slugify a category name."""
-        if not path:  # Probably used link://category
-            utils.LOGGER.error('Invalid link to a category without passing a category name. Probably meant to use category_index?')
-            raise ValueError()
         if lang is None:  # TODO: remove in v8
             utils.LOGGER.warn("ClassifyCategories.slugify_category_name() called without language!")
             lang = ''

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -116,6 +116,9 @@ link://category_rss/dogs => /categories/dogs.xml""",
 
     def slugify_category_name(self, path, lang):
         """Slugify a category name."""
+        if not path:  # Probably used link://category
+            utils.LOGGER.error('Invalid link to a category without passing a category name. Probably meant to use category_index?')
+            raise ValueError()
         if lang is None:  # TODO: remove in v8
             utils.LOGGER.warn("ClassifyCategories.slugify_category_name() called without language!")
             lang = ''

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -212,7 +212,7 @@ def _parse_shortcode_args(data, start, shortcode_name, start_pos):
 def _extract_shortcodes(data):
     """
     Returns data, shortcodes:
-    
+
     data is the original data, with the shortcodes replaced by UUIDs.
 
     a dictionary of shortcodes, where the keys are UUIDs and the values
@@ -242,15 +242,12 @@ def _extract_shortcodes(data):
         elif chunk[0] == 'SHORTCODE_END':
             # Previous shortcode closes here
             buffer.append(chunk)
-            sc_id = str(uuid.uuid4())
+            sc_id = str('SHORTCODE{0}REPLACEMENT'.format(str(uuid.uuid4()).replace('-', '')))
             new_data.append(sc_id)
             shortcodes[sc_id] = ''.join(x[1] for x in buffer)
             in_sc = False
 
     return ''.join(new_data), shortcodes
-
-
-
 
 
 def _split_shortcodes(data):

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -223,7 +223,7 @@ def _extract_shortcodes(data):
     in_sc = False
     buffer = []
     shortcodes = {}
-    for i, chunk in enumerate(splitted):
+    for chunk in splitted:
         if chunk[0] == 'TEXT':
             if in_sc:
                 buffer.append(chunk)

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -211,7 +211,7 @@ def _new_sc_id():
 
 def extract_shortcodes(data, _new_sc_id=_new_sc_id):
     """
-    Returns data, shortcodes:
+    Return data with replaced shortcodes, shortcodes.
 
     data is the original data, with the shortcodes replaced by UUIDs.
 
@@ -239,12 +239,12 @@ def extract_shortcodes(data, _new_sc_id=_new_sc_id):
     (u'AAASC7 BBB SC8 CCC', {u'SC7': u'{{% foo %}}', u'SC8': u'{{% bar %}} quux {{% /bar %}}'})
 
     """
-
     shortcodes = {}
     splitted = _split_shortcodes(data)
 
     def extract_data_chunk(data):
-        """Takes a list of splitted shortcodes and returns a string and a tail.
+        """Take a list of splitted shortcodes and return a string and a tail.
+
         The string is data, the tail is ready for a new run of this same function.
         """
         text = []

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -83,11 +83,7 @@ def _skip_nonwhitespace(data, pos):
     for i, x in enumerate(data[pos:]):
         if x.isspace():
             return pos + i
-    while pos < len(data):
-        if data[pos].isspace():
-            break
-        pos += 1
-    return pos
+    return len(data)
 
 
 def _parse_quoted_string(data, start):

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -209,7 +209,7 @@ def _parse_shortcode_args(data, start, shortcode_name, start_pos):
     raise ParsingError("Shortcode '{0}' starting at {1} is not terminated correctly with '%}}}}'!".format(shortcode_name, _format_position(data, start_pos)))
 
 
-def _extract_shortcodes(data):
+def extract_shortcodes(data):
     """
     Returns data, shortcodes:
 

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -218,7 +218,6 @@ def _extract_shortcodes(data):
     a dictionary of shortcodes, where the keys are UUIDs and the values
     are the shortcodes themselves ready to process.
     """
-    import pdb; pdb.set_trace()
     splitted = _split_shortcodes(data)
     new_data = []
     in_sc = False

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -209,7 +209,7 @@ def _new_sc_id():
     return str('SHORTCODE{0}REPLACEMENT'.format(str(uuid.uuid4()).replace('-', '')))
 
 
-def extract_shortcodes(data, _new_sc_id=_new_sc_id):
+def extract_shortcodes(data):
     """
     Return data with replaced shortcodes, shortcodes.
 
@@ -217,27 +217,6 @@ def extract_shortcodes(data, _new_sc_id=_new_sc_id):
 
     a dictionary of shortcodes, where the keys are UUIDs and the values
     are the shortcodes themselves ready to process.
-
-    >>> c = 0
-    >>> def _new_sc_id():
-    ...     global c
-    ...     c += 1
-    ...     return 'SC%d' % c
-    >>> extract_shortcodes('{{% foo %}}', _new_sc_id)
-    (u'SC1', {u'SC1': u'{{% foo %}}'})
-    >>> extract_shortcodes('{{% foo %}} bar {{% /foo %}}', _new_sc_id)
-    (u'SC2', {u'SC2': u'{{% foo %}} bar {{% /foo %}}'})
-    >>> extract_shortcodes('AAA{{% foo %}} bar {{% /foo %}}BBB', _new_sc_id)
-    (u'AAASC3BBB', {u'SC3': u'{{% foo %}} bar {{% /foo %}}'})
-    >>> extract_shortcodes('AAA{{% foo %}} {{% bar %}} {{% /foo %}}BBB', _new_sc_id)
-    (u'AAASC4BBB', {u'SC4': u'{{% foo %}} {{% bar %}} {{% /foo %}}'})
-    >>> extract_shortcodes('AAA{{% foo %}} {{% /bar %}} {{% /foo %}}BBB', _new_sc_id)
-    (u'AAASC5BBB', {u'SC5': u'{{% foo %}} {{% /bar %}} {{% /foo %}}'})
-    >>> extract_shortcodes('AAA{{% foo %}} {{% bar %}} quux {{% /bar %}} {{% /foo %}}BBB', _new_sc_id)
-    (u'AAASC6BBB', {u'SC6': u'{{% foo %}} {{% bar %}} quux {{% /bar %}} {{% /foo %}}'})
-    >>> extract_shortcodes('AAA{{% foo %}} BBB {{% bar %}} quux {{% /bar %}} CCC', _new_sc_id)
-    (u'AAASC7 BBB SC8 CCC', {u'SC7': u'{{% foo %}}', u'SC8': u'{{% bar %}} quux {{% /bar %}}'})
-
     """
     shortcodes = {}
     splitted = _split_shortcodes(data)
@@ -268,14 +247,14 @@ def extract_shortcodes(data, _new_sc_id=_new_sc_id):
             elif token[0] == 'SHORTCODE_END':  # This is malformed
                 raise Exception('Closing unopened shortcode {}'.format(token[3]))
 
-    text = ''
+    text = []
     tail = splitted
     while True:
         new_text, tail = extract_data_chunk(tail)
-        text += new_text
+        text.append(new_text)
         if not tail:
             break
-    return text, shortcodes
+    return ''.join(text), shortcodes
 
 
 def _split_shortcodes(data):

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -231,7 +231,7 @@ def extract_shortcodes(data):
                 new_data.append(chunk[1])
         elif chunk[0] == 'SHORTCODE_START':
             if in_sc:  # Previous sc doesn't close
-                sc_id = str(uuid.uuid4())
+                sc_id = str('SHORTCODE{0}REPLACEMENT'.format(str(uuid.uuid4()).replace('-', '')))
                 new_data.append(sc_id)
                 shortcodes[sc_id] = buffer[0][1]
                 for c in buffer[1:]:  # Dump buffered text
@@ -246,6 +246,13 @@ def extract_shortcodes(data):
             new_data.append(sc_id)
             shortcodes[sc_id] = ''.join(x[1] for x in buffer)
             in_sc = False
+    # Whatever is left in the buffer goes in the text
+    if in_sc:  # Previous sc doesn't close
+        sc_id = str('SHORTCODE{0}REPLACEMENT'.format(str(uuid.uuid4()).replace('-', '')))
+        new_data.append(sc_id)
+        shortcodes[sc_id] = buffer[0][1]
+        for c in buffer[1:]:  # Dump buffered text
+            new_data.append(c[1])
 
     return ''.join(new_data), shortcodes
 

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -13,3 +13,4 @@ ipykernel>=4.0.0
 ghp-import2>=1.0.0
 ws4py==0.4.2
 watchdog==0.8.3
+AppMetrics==0.5.0

--- a/tests/base.py
+++ b/tests/base.py
@@ -230,3 +230,7 @@ class FakeSite(object):
     def apply_shortcodes(self, data, *a, **kw):
         """Apply shortcodes from the registry on data."""
         return nikola.shortcodes.apply_shortcodes(data, self.shortcode_registry, **kw)
+
+    def apply_shortcodes_uuid(self, data, shortcodes, *a, **kw):
+        """Apply shortcodes from the registry on data."""
+        return nikola.shortcodes.apply_shortcodes_uuid(data, shortcodes, self.shortcode_registry, **kw)

--- a/tests/base.py
+++ b/tests/base.py
@@ -233,4 +233,4 @@ class FakeSite(object):
 
     def apply_shortcodes_uuid(self, data, shortcodes, *a, **kw):
         """Apply shortcodes from the registry on data."""
-        return nikola.shortcodes.apply_shortcodes_uuid(data, shortcodes, self.shortcode_registry, **kw)
+        return nikola.shortcodes.apply_shortcodes(data, self.shortcode_registry, **kw)

--- a/tests/test_shortcodes.py
+++ b/tests/test_shortcodes.py
@@ -88,7 +88,7 @@ class TestErrors(BaseTestCase):
 def test_extract_shortcodes(input, expected, monkeypatch):
 
     i = iter('SC%d' % i for i in range(1, 100))
-    if sys.version[0] < 3:
+    if sys.version[0] < "3":
         monkeypatch.setattr(shortcodes, '_new_sc_id', i.next)
     else:
         monkeypatch.setattr(shortcodes, '_new_sc_id', i.__next__)

--- a/tests/test_shortcodes.py
+++ b/tests/test_shortcodes.py
@@ -88,7 +88,7 @@ class TestErrors(BaseTestCase):
 def test_extract_shortcodes(input, expected, monkeypatch):
 
     i = iter('SC%d' % i for i in range(1, 100))
-    if sys.version[0] < "3":
+    if sys.version_info[0] < "3":
         monkeypatch.setattr(shortcodes, '_new_sc_id', i.next)
     else:
         monkeypatch.setattr(shortcodes, '_new_sc_id', i.__next__)

--- a/tests/test_shortcodes.py
+++ b/tests/test_shortcodes.py
@@ -4,6 +4,8 @@
 u"""Test shortcodes."""
 
 from __future__ import unicode_literals
+import itertools
+
 import pytest
 from nikola import shortcodes
 from .base import FakeSite, BaseTestCase
@@ -88,7 +90,7 @@ class TestErrors(BaseTestCase):
 def test_extract_shortcodes(input, expected, monkeypatch):
 
     i = iter('SC%d' % i for i in range(1, 100))
-    if sys.version_info[0] < "3":
+    if sys.version_info[0] < 3:
         monkeypatch.setattr(shortcodes, '_new_sc_id', i.next)
     else:
         monkeypatch.setattr(shortcodes, '_new_sc_id', i.__next__)

--- a/tests/test_shortcodes.py
+++ b/tests/test_shortcodes.py
@@ -88,6 +88,9 @@ class TestErrors(BaseTestCase):
 def test_extract_shortcodes(input, expected, monkeypatch):
 
     i = iter('SC%d' % i for i in range(1, 100))
-    monkeypatch.setattr(shortcodes, '_new_sc_id', i.next)
+    if sys.version[0] < 3:
+        monkeypatch.setattr(shortcodes, '_new_sc_id', i.next)
+    else:
+        monkeypatch.setattr(shortcodes, '_new_sc_id', i.__next__)
     extracted = shortcodes.extract_shortcodes(input)
     assert extracted == expected


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

This changes how shortcodes are applied:

* Before compiling the file, shortcodes are extracted and replaced by UUIDs
* After compiling, shortcodes are processed and re-inserted where the UUID markers are

This avoids problems like rst mangling URLs and such.

Still needs work:

* apply_shortcodes_2 is not a proper function name ;-)
* All compilers can be switched to this approach gradually, but I would prefer if they all switched at once.

The older API can be kept for backwards compatibility since it has not been touched.