### PR TITLE
Support blank lines in YAML/TOML metadata (part of issue #2801)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Features
 Bugfixes
 --------
 
+* Support empty lines in YAML/TOML metadata (Part of issue #2801)
 * Tests run on macOS.
 
 New in v7.8.7

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -338,7 +338,12 @@ class PageCompiler(BasePlugin):
         This splits in the first empty line that is NOT at the beginning
         of the document.
         """
-        split_result = re.split('(\n\n|\r\n\r\n)', data.lstrip(), maxsplit=1)
+        if data.startswith('---'):  # YAML metadata
+            split_result = re.split('(---\n\n|----\r\n\r\n)', data.lstrip(), maxsplit=1)
+        elif data.startswith('+++'):  # TOML metadata
+            split_result = re.split('(+++\n\n|+++\r\n\r\n)', data.lstrip(), maxsplit=1)
+        else:
+            split_result = re.split('(\n\n|\r\n\r\n)', data.lstrip(), maxsplit=1)
         if len(split_result) == 1:
             return '', split_result[0]
         # ['metadata', '\n\n', 'post content']

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -339,9 +339,9 @@ class PageCompiler(BasePlugin):
         of the document.
         """
         if data.startswith('---'):  # YAML metadata
-            split_result = re.split('(---\n\n|----\r\n\r\n)', data.lstrip(), maxsplit=1)
+            split_result = re.split('(\n---\n\n|\r\n---\r\n\r\n)', data.lstrip(), maxsplit=1)
         elif data.startswith('+++'):  # TOML metadata
-            split_result = re.split('(+++\n\n|+++\r\n\r\n)', data.lstrip(), maxsplit=1)
+            split_result = re.split('(\n+++\n\n|\r\n+++\r\n\r\n)', data.lstrip(), maxsplit=1)
         else:
             split_result = re.split('(\n\n|\r\n\r\n)', data.lstrip(), maxsplit=1)
         if len(split_result) == 1:


### PR DESCRIPTION
Split on the right markers for YAML/TOML metadata.