### PR TITLE
Add jpegoptim_progressive filter to convert jpegs to progressive scan

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -45,6 +45,7 @@
 * `Felix Schwarz <https://github.com/FelixSchwarz>`_
 * `Florian Finkernagel <https://github.com/TyberiusPrime>`_
 * `follower <https://github.com/follower>`_
+* `George Leslie-Waksman <https://github.com/gwax>`_
 * `Grzegorz Śliwiński <https://github.com/fizyk>`_
 * `Guillermo O. Freschi <https://github.com/Tordek>`_
 * `Hardening <https://github.com/hardening>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,8 @@ Features
 * Include KaTeX CSS automatically when needed (Issue #2715)
 * Split out math code into new ``math_helper.tmpl`` template (Issue
   #2715)
+* Added ``jpegoptim_progressive`` filter to convert jpeg images to progressive
+  jpegs.
 
 Bugfixes
 --------

--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -178,6 +178,12 @@ def jpegoptim(infile, executable='jpegoptim'):
     return runinplace("{} -p --strip-all -q %1".format(executable), infile)
 
 
+@_ConfigurableFilter(executable='JPEGOPTIM_EXECUTABLE')
+def jpegoptim_progressive(infile, executable='jpegoptim'):
+    """Run jpegoptim on a file and convert to progressive."""
+    return runinplace("{} -p --strip-all --all-progressive -q %1".format(executable), infile)
+
+
 @_ConfigurableFilter(executable='HTML_TIDY_EXECUTABLE')
 def html_tidy_withconfig(infile, executable='tidy5'):
     """Run HTML Tidy with tidy5.conf as config file."""


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Add a new `jpegoptim_progressive` filter that performs jpegoptim with progressive scan output conversion.