### PR TITLE
Handle animated gifs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,7 @@ Features
 Bugfixes
 --------
 
+* Don't break animated GIFs in postprocessing (Issue #2750)
 * More robust shortcodes, no need to escape URLs in reSt, work better
   with LaTeX, etc.
 * No longer creates empty subarchive pages, and no longer create broken

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -98,6 +98,12 @@ class ImageProcessor(object):
             self.resize_svg(src, dst, max_size, bigger_panoramas)
             return
         im = Image.open(src)
+
+        if hasattr(im, 'n_frames') and im.n_frames > 1:
+            # Animated gif, leave as-is
+            utils.copy_file(src, dst)
+            return
+
         size = w, h = im.size
         if w > max_size or h > max_size:
             size = max_size, max_size


### PR DESCRIPTION
Don't postrocess animated GIFs, so we don't break them.

It should be possible to still resize them, but it's sort of a hassle, and the experiments I did really show a lot of degradation, so let's not touch them.