### PR TITLE
Fix #2816 — use inheritance tree when looking for engine

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,7 @@ Features
 Bugfixes
 --------
 
+* Use inheritance tree when looking for theme engine (Issue #2816)
 * Fix unbound variable error in locale guessing (Issue #2806)
 
 New in v7.8.6

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -646,8 +646,8 @@ def get_template_engine(themes):
             if os.path.isfile(engine_path):
                 with open(engine_path) as fd:
                     return fd.readlines()[0].strip()
-        # default
-        return 'mako'
+    # default
+    return 'mako'
 
 
 def get_parent_theme_name(theme_name, themes_dirs=None):


### PR DESCRIPTION
This fixes #2816. cc @t-animal.

A release would be a good idea, but after #2817 and with more of #2801 done.