### PR TITLE
Add a file blacklist for header permalinks

### DIFF
--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -1928,6 +1928,10 @@ add_header_permalinks
         # Include *every* header (not recommended):
         # HEADER_PERMALINKS_XPATH_LIST = ['*//{hx}']
 
+    You can also use a file blacklist (``HEADER_PERMALINKS_FILE_BLACKLIST``),
+    useful for some index pages. Paths include the output directory (eg.
+    ``output/index.html``)
+
 You can apply filters to specific posts or pages by using the ``filters`` metadata field:
 
 .. code:: restructuredtext

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -590,10 +590,13 @@ GITHUB_COMMIT_SOURCE = True
 # ({hx}} is replaced by headers h1 through h6).
 # You must change this if you use a custom theme that does not use
 # "e-content entry-content" as a class for post and page contents.
-
 # HEADER_PERMALINKS_XPATH_LIST = ['*//div[@class="e-content entry-content"]//{hx}']
 # Include *every* header (not recommended):
 # HEADER_PERMALINKS_XPATH_LIST = ['*//{hx}']
+
+# File blacklist for header permalinks. Contains output path
+# (eg. 'output/index.html')
+# HEADER_PERMALINKS_FILE_BLACKLIST = []
 
 # Expert setting! Create a gzipped copy of each generated file. Cheap server-
 # side optimization for very high traffic sites or low memory servers.


### PR DESCRIPTION
Header permalinks are not desirable in some files (eg. output/index.html on getnikola.com — which I just rebuilt using header_permalinks; deduplication is pending until it’s merged). So, here’s a blacklist.