### PR TITLE
Implement metadata mapping

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Features
 * Support ignoring assets via ``ignore_assets`` theme meta field
   (Issue #2812)
 * Ignore unused Colorbox locales (Issue #2812)
+* Accept tag metadata as lists for YAML/TOML (Issue #2801)
 * Support for mapping metadata from other formats to Nikola names
   using the ``METADATA_MAPPING`` setting (Issue #2817)
 * Support for reStructured text docinfo metadata with

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,9 +7,11 @@ Features
 * Support ignoring assets via ``ignore_assets`` theme meta field
   (Issue #2812)
 * Ignore unused Colorbox locales (Issue #2812)
+* Support for mapping metadata from other formats to Nikola names
+  using the ``METADATA_MAPPING`` setting (Issue #2817)
 * Support for reStructured text docinfo metadata with
-  USE_REST_DOCINFO_METADATA option, defaulting to False (Issue #1923)
-* New HIDE_REST_DOCINFO option, defaulting to False.
+  ``USE_REST_DOCINFO_METADATA`` option, defaulting to False (Issue #1923)
+* New ``HIDE_REST_DOCINFO`` option, defaulting to False.
 * Support for Markdown Metadata for Pelican compatibility by adding
   ``'markdown.extensions.meta'`` to ``MARKDOWN_EXTENSIONS`` (Issue #1923)
 * Support for YAML and TOML metadata (Issue #2801)

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -278,63 +278,7 @@ Metadata fields
 ~~~~~~~~~~~~~~~
 
 Nikola supports many metadata fields in posts. All of them are
-translatable and almost all are optional. Metadata can be in different formats.
-
-The "traditional" meta field format is:
-
-.. code:: text
-
-   .. name: value
-
-You can add your own metadata fields in the same manner. If you are not using
-reStructuredText, make sure the fields are in a HTML comment in output.
-
-Current Nikola versions experimentally supports other metadata formats that make it more compatiblw with
-other static site generators.
-
-YAML metadata should be wrapped by a "---" separator and in that case, the usual YAML syntax is used:
-
-.. code:: yaml
-
-   ---
-   title: How to make money
-   slug: how-to-make-money
-   date: 2012-09-15 19:52:05 UTC
-   ---
-
-TOML metadata should be wrapped by a "+++" separator and in that case, the usual TOML syntax is used:
-
-.. code:: yaml
-
-   +++
-   title = "How to make money"
-   slug =  "how-to-make-money"
-   date = "2012-09-15 19:52:05 UTC"
-   +++
-
-Markdown Metadata only works in markdown files, and requires the ``markdown.extensions.meta`` extension 
-(see `MARKDOWN_EXTENSIONS <#markdown>`__). The exact format is described in 
-the `markdown metadata extension docs <https://pythonhosted.org/Markdown/extensions/meta_data.html>`__
-
-.. code::
-
-   title: How to make money
-   slug: how-to-make-money
-   date: 2012-09-15 19:52:05 UTC
-
-Nikola can extract metadata from reStructured Text docinfo fields and the document itself, too:
-
-.. code::
-
-    How to make money
-    =================
-
-    :slug: how-to-make-money
-    :date: 2012-09-15 19:52:05 UTC
-
-To do this, you need  ``USE_REST_DOCINFO_METADATA = True`` in your ``conf.py``, 
-and Nikola will hide the docinfo fields in the output if you set 
-``HIDE_REST_DOCINFO = True``.
+translatable and almost all are optional.
 
 Basic
 `````
@@ -460,31 +404,155 @@ to your configuration:
     }
 
 
-.. note:: The Two-File Format
+Metadata formats
+~~~~~~~~~~~~~~~~
 
-   Nikola originally used a separate ``.meta`` file. That will still work!
-   The format of the meta files is the same as shown above (i.e. only
-   the 7 base fields, in the order listed above), but without the
-   explanations:
+Metadata can be in different formats.
+Current Nikola versions experimentally supports other metadata formats that make it more compatible with
+other static site generators. The currently supported metadata formats are:
 
-    .. code:: text
+* reST-style comments (``.. name: value`` — default format)
+* Two-file format (reST-style comments or 7-line)
+* Jupyter Notebook metadata
+* YAML, between ``---`` (Jekyll, Hugo)
+* TOML, between ``+++`` (Hugo)
+* reST docinfo (Pelican)
+* Markdown metadata extension (Pelican)
 
-        How to make money
-        how-to-make-money
-        2012-09-15 19:52:05 UTC
+You can add arbitrary meta fields in any format.
 
-   However, starting with Nikola v7, you can now use ``.meta`` files and put
-   all metadata you want, complete with the explanations — they look just like
-   the beginning of our reST files.
+reST-style comments
+```````````````````
 
-      .. code:: restructuredtext
+The “traditional” and default meta field format is:
 
-         .. title: How to make money
-         .. slug: how-to-make-money
-         .. date: 2012-09-15 19:52:05 UTC
+.. code:: text
 
-   Both file formats are supported; however, the new format is preferred, if
-   possible.
+   .. name: value
+
+If you are not using reStructuredText, make sure the fields are in a HTML comment in output.
+
+Two-file format
+```````````````
+
+Meta information can also be specified in separate ``.meta`` files. Those support reST-style metadata, with names and custom fields. They look like the beginning of our reST files:
+
+.. code:: text
+
+    .. title: How to make money
+    .. slug: how-to-make-money
+    .. date: 2012-09-15 19:52:05 UTC
+
+There is also an older version of the format. It uses the 7 base fields, in order, without names and custom meta:
+
+.. code:: text
+
+    How to make money
+    how-to-make-money
+    2012-09-15 19:52:05 UTC
+
+The support for this older format is kept only for backwards compatibility and will be removed in a future version. You can use `a converter plugin <https://plugins.getnikola.com/v7/upgrade_metadata/>`_ if you’re still using that format.
+
+Jupyter Notebook metadata
+`````````````````````````
+
+Jupyter posts can store meta information inside ``.ipynb`` files by using the ``nikola`` key inside notebook metadata. It can be edited by using *Edit → Edit Notebook Metadata* in Jupyter. Note that values are currently only strings. Sample metadata (Jupyter-specific information omitted):
+
+.. code:: json
+
+    {
+        "nikola": {
+            "title": "How to make money",
+            "slug": "how-to-make-money",
+            "date": "2012-09-15 19:52:05 UTC"
+        }
+    }
+
+
+YAML metadata
+`````````````
+
+YAML metadata should be wrapped by a ``---`` separator (three dashes) and in that case, the usual YAML syntax is used:
+
+.. code:: yaml
+
+   ---
+   title: How to make money
+   slug: how-to-make-money
+   date: 2012-09-15 19:52:05 UTC
+   ---
+
+TOML metadata
+`````````````
+
+TOML metadata should be wrapped by a "+++" separator (three plus signs) and in that case, the usual TOML syntax is used:
+
+.. code:: yaml
+
+   +++
+   title = "How to make money"
+   slug =  "how-to-make-money"
+   date = "2012-09-15 19:52:05 UTC"
+   +++
+
+reST docinfo
+````````````
+
+Nikola can extract metadata from reStructuredText docinfo fields and the document itself, too:
+
+.. code:: restructuredtext
+
+    How to make money
+    =================
+
+    :slug: how-to-make-money
+    :date: 2012-09-15 19:52:05 UTC
+
+To do this, you need  ``USE_REST_DOCINFO_METADATA = True`` in your ``conf.py``,
+and Nikola will hide the docinfo fields in the output if you set
+``HIDE_REST_DOCINFO = True``.
+
+Note that keys are converted to lowercase automatically.
+
+Markdown metadata
+`````````````````
+
+Markdown Metadata only works in Markdown files, and requires the ``markdown.extensions.meta`` extension
+(see `MARKDOWN_EXTENSIONS <#markdown>`__). The exact format is described in
+the `markdown metadata extension docs <https://pythonhosted.org/Markdown/extensions/meta_data.html>`__
+
+.. code:: text
+
+   title: How to make money
+   slug: how-to-make-money
+   date: 2012-09-15 19:52:05 UTC
+
+Note that keys are converted to lowercase automatically.
+
+Mapping metadata from other formats
+```````````````````````````````````
+
+If you import posts from other engines, those may not work with Nikola out of the box due to differing names. However, you can create a mapping to convert meta field names from those formats into what Nikola expects.
+
+For Pelican, use:
+
+.. code:: python
+
+    METADATA_MAPPING = {
+        "rest_docinfo": {"summary": "description", "modified": "updated"},
+        "markdown_metadata": {"summary": "description", "modified": "updated"}
+    }
+
+For Hugo, use:
+
+.. code:: python
+
+    METADATA_MAPPING = {
+        "yaml": {"lastmod": "updated"},
+        "toml": {"lastmod": "updated"}
+    }
+
+The following source names are supported: ``yaml``, ``toml``, ``rest_docinfo``, ``markdown_metadata``.
 
 Multilingual posts
 ~~~~~~~~~~~~~~~~~~

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1135,11 +1135,22 @@ MARKDOWN_EXTENSIONS = ['markdown.extensions.fenced_code', 'markdown.extensions.c
 # (Note the '.*\/' in the beginning -- matches source paths relative to conf.py)
 # FILE_METADATA_REGEXP = None
 
-# If enabled, extract metadata from docinfo fields in reSt documents
+# If enabled, extract metadata from docinfo fields in reST documents
 # USE_REST_DOCINFO_METADATA = False
 
-# If enabled, hide docinfo fields in reSt document output
+# If enabled, hide docinfo fields in reST document output
 # HIDE_REST_DOCINFO = False
+
+# Map metadata from other formats to Nikola names.
+# Supported formats: ${_METADATA_MAPPING_FORMATS}
+# METADATA_MAPPING = {}
+#
+# Example for Pelican compatibility:
+# METADATA_MAPPING = {
+#     "rest_docinfo": {"summary": "description", "modified": "updated"},
+#     "markdown_metadata": {"summary": "description", "modified": "updated"}
+# }
+# Other examples: https://getnikola.com/handbook.html#mapping-metadata-from-other-formats
 
 # If you hate "Filenames with Capital Letters and Spaces.md", you should
 # set this to true.

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -355,7 +355,8 @@ LEGAL_VALUES = {
         'sv': 'sv',
         'zh_cn': 'zh_cn',
         'zh_tw': 'zh_tw'
-    }
+    },
+    "METADATA_MAPPING": ["yaml", "toml", "rest_docinfo", "markdown_metadata"],
 }
 
 # Mapping old pre-taxonomy plugin names to new post-taxonomy plugin names
@@ -544,6 +545,7 @@ class Nikola(object):
             'MARKDOWN_EXTENSIONS': ['fenced_code', 'codehilite'],  # FIXME: Add 'extras' in v8
             'MAX_IMAGE_SIZE': 1280,
             'MATHJAX_CONFIG': '',
+            'METADATA_MAPPING': {},
             'NEW_POST_DATE_PATH': False,
             'NEW_POST_DATE_PATH_FORMAT': '%Y/%m/%d',
             'OLD_THEME_SUPPORT': True,

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -108,6 +108,7 @@ SAMPLE_CONF = {
     ),
 }""",
     'REDIRECTIONS': [],
+    '_METADATA_MAPPING_FORMATS': ', '.join(LEGAL_VALUES['METADATA_MAPPING'])
 }
 
 
@@ -212,7 +213,7 @@ def prepare_config(config):
     """Parse sample config with JSON."""
     p = config.copy()
     p.update({k: json.dumps(v, ensure_ascii=False) for k, v in p.items()
-             if k not in ('POSTS', 'PAGES', 'COMPILERS', 'TRANSLATIONS', 'NAVIGATION_LINKS', '_SUPPORTED_LANGUAGES', '_SUPPORTED_COMMENT_SYSTEMS', 'INDEX_READ_MORE_LINK', 'FEED_READ_MORE_LINK')})
+             if k not in ('POSTS', 'PAGES', 'COMPILERS', 'TRANSLATIONS', 'NAVIGATION_LINKS', '_SUPPORTED_LANGUAGES', '_SUPPORTED_COMMENT_SYSTEMS', 'INDEX_READ_MORE_LINK', 'FEED_READ_MORE_LINK', '_METADATA_MAPPING_FORMATS')})
     # READ_MORE_LINKs require some special treatment.
     p['INDEX_READ_MORE_LINK'] = "'" + p['INDEX_READ_MORE_LINK'].replace("'", "\\'") + "'"
     p['FEED_READ_MORE_LINK'] = "'" + p['FEED_READ_MORE_LINK'].replace("'", "\\'") + "'"

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -42,7 +42,7 @@ except ImportError:
 
 from nikola import shortcodes as sc
 from nikola.plugin_categories import PageCompiler
-from nikola.utils import makedirs, req_missing, write_metadata, LocaleBorg
+from nikola.utils import makedirs, req_missing, write_metadata, LocaleBorg, map_metadata
 
 
 class ThreadLocalMarkdown(threading.local):
@@ -152,5 +152,8 @@ class CompileMarkdown(PageCompiler):
             lang = LocaleBorg().current_lang
         source = post.translated_source_path(lang)
         with io.open(source, 'r', encoding='utf-8') as inf:
+            # Note: markdown meta returns lowercase keys
             _, meta = self.converter.convert(inf.read())
+        # Map metadata from other platforms to names Nikola expects (Issue #2817)
+        map_metadata(meta, 'markdown_metadata', self.site.config)
         return meta

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -91,6 +91,10 @@ class CompileRest(PageCompiler):
 
                 meta[name] = value
 
+        # Put 'authors' meta field contents in 'author', too
+        if 'authors' in meta and 'author' not in meta:
+            meta['author'] = '; '.join(meta['authors'])
+
         # Map metadata from other platforms to names Nikola expects (Issue #2817)
         map_metadata(meta, 'rest_docinfo', self.site.config)
         return meta

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -48,7 +48,8 @@ from nikola.utils import (
     makedirs,
     write_metadata,
     STDERR_HANDLER,
-    LocaleBorg
+    LocaleBorg,
+    map_metadata
 )
 
 
@@ -89,6 +90,9 @@ class CompileRest(PageCompiler):
                 name = name.lower()
 
                 meta[name] = value
+
+        # Map metadata from other platforms to names Nikola expects (Issue #2817)
+        map_metadata(meta, 'rest_docinfo', self.site.config)
         return meta
 
     def compile_string(self, data, source_path=None, is_two_file=True, post=None, lang=None):

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -239,8 +239,12 @@ class Post(object):
         is_private = False
         self._tags = {}
         for lang in self.translated_to:
+            if isinstance(self.meta[lang]['tags'], (list, tuple, set)):
+                _tag_list = self.meta[lang]['tags']
+            else:
+                _tag_list = self.meta[lang]['tags'].split(',')
             self._tags[lang] = natsort.natsorted(
-                list(set([x.strip() for x in self.meta[lang]['tags'].split(',')])),
+                list(set([x.strip() for x in _tag_list])),
                 alg=natsort.ns.F | natsort.ns.IC)
             self._tags[lang] = [t for t in self._tags[lang] if t]
             if 'draft' in [_.lower() for _ in self._tags[lang]]:

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -75,6 +75,7 @@ from .utils import (
     demote_headers,
     get_translation_candidate,
     unslugify,
+    map_metadata
 )
 
 __all__ = ('Post',)
@@ -1026,6 +1027,8 @@ def _get_metadata_from_file(meta_data):
         for k in meta:
             if meta[k] is None:
                 meta[k] = ''
+        # Map metadata from other platforms to names Nikola expects (Issue #2817)
+        map_metadata(meta, 'yaml', self.config)
         return meta
 
     # If 1st line is '+++', then it's TOML metadata
@@ -1035,6 +1038,8 @@ def _get_metadata_from_file(meta_data):
             raise ValueError('Error parsing metadata')
         idx = meta_data.index('+++', 1)
         meta = toml.load('\n'.join(meta_data[1:idx]))
+        # Map metadata from other platforms to names Nikola expects (Issue #2817)
+        map_metadata(meta, 'toml', self.config)
         return meta
 
     # First, get metadata from the beginning of the file,

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -990,7 +990,7 @@ def get_metadata_from_file(source_path, config=None, lang=None):
             source_path += '.' + lang
         with io.open(source_path, "r", encoding="utf-8-sig") as meta_file:
             meta_data = [x.strip() for x in meta_file.readlines()]
-        return _get_metadata_from_file(meta_data)
+        return _get_metadata_from_file(meta_data, config)
     except (UnicodeDecodeError, UnicodeEncodeError):
         msg = 'Error reading {0}: Nikola only supports UTF-8 files'.format(source_path)
         LOGGER.error(msg)
@@ -1006,7 +1006,7 @@ re_rst_title = re.compile(r'^([{0}]{{4,}})'.format(re.escape(
     string.punctuation)))
 
 
-def _get_metadata_from_file(meta_data):
+def _get_metadata_from_file(meta_data, config=None):
     """Extract metadata from a post's source file."""
     meta = {}
     if not meta_data:
@@ -1028,7 +1028,7 @@ def _get_metadata_from_file(meta_data):
             if meta[k] is None:
                 meta[k] = ''
         # Map metadata from other platforms to names Nikola expects (Issue #2817)
-        map_metadata(meta, 'yaml', self.config)
+        map_metadata(meta, 'yaml', config)
         return meta
 
     # If 1st line is '+++', then it's TOML metadata
@@ -1039,7 +1039,7 @@ def _get_metadata_from_file(meta_data):
         idx = meta_data.index('+++', 1)
         meta = toml.load('\n'.join(meta_data[1:idx]))
         # Map metadata from other platforms to names Nikola expects (Issue #2817)
-        map_metadata(meta, 'toml', self.config)
+        map_metadata(meta, 'toml', config)
         return meta
 
     # First, get metadata from the beginning of the file,

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -2103,7 +2103,8 @@ def rss_writer(rss_obj, output_path):
 def map_metadata(meta, key, config):
     """Map metadata from other platforms to Nikola names.
 
-    This uses the METADATA_MAPPING setting (via ``config``) and modifies the dict in place."""
+    This uses the METADATA_MAPPING setting (via ``config``) and modifies the dict in place.
+    """
     for foreign, ours in config['METADATA_MAPPING'].get(key, {}).items():
         if foreign in meta:
             meta[ours] = meta[foreign]

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -98,7 +98,8 @@ __all__ = ('CustomEncoder', 'get_theme_path', 'get_theme_path_real',
            'clone_treenode', 'flatten_tree_structure',
            'parse_escaped_hierarchical_category_name',
            'join_hierarchical_category_path', 'clean_before_deployment',
-           'sort_posts', 'indent', 'load_data', 'html_unescape', 'rss_writer',)
+           'sort_posts', 'indent', 'load_data', 'html_unescape', 'rss_writer',
+           'map_metadata',)
 
 # Are you looking for 'generic_rss_renderer'?
 # It's defined in nikola.nikola.Nikola (the site object).
@@ -2097,3 +2098,12 @@ def rss_writer(rss_obj, output_path):
         if isinstance(data, bytes_str):
             data = data.decode('utf-8')
         rss_file.write(data)
+
+
+def map_metadata(meta, key, config):
+    """Map metadata from other platforms to Nikola names.
+
+    This uses the METADATA_MAPPING setting (via ``config``) and modifies the dict in place."""
+    for foreign, ours in config['METADATA_MAPPING'].get(key, {}).items():
+        if foreign in meta:
+            meta[ours] = meta[foreign]


### PR DESCRIPTION
* Support for mapping metadata from other formats to Nikola names using the `METADATA_MAPPING` setting (Issue #2817)
* Accept tag metadata as lists for YAML/TOML (Issue #2801)
* reST docinfo: put 'authors' info in 'author' as well (kinda ugly with multiple authors, but Nikola doesn’t have any specific support for those (yet))