### PR TITLE
Enable md by default

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Enable markdown by default (part of Issue #2809)
 * Allowing to register filters from plugins, and allowing to specify default
   filters as strings of the form ``filters.<name>`` (part of Issue #2475)
 * Support ignoring assets via ``ignore_assets`` theme meta field

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -74,11 +74,13 @@ SAMPLE_CONF = {
     'FEED_READ_MORE_LINK': DEFAULT_FEED_READ_MORE_LINK,
     'POSTS': """(
     ("posts/*.rst", "posts", "post.tmpl"),
+    ("posts/*.md", "posts", "post.tmpl"),
     ("posts/*.txt", "posts", "post.tmpl"),
     ("posts/*.html", "posts", "post.tmpl"),
 )""",
     'PAGES': """(
     ("pages/*.rst", "pages", "page.tmpl"),
+    ("pages/*.md", "pages", "page.tmpl"),
     ("pages/*.txt", "pages", "page.tmpl"),
     ("pages/*.html", "pages", "page.tmpl"),
 )""",

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,5 +1,4 @@
 -r requirements.txt
-Markdown>=2.4.0
 Jinja2>=2.7.2
 husl>=4.0.2
 pyphen>=0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Pillow>=2.4.0
 python-dateutil>=2.4.0
 docutils>=0.12
 mako>=1.0.0
+Markdown>=2.4.0
 unidecode>=0.04.16
 lxml>=3.3.5
 Yapsy>=1.11.223


### PR DESCRIPTION
Enables markdown in posts/pages (*.md) and makes Markdown not optional (it's pretty small anyway)