### PR TITLE
Don't crash when translating untranslated strings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,8 @@ Features
 Bugfixes
 --------
 
+* Don't crash when translating untranslated messages.
+
 New in v7.8.5
 =============
 

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -265,6 +265,10 @@ class Functionary(defaultdict):
         """When called as a function, take an optional lang and return self[lang][key]."""
         if lang is None:
             lang = LocaleBorg().current_lang
+        if lang not in self:
+            LOGGER.warning('Unknown language %s', lang)
+        elif key not in self[lang]:
+            LOGGER.warning('Unknown message %s', key)
         return self[lang][key]
 
 


### PR DESCRIPTION
keturn just reported on IRC that an old theme crashed because it used `messages['Posted']` instead of the current `messages['Posted:']`  ... that's harsh :-)