### PR TITLE
Fix #1891

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ Bugfixes
 --------
 
 * Ignore files ending wih "bak" (Issue #2740)
+* Use page.tmpl by default, which is inherited from story.tmpl (Issue
+  #1891)
 
 New in v7.8.5
 =============

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -123,8 +123,8 @@ THEME_COLOR = '#5670d4'
 # Finally, note that destination can be translated, i.e. you can
 # specify a different translation folder per language. Example:
 #     PAGES = (
-#         ("pages/*.rst", {"en": "pages", "de": "seiten"}, "story.tmpl"),
-#         ("pages/*.md", {"en": "pages", "de": "seiten"}, "story.tmpl"),
+#         ("pages/*.rst", {"en": "pages", "de": "seiten"}, "page.tmpl"),
+#         ("pages/*.md", {"en": "pages", "de": "seiten"}, "page.tmpl"),
 #     )
 
 POSTS = ${POSTS}

--- a/nikola/data/themes/base/templates/page.tmpl
+++ b/nikola/data/themes/base/templates/page.tmpl
@@ -1,0 +1,1 @@
+<%inherit file="story.tmpl"/>

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -78,9 +78,9 @@ SAMPLE_CONF = {
     ("posts/*.html", "posts", "post.tmpl"),
 )""",
     'PAGES': """(
-    ("pages/*.rst", "pages", "story.tmpl"),
-    ("pages/*.txt", "pages", "story.tmpl"),
-    ("pages/*.html", "pages", "story.tmpl"),
+    ("pages/*.rst", "pages", "page.tmpl"),
+    ("pages/*.txt", "pages", "page.tmpl"),
+    ("pages/*.html", "pages", "page.tmpl"),
 )""",
     'COMPILERS': """{
     "rest": ('.rst', '.txt'),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -392,10 +392,10 @@ class RelativeLinkTest2(DemoBuildTest):
         conf_path = os.path.join(self.target_dir, "conf.py")
         with io.open(conf_path, "r", encoding="utf-8") as inf:
             data = inf.read()
-            data = data.replace('("pages/*.txt", "pages", "story.tmpl"),',
-                                '("pages/*.txt", "", "story.tmpl"),')
-            data = data.replace('("pages/*.rst", "pages", "story.tmpl"),',
-                                '("pages/*.rst", "", "story.tmpl"),')
+            data = data.replace('("pages/*.txt", "pages", "page.tmpl"),',
+                                '("pages/*.txt", "", "page.tmpl"),')
+            data = data.replace('("pages/*.rst", "pages", "page.tmpl"),',
+                                '("pages/*.rst", "", "page.tmpl"),')
             data = data.replace('# INDEX_PATH = ""',
                                 'INDEX_PATH = "blog"')
         with io.open(conf_path, "w+", encoding="utf8") as outf:
@@ -553,7 +553,7 @@ class SectionPageCollisionTest(EmptyBuildTest):
         """Enable post sections."""
         conf_path = os.path.join(self.target_dir, "conf.py")
         with io.open(conf_path, "a", encoding="utf8") as outf:
-            outf.write("""\n\nPOSTS_SECTIONS = True\nPOSTS_SECTIONS_ARE_INDEXES = True\nPRETTY_URLS = True\nPOSTS = (('posts/*.txt', '', 'post.tmpl'),)\nPAGES = (('pages/*.txt', '', 'story.tmpl'),)\n\n""")
+            outf.write("""\n\nPOSTS_SECTIONS = True\nPOSTS_SECTIONS_ARE_INDEXES = True\nPRETTY_URLS = True\nPOSTS = (('posts/*.txt', '', 'post.tmpl'),)\nPAGES = (('pages/*.txt', '', 'page.tmpl'),)\n\n""")
 
     @classmethod
     def fill_site(self):
@@ -602,7 +602,7 @@ class PageIndexTest(EmptyBuildTest):
         """Enable PAGE_INDEX."""
         conf_path = os.path.join(self.target_dir, "conf.py")
         with io.open(conf_path, "a", encoding="utf8") as outf:
-            outf.write("""\n\nPAGE_INDEX = True\nPRETTY_URLS = False\nPAGES = PAGES + (('pages/*.php', 'pages', 'story.tmpl'),)\n\n""")
+            outf.write("""\n\nPAGE_INDEX = True\nPRETTY_URLS = False\nPAGES = PAGES + (('pages/*.php', 'pages', 'page.tmpl'),)\n\n""")
 
     @classmethod
     def fill_site(self):
@@ -707,7 +707,7 @@ class PageIndexPrettyUrlsTest(PageIndexTest):
         """Enable PAGE_INDEX."""
         conf_path = os.path.join(self.target_dir, "conf.py")
         with io.open(conf_path, "a", encoding="utf8") as outf:
-            outf.write("""\n\nPAGE_INDEX = True\nPRETTY_URLS = True\nPAGES = PAGES + (('pages/*.php', 'pages', 'story.tmpl'),)\n\n""")
+            outf.write("""\n\nPAGE_INDEX = True\nPRETTY_URLS = True\nPAGES = PAGES + (('pages/*.php', 'pages', 'page.tmpl'),)\n\n""")
 
     def _make_output_path(self, dir, name):
         """Make a file path to the output."""


### PR DESCRIPTION
* Create a page.tmpl which inherits story.tmpl and changes nothing.
* Use page.tmpl by default for new sites PAGES

This makes story.tmpl less visible, making the naming more consistent, and should break nothing.
