### PR TITLE
Fix #2755 -- open 127.0.0.1 instead of 0.0.0.0 in serve -b

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,9 @@ Features
 Bugfixes
 --------
 
+* Open ``127.0.0.1`` when using ``nikola serve -b`` and default
+  ``0.0.0.0`` hostname to avoid resolution issues — the site is still
+  available on all interfaces (Issue #2755)
 * Don't break animated GIFs in postprocessing (Issue #2750)
 * More robust shortcodes, no need to escape URLs in reSt, work better
   with LaTeX, etc.

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -146,6 +146,8 @@ class CommandServe(Command):
             if options['browser']:
                 if ipv6:
                     server_url = "http://[{0}]:{1}/".format(*sa)
+                elif sa[0] == '0.0.0.0':
+                    server_url = "http://127.0.0.1:{1}/".format(*sa)
                 else:
                     server_url = "http://{0}:{1}/".format(*sa)
                 self.logger.info("Opening {0} in the default web browser...".format(server_url))


### PR DESCRIPTION
Open `127.0.0.1` when using `nikola serve -b` and default `0.0.0.0` hostname to avoid resolution issues — the site is still available on all interfaces.