### PR TITLE
Correctly handle meta tags with no name while extracting metadata

### DIFF
--- a/nikola/plugins/compile/html.py
+++ b/nikola/plugins/compile/html.py
@@ -103,7 +103,7 @@ class CompileHtml(PageCompiler):
             metadata['title'] = title_tag.text
         meta_tags = doc.findall('*//meta')
         for tag in meta_tags:
-            k = tag.get('name').lower()
+            k = tag.get('name', '').lower()
             if not k:
                 continue
             elif k == 'keywords':


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [ ] I tested my changes.

### Description

`meta` tags with no `name` attribute cause the metadata extraction to crash - for instance `<meta charset='utf-8'>`
