### PR TITLE
Fix two grave and one interop bug in TOML/YAML meta handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Features
 Bugfixes
 --------
 
+* Fix two grave bugs in TOML metadata
+* Require just one line break after TOML/YAML metadata
 * Add alt attribute to images in galleries in base theme (Part of issue #2777)
 * Support empty lines in YAML/TOML metadata (Part of issue #2801)
 * Tests run on macOS.

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -336,7 +336,7 @@ class PageCompiler(BasePlugin):
         """Split data from metadata in the raw post content.
 
         This splits in the first empty line that is NOT at the beginning
-        of the document.
+        of the document, or after YAML/TOML metadata without an empty line.
         """
         if data.startswith('---'):  # YAML metadata
             split_result = re.split('(\n---\n|\r\n---\r\n)', data.lstrip(), maxsplit=1)

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -339,9 +339,9 @@ class PageCompiler(BasePlugin):
         of the document.
         """
         if data.startswith('---'):  # YAML metadata
-            split_result = re.split('(\n---\n\n|\r\n---\r\n\r\n)', data.lstrip(), maxsplit=1)
+            split_result = re.split('(\n---\n|\r\n---\r\n)', data.lstrip(), maxsplit=1)
         elif data.startswith('+++'):  # TOML metadata
-            split_result = re.split('(\n+++\n\n|\r\n+++\r\n\r\n)', data.lstrip(), maxsplit=1)
+            split_result = re.split('(\n\\+\\+\\+\n|\r\n\\+\\+\\+\r\n)', data.lstrip(), maxsplit=1)
         else:
             split_result = re.split('(\n\n|\r\n\r\n)', data.lstrip(), maxsplit=1)
         if len(split_result) == 1:

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1041,7 +1041,7 @@ def _get_metadata_from_file(meta_data, config=None):
             utils.req_missing('toml', 'use TOML metadata', optional=True)
             raise ValueError('Error parsing metadata')
         idx = meta_data.index('+++', 1)
-        meta = toml.load('\n'.join(meta_data[1:idx]))
+        meta = toml.loads('\n'.join(meta_data[1:idx]))
         # Map metadata from other platforms to names Nikola expects (Issue #2817)
         map_metadata(meta, 'toml', config)
         return meta


### PR DESCRIPTION
1. toml.load wants a file handle, toml.loads wants a string
2. `+` has special meaning in regular expressions
3. Require one linebreak after TOML/YAML (as Jekyll does)

Releasing v7.8.8 after this merges.