### PR TITLE
Support YAML metadata (Issue #2801)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+New in master
+=============
+
+Features
+--------
+
+* Support for YAML metadata (Issue #2801)
+
 New in v7.8.6
 =============
 

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -278,7 +278,9 @@ Metadata fields
 ~~~~~~~~~~~~~~~
 
 Nikola supports many metadata fields in posts. All of them are
-translatable and almost all are optional. The meta field format is:
+translatable and almost all are optional. Metadata can be in different formats.
+
+The "traditional" meta field format is:
 
 .. code:: text
 
@@ -286,6 +288,17 @@ translatable and almost all are optional. The meta field format is:
 
 You can add your own metadata fields in the same manner. If you are not using
 reStructuredText, make sure the fields are in a HTML comment in output.
+
+Current Nikola versions experimentally support YAML metadata wrapped by a "---" separator
+and in that case, the usual YAML syntax is used:
+
+.. code:: yaml
+
+   ---
+   title: How to make money
+   slug: how-to-make-money
+   date: 2012-09-15 19:52:05 UTC
+   ---
 
 Basic
 `````

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -51,6 +51,10 @@ try:
     import pyphen
 except ImportError:
     pyphen = None
+try:
+    import yaml
+except ImportError:
+    yaml = None
 
 from math import ceil  # for reading time feature
 
@@ -1022,6 +1026,17 @@ def _get_metadata_from_file(meta_data):
     # Skip up to one empty line at the beginning (for txt2tags)
     if not meta_data[0]:
         meta_data = meta_data[1:]
+
+    # If 1st line is '---', then it's YAML metadata
+    if meta_data[0] == '---':
+        if yaml is None:
+            utils.req_missing('pyyaml', 'use YAML metadata')
+        idx = meta_data.index('---', 1)
+        meta = yaml.load('\n'.join(meta_data[1:idx]))
+        # We expect empty metadata to be '', not None
+        for k in meta:
+            if meta[k] is None:
+                meta[k] = ''
 
     # First, get metadata from the beginning of the file,
     # up to first empty line

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1033,7 +1033,7 @@ def _get_metadata_from_file(meta_data):
             utils.req_missing('pyyaml', 'use YAML metadata', optional=True)
             raise ValueError('Error parsing metadata')
         idx = meta_data.index('---', 1)
-        meta = yaml.load('\n'.join(meta_data[1:idx]))
+        meta = yaml.safe_load('\n'.join(meta_data[1:idx]))
         # We expect empty metadata to be '', not None
         for k in meta:
             if meta[k] is None:

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1038,6 +1038,7 @@ def _get_metadata_from_file(meta_data):
         for k in meta:
             if meta[k] is None:
                 meta[k] = ''
+        return meta
 
     # First, get metadata from the beginning of the file,
     # up to first empty line

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1030,7 +1030,8 @@ def _get_metadata_from_file(meta_data):
     # If 1st line is '---', then it's YAML metadata
     if meta_data[0] == '---':
         if yaml is None:
-            utils.req_missing('pyyaml', 'use YAML metadata')
+            utils.req_missing('pyyaml', 'use YAML metadata', optional=True)
+            raise ValueError('Error parsing metadata')
         idx = meta_data.index('---', 1)
         meta = yaml.load('\n'.join(meta_data[1:idx]))
         # We expect empty metadata to be '', not None

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -13,3 +13,5 @@ ipykernel>=4.0.0
 ghp-import2>=1.0.0
 ws4py==0.4.2
 watchdog==0.8.3
+PyYAML==3.12
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ setuptools>=20.3
 natsort>=3.5.2
 requests>=2.2.0
 piexif>=1.0.3
-PyYAML==3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ setuptools>=20.3
 natsort>=3.5.2
 requests>=2.2.0
 piexif>=1.0.3
+PyYAML==3.12


### PR DESCRIPTION
First step in #2801 : Naïve support for YAML metadata.

- Optional yaml import
- Fail only if required by posts
- Parse just like our traditional metadata