### PR TITLE
re-raise the original exception, not a copy of it

### DIFF
--- a/nikola/plugins/command/console.py
+++ b/nikola/plugins/command/console.py
@@ -78,10 +78,10 @@ If there is no console to use specified (as -b, -i, -p) it tries IPython, then f
         """Run an IPython shell."""
         try:
             import IPython
-        except ImportError as e:
+        except ImportError:
             if willful:
                 req_missing(['IPython'], 'use the IPython console')
-            raise e  # That’s how _execute knows whether to try something else.
+            raise  # That’s how _execute knows whether to try something else.
         else:
             site = self.context['site']  # NOQA
             nikola_site = self.context['site']  # NOQA
@@ -96,7 +96,7 @@ If there is no console to use specified (as -b, -i, -p) it tries IPython, then f
         except ImportError as e:
             if willful:
                 req_missing(['bpython'], 'use the bpython console')
-            raise e  # That’s how _execute knows whether to try something else.
+            raise  # That’s how _execute knows whether to try something else.
         else:
             bpython.embed(banner=self.header.format('bpython'), locals_=self.context)
 

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -164,11 +164,11 @@ class CommandServe(Command):
                         with open(self.serve_pidfile, 'w') as fh:
                             fh.write('{0}\n'.format(pid))
                         self.logger.info("Detached with PID {0}. Run `kill {0}` or `kill $(cat nikolaserve.pid)` to stop the server.".format(pid))
-                except AttributeError as e:
+                except AttributeError:
                     if os.name == 'nt':
                         self.logger.warning("Detaching is not available on Windows, server is running in the foreground.")
                     else:
-                        raise e
+                        raise
             else:
                 self.detached = False
                 try:

--- a/nikola/plugins/misc/scan_posts.py
+++ b/nikola/plugins/misc/scan_posts.py
@@ -101,9 +101,9 @@ class ScanPosts(PostScanner):
                             destination_base=destination_translatable
                         )
                         timeline.append(post)
-                    except Exception as err:
+                    except Exception:
                         LOGGER.error('Error reading post {}'.format(base_path))
-                        raise err
+                        raise
 
         return timeline
 

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -382,7 +382,7 @@ def apply_shortcodes(data, registry, site=None, filename=None, raise_exceptions=
     except ParsingError as e:
         if raise_exceptions:
             # Throw up
-            raise e
+            raise
         if filename:
             LOGGER.error("Shortcode error in file {0}: {1}".format(filename, e))
         else:


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
otherwise the resulting traceback will have the `raise` line as the offending one, not the really problematic one.

example:

    >>> try:
    ...     import nothing
    ... except ImportError as e:
    ...     raise e
    Traceback (most recent call last):
      File "<input>", line 5, in <module>
        raise e
    ImportError: No module named nothing

    >>> try:
    ...     import nothing
    ... except ImportError as e:
    ...     raise
    Traceback (most recent call last):
      File "<input>", line 2, in <module>
        import nothing
    ImportError: No module named nothing