### PR TITLE
Taxonomy language link left-overs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,8 +5,6 @@ Features
 --------
 
 * Use ``PRETTY_URLS`` by default on all sites (Issue #1838)
-* `also_create_classifications_from_other_languages` is deprecated
-  and no longer used by standard taxonomies (Issue #2785)
 * Feed link generation is completely refactored (PR #2844)
 
 
@@ -25,6 +23,9 @@ Removed features
 * Drop insecure post encryption feature
 * Stop supporting all deprecated config options
 * Drop annotations support (annotateit.org closed down in March 2017)
+* `also_create_classifications_from_other_languages` was removed
+  (Issue #2785)
+
 
 New in v7.8.8
 =============

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,11 +5,17 @@ Features
 --------
 
 * Use ``PRETTY_URLS`` by default on all sites (Issue #1838)
+* `also_create_classifications_from_other_languages` is deprecated
+  and no longer used by standard taxonomies (Issue #2785)
+* Feed link generation is completely refactored (PR #2844)
+
 
 Bugfixes
 --------
 * Use Jupyter name more consistently in docs
 * Support CODE_COLOR_SCHEME in Jupyter notebooks (Issue #2093)
+* Language was not passed to title and link generation for page
+  indexes.
 
 
 Removed features

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,16 +5,13 @@ Features
 --------
 
 * Use ``PRETTY_URLS`` by default on all sites (Issue #1838)
-* Feed link generation is completely refactored (PR #2844)
-
+* Feed link generation is completely refactored (Issue #2844)
 
 Bugfixes
 --------
 * Use Jupyter name more consistently in docs
 * Support CODE_COLOR_SCHEME in Jupyter notebooks (Issue #2093)
-* Language was not passed to title and link generation for page
-  indexes.
-
+* Language was not passed to title and link generation for page indexes
 
 Removed features
 ----------------
@@ -23,9 +20,8 @@ Removed features
 * Drop insecure post encryption feature
 * Stop supporting all deprecated config options
 * Drop annotations support (annotateit.org closed down in March 2017)
-* `also_create_classifications_from_other_languages` was removed
+* Remove taxonomy option ``also_create_classifications_from_other_languages``
   (Issue #2785)
-
 
 New in v7.8.8
 =============

--- a/nikola/data/themes/base-jinja/templates/archiveindex.tmpl
+++ b/nikola/data/themes/base-jinja/templates/archiveindex.tmpl
@@ -5,10 +5,16 @@
 
 {% block extra_head %}
     {{ super() }}
-    {{ feeds_translations.head(archive_name) }}
+    {{ feeds_translations.head(archive_name, kind, rss_override=False) }}
 {% endblock %}
 
 {% block content_header %}
-    {{ archive_nav.archive_navigation() }}
-    {{ parent.content_header() }}
+    <header>
+        <h1>{{ title|e }}</h1>
+        {{ archive_nav.archive_navigation() }}
+        <div class="metadata">
+            {{ feeds_translations.feed_link(archive, kind) }}
+            {{ feeds_translations.translation_link(kind) }}
+        </div>
+    </header>
 {% endblock %}

--- a/nikola/data/themes/base-jinja/templates/author.tmpl
+++ b/nikola/data/themes/base-jinja/templates/author.tmpl
@@ -3,10 +3,8 @@
 {% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
 
 {% block extra_head %}
-    {{ super() }}
-    {{ feeds_translations.head(author) }}
+    {{ feeds_translations.head(author, kind, rss_override=False) }}
 {% endblock %}
-
 
 {% block content %}
 <article class="authorpage">
@@ -16,7 +14,7 @@
             <p>{{ description }}</p>
         {% endif %}
         <div class="metadata">
-            {{ feeds_translations.feed_link(author) }}
+            {{ feeds_translations.feed_link(author, kind) }}
         </div>
     </header>
     {% if posts %}

--- a/nikola/data/themes/base-jinja/templates/authorindex.tmpl
+++ b/nikola/data/themes/base-jinja/templates/authorindex.tmpl
@@ -2,7 +2,20 @@
 {% extends 'index.tmpl' %}
 {% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
 
+{% block content_header %}
+    <header>
+        <h1>{{ title|e }}</h1>
+        {% if description %}
+        <p>{{ description }}</p>
+        {% endif %}
+        <div class="metadata">
+            {{ feeds_translations.feed_link(author, kind) }}
+            {{ feeds_translations.translation_link(kind) }}
+        </div>
+    </header>
+{% endblock %}
+
 {% block extra_head %}
     {{ super() }}
-    {{ feeds_translations.head(author) }}
+    {{ feeds_translations.head(author, kind, rss_override=False) }}
 {% endblock %}

--- a/nikola/data/themes/base-jinja/templates/authors.tmpl
+++ b/nikola/data/themes/base-jinja/templates/authors.tmpl
@@ -1,10 +1,18 @@
 {#  -*- coding: utf-8 -*- #}
 {% extends 'base.tmpl' %}
+{% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
+
+{% block extra_head %}
+    {{ feeds_translations.head(kind=kind, feeds=False) }}
+{% endblock %}
 
 {% block content %}
 <article class="authorindex">
     {% if items %}
         <h2>{{ messages("Authors") }}</h2>
+        <div class="metadata">
+            {{ feeds_translations.translation_link(kind) }}
+        </div>
         <ul class="postlist">
         {% for text, link in items %}
             {% if text not in hidden_authors %}

--- a/nikola/data/themes/base-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_helper.tmpl
@@ -42,7 +42,7 @@ lang="{{ lang }}">
     {% if meta_generator_tag %}
         <meta name="generator" content="Nikola (getnikola.com)">
     {% endif %}
-    {{ feeds_translations.head(classification=None, kind=kind, other=False) }}
+    {{ feeds_translations.head(classification=None, kind='index', other=False) }}
     <link rel="canonical" href="{{ abs_link(permalink) }}">
 
     {% if favicons %}
@@ -101,7 +101,7 @@ lang="{{ lang }}">
 
 {#  This function is deprecated; use feed_helper directly. #}
 {% macro html_feedlinks() %}
-    {{ feeds_translations.head(classification=None, kind=kind, other=False) }}
+    {{ feeds_translations.head(classification=None, kind='index', other=False) }}
 {% endmacro %}
 
 {% macro html_translations() %}

--- a/nikola/data/themes/base-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_helper.tmpl
@@ -42,7 +42,7 @@ lang="{{ lang }}">
     {% if meta_generator_tag %}
         <meta name="generator" content="Nikola (getnikola.com)">
     {% endif %}
-    {{ feeds_translations.head() }}
+    {{ feeds_translations.head(classification=None, kind=kind, other=False) }}
     <link rel="canonical" href="{{ abs_link(permalink) }}">
 
     {% if favicons %}
@@ -101,7 +101,7 @@ lang="{{ lang }}">
 
 {#  This function is deprecated; use feed_helper directly. #}
 {% macro html_feedlinks() %}
-    {{ feeds_translations.head() }}
+    {{ feeds_translations.head(classification=None, kind=kind, other=False) }}
 {% endmacro %}
 
 {% macro html_translations() %}

--- a/nikola/data/themes/base-jinja/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/feeds_translations_helper.tmpl
@@ -5,6 +5,18 @@
 {% macro _append_name_language_proper(language, kind, name) %}{{  (" (" + name + ", " + language + ")" if name and kind != "archive" and kind != "author" else " (" + language + ")") | h  }}{% endmacro %}
 {% macro _append_name_language(language, kind, name=None) %}{{  _append_name_language_proper(language, kind, name) if translations|length > 1 else _append_name(name, kind)  }}{% endmacro %}
 
+{% macro _head_feed_link(link_type, link_name, link_postfix, classification, kind, language) %}
+    <link rel="alternate" type="{{ link_type }}" title="{{ link_name|e }}{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link(kind + '_' + link_postfix, classification, language) }}">
+{% endmacro %}
+
+{% macro _html_feed_link(link_type, link_name, link_postfix, classification, kind, language, name=None) %}
+    <a href="{{ _link(kind + '_' + link_postfix, classification, language) }}" hreflang="{{ language }}" type="{{ link_type }}">{{ messages(link_name, language) }} {{ _append_name_language(language, kind, name) }}</a>
+{% endmacro %}
+
+{% macro _html_translation_link(classification, kind, language, name=None) %}
+    <a href="{{ _link(kind, classification, language) }}" hreflang="{{ language }}" rel="alternate">{{ messages("LANGUAGE", language) }}{{ _append_name(name, kind) }}</a>
+{% endmacro %}
+
 {% macro _head_rss(classification=None, kind='index', rss_override=True) %}
     {% if rss_link and rss_override %}
         {{ rss_link }}
@@ -17,9 +29,9 @@
         {% else %}
             {% for language in translations|sort %}
                 {% if classification and kind != 'index' %}
-                    <link rel="alternate" type="application/rss+xml" title="RSS for {{ kind }} {{ classification|e }}{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link(kind + "_rss", classification, language) }}">
+                    {{ _head_feed_link('application/rss+xml', 'RSS for ' + kind + ' ' + classification, 'rss', classification, kind, language) }}
                 {% else %}
-                    <link rel="alternate" type="application/rss+xml" title="RSS{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link("index_rss", None, language) }}">
+                    {{ _head_feed_link('application/rss+xml', 'RSS', 'rss', classification, 'index', language) }}
                 {% endif %}
             {% endfor %}
         {% endif %}
@@ -35,9 +47,9 @@
         {% else %}
             {% for language in translations|sort %}
                 {% if classification and kind != 'index' %}
-                    <link rel="alternate" type="application/atom+xml" title="Atom for {{ kind }} {{ classification|e }}{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link(kind + "_atom", classification, language) }}">
+                    {{ _head_feed_link('application/atom+xml', 'Atom for ' + kind + ' ' + classification, 'atom', classification, kind, language) }}
                 {% else %}
-                    <link rel="alternate" type="application/atom+xml" title="Atom{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link("index_atom", None, language) }}">
+                    {{ _head_feed_link('application/atom+xml', 'Atom', 'atom', classification, 'index', language) }}
                 {% endif %}
             {% endfor %}
         {% endif %}
@@ -63,10 +75,10 @@
             {% for language, classification, name in all_languages %}
                 <p class="feedlink">
                     {% if generate_atom %}
-                        <a href="{{ _link(kind + "_atom", classification, language) }}" hreflang="{{ language }}" type="application/atom+xml">{{ messages('Atom feed', language) }} {{ _append_name_language(language, kind, name) }}</a>
+                        {{ _html_feed_link('application/atom+xml', 'Atom feed', 'atom', classification, kind, language, name) }}
                     {% endif %}
                     {% if generate_rss and kind != 'archive' %}
-                        <a href="{{ _link(kind + "_rss", classification, language) }}" hreflang="{{ language }}" type="application/rss+xml">{{ messages('RSS feed', language) }} {{ _append_name_language(language, kind, name) }}</a>
+                        {{ _html_feed_link('application/rss+xml', 'RSS feed', 'rss', classification, kind, language, name) }}
                     {% endif %}
                 </p>
             {% endfor %}
@@ -74,10 +86,10 @@
             {% for language in translations|sort %}
                 <p class="feedlink">
                     {% if generate_atom %}
-                        <a href="{{ _link(kind + "_atom", classification, language) }}" hreflang="{{ language }}" type="application/atom+xml">{{ messages('Atom feed', language) }}{{ _append_language(language) }}</a>
+                        {{ _html_feed_link('application/atom+xml', 'Atom feed', 'atom', classification, kind, language) }}
                     {% endif %}
                     {% if generate_rss and kind != 'archive' %}
-                        <a href="{{ _link(kind + "_rss", classification, language) }}" hreflang="{{ language }}" type="application/rss+xml">{{ messages('RSS feed', language) }}{{ _append_language(language) }}</a>
+                        {{ _html_feed_link('application/rss+xml', 'RSS feed', 'rss', classification, kind, language) }}
                     {% endif %}
                 </p>
             {% endfor %}
@@ -90,7 +102,7 @@
         <div class="translationslist translations">
             <h3 class="translationslist-intro">{{ messages("Also available in:") }}</h3>
         {% for language, classification, name in other_languages %}
-            <p><a href="{{ _link(kind, classification, language) }}" hreflang="{{ language }}" rel="alternate">{{ messages("LANGUAGE", language) }} {{ _append_name(name, kind) }}</a></p>
+            <p>{{ _html_translation_link(classification, kind, language, name) }}</p>
         {% endfor %}
         </div>
     {% endif %}

--- a/nikola/data/themes/base-jinja/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/feeds_translations_helper.tmpl
@@ -1,90 +1,96 @@
 {#  -*- coding: utf-8 -*- #}
 
-{#  Handles both feeds and translations #}
-{% macro head(classification=None) %}
-    {% if rss_link %}
+{% macro _append_language(language) %}{{  " (" + language + ")" if translations|length > 1 else ""  }}{% endmacro %}
+{% macro _append_name(name, kind) %}{{  (" (" + name + ")" if name and kind != "archive" and kind != "author" else "") | h  }}{% endmacro %}
+{% macro _append_name_language_proper(language, kind, name) %}{{  (" (" + name + ", " + language + ")" if name and kind != "archive" and kind != "author" else " (" + language + ")") | h  }}{% endmacro %}
+{% macro _append_name_language(language, kind, name=None) %}{{  _append_name_language_proper(language, kind, name) if translations|length > 1 else _append_name(name, kind)  }}{% endmacro %}
+
+{% macro _head_rss(classification=None, kind='index', rss_override=True) %}
+    {% if rss_link and rss_override %}
         {{ rss_link }}
     {% endif %}
-    {% if translations|length > 1 %}
-        {% for language in translations|sort %}
-            {% if classification %}
-                {% if generate_atom %}
-                    <link rel="alternate" type="application/atom+xml" title="Atom for {{ kind }} {{ classification|e }} ({{ language }})" href="{{ _link(kind + "_atom", classification, language) }}">
-                {% endif %}
-                {% if generate_rss and not rss_link %}
-                    <link rel="alternate" type="application/rss+xml" title="RSS for {{ kind }} {{ classification|e }} ({{ language }})" href="{{ _link(kind + "_rss", classification, language) }}">
-                {% endif %}
-            {% else %}
-                {% if generate_atom %}
-                    <link rel="alternate" type="application/atom+xml" title="Atom ({{ language }})" href="{{ _link("index_atom", None, language) }}">
-                {% endif %}
-                {% if generate_rss and not rss_link %}
-                    <link rel="alternate" type="application/rss+xml" title="RSS ({{ language }})" href="{{ _link("rss", None, language) }}">
-                {% endif %}
-            {% endif %}
-        {% endfor %}
-    {% else %}
-        {% if classification %}
-            {% if generate_atom %}
-                <link rel="alternate" type="application/atom+xml" title="Atom for {{ kind }} {{ classification|e }}" href="{{ _link(kind + "_atom", classification) }}">
-            {% endif %}
-            {% if generate_rss and not rss_link %}
-                <link rel="alternate" type="application/rss+xml" title="RSS for {{ kind }} {{ classification|e }}" href="{{ _link(kind + "_rss", classification) }}">
-            {% endif %}
+    {% if generate_rss and not (rss_link and rss_override) and kind != 'archive' %}
+        {% if translations|length > 1 and has_other_languages and classification and kind != 'index' %}
+            {% for language, classification, name in all_languages %}
+                <link rel="alternate" type="application/rss+xml" title="RSS for {{ kind }} {{ name|e }} ({{ language }})" hreflang="{{ language }}" href="{{ _link(kind + "_rss", classification, language) }}">
+            {% endfor %}
         {% else %}
-            {% if generate_atom %}
-                <link rel="alternate" type="application/atom+xml" title="Atom" href="{{ _link("index_atom", None) }}">
-            {% endif %}
-            {% if generate_rss and not rss_link %}
-                <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ _link("rss", None) }}">
-            {% endif %}
+            {% for language in translations|sort %}
+                {% if classification and kind != 'index' %}
+                    <link rel="alternate" type="application/rss+xml" title="RSS for {{ kind }} {{ classification|e }}{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link(kind + "_rss", classification, language) }}">
+                {% else %}
+                    <link rel="alternate" type="application/rss+xml" title="RSS{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link("index_rss", None, language) }}">
+                {% endif %}
+            {% endfor %}
         {% endif %}
     {% endif %}
-    {% if has_other_languages and other_languages %}
+{% endmacro %}
+
+{% macro _head_atom(classification=None, kind='index') %}
+    {% if generate_atom %}
+        {% if translations|length > 1 and has_other_languages and classification and kind != 'index' %}
+            {% for language, classification, name in all_languages %}
+                <link rel="alternate" type="application/atom+xml" title="Atom for {{ kind }} {{ name|e }} ({{ language }})" hreflang="{{ language }}" href="{{ _link(kind + "_atom", classification, language) }}">
+            {% endfor %}
+        {% else %}
+            {% for language in translations|sort %}
+                {% if classification and kind != 'index' %}
+                    <link rel="alternate" type="application/atom+xml" title="Atom for {{ kind }} {{ classification|e }}{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link(kind + "_atom", classification, language) }}">
+                {% else %}
+                    <link rel="alternate" type="application/atom+xml" title="Atom{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link("index_atom", None, language) }}">
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+    {% endif %}
+{% endmacro %}
+
+{#  Handles both feeds and translations #}
+{% macro head(classification=None, kind='index', feeds=True, other=True, rss_override=True, has_no_feeds=False) %}
+    {% if feeds and not has_no_feeds %}
+        {{ _head_rss(classification, 'index' if (kind == 'archive' and rss_override) else kind, rss_override) }}
+        {{ _head_atom(classification, kind) }}
+    {% endif %}
+    {% if other and has_other_languages and other_languages %}
         {% for language, classification, _ in other_languages %}
             <link rel="alternate" hreflang="{{ language }}" href="{{ _link(kind, classification, language) }}">
         {% endfor %}
     {% endif %}
 {% endmacro %}
 
-{% macro feed_link(classification) %}
-    {% if translations|length > 1 %}
-        {% for language in translations|sort %}
-            {% if generate_atom or generate_rss %}
+{% macro feed_link(classification, kind) %}
+    {% if generate_atom or generate_rss %}
+        {% if translations|length > 1 and has_other_languages and kind != 'index' %}
+            {% for language, classification, name in all_languages %}
                 <p class="feedlink">
                     {% if generate_atom %}
-                        <a href="{{ _link(kind + "_atom", classification, language) }}" hreflang="{{ language }}" type="application/atom+xml">{{ messages('Atom feed', language) }} ({{ language }})</a>
+                        <a href="{{ _link(kind + "_atom", classification, language) }}" hreflang="{{ language }}" type="application/atom+xml">{{ messages('Atom feed', language) }} {{ _append_name_language(language, kind, name) }}</a>
                     {% endif %}
-                    {% if generate_rss %}
-                        <a href="{{ _link(kind + "_rss", classification, language) }}" hreflang="{{ language }}" type="application/rss+xml">{{ messages('RSS feed', language) }} ({{ language }})</a>
+                    {% if generate_rss and kind != 'archive' %}
+                        <a href="{{ _link(kind + "_rss", classification, language) }}" hreflang="{{ language }}" type="application/rss+xml">{{ messages('RSS feed', language) }} {{ _append_name_language(language, kind, name) }}</a>
                     {% endif %}
                 </p>
-            {% endif %}
-        {% endfor %}
-    {% else %}
-        {% if generate_atom or generate_rss %}
-            <p class="feedlink">
-                {% if generate_atom %}
-                    <a href="{{ _link(kind + "_atom", classification) }}" type="application/atom+xml">{{ messages('Atom feed') }}</a>
-                {% endif %}
-                {% if generate_rss %}
-                    <a href="{{ _link(kind + "_rss", classification) }}" type="application/rss+xml">{{ messages('RSS feed') }}</a>
-                {% endif %}
-            </p>
+            {% endfor %}
+        {% else %}
+            {% for language in translations|sort %}
+                <p class="feedlink">
+                    {% if generate_atom %}
+                        <a href="{{ _link(kind + "_atom", classification, language) }}" hreflang="{{ language }}" type="application/atom+xml">{{ messages('Atom feed', language) }}{{ _append_language(language) }}</a>
+                    {% endif %}
+                    {% if generate_rss and kind != 'archive' %}
+                        <a href="{{ _link(kind + "_rss", classification, language) }}" hreflang="{{ language }}" type="application/rss+xml">{{ messages('RSS feed', language) }}{{ _append_language(language) }}</a>
+                    {% endif %}
+                </p>
+            {% endfor %}
         {% endif %}
     {% endif %}
 {% endmacro %}
 
-{% macro translation_link() %}
+{% macro translation_link(kind) %}
     {% if has_other_languages and other_languages %}
         <div class="translationslist translations">
             <h3 class="translationslist-intro">{{ messages("Also available in:") }}</h3>
         {% for language, classification, name in other_languages %}
-            <p><a href="{{ _link(kind, classification, language) }}" rel="alternate">{{ messages("LANGUAGE", language) }}
-            {% if kind != 'archive' %}
-                ({{ name|e }})
-            {% endif %}
-            </a></p>
+            <p><a href="{{ _link(kind, classification, language) }}" hreflang="{{ language }}" rel="alternate">{{ messages("LANGUAGE", language) }} {{ _append_name(name, kind) }}</a></p>
         {% endfor %}
         </div>
     {% endif %}

--- a/nikola/data/themes/base-jinja/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/feeds_translations_helper.tmpl
@@ -1,20 +1,35 @@
 {#  -*- coding: utf-8 -*- #}
 
-{% macro _append_language(language) %}{{  " (" + language + ")" if translations|length > 1 else ""  }}{% endmacro %}
-{% macro _append_name(name, kind) %}{{  (" (" + name + ")" if name and kind != "archive" and kind != "author" else "") | h  }}{% endmacro %}
-{% macro _append_name_language_proper(language, kind, name) %}{{  (" (" + name + ", " + language + ")" if name and kind != "archive" and kind != "author" else " (" + language + ")") | h  }}{% endmacro %}
-{% macro _append_name_language(language, kind, name=None) %}{{  _append_name_language_proper(language, kind, name) if translations|length > 1 else _append_name(name, kind)  }}{% endmacro %}
-
 {% macro _head_feed_link(link_type, link_name, link_postfix, classification, kind, language) %}
-    <link rel="alternate" type="{{ link_type }}" title="{{ link_name|e }}{{ _append_language(language) }}" hreflang="{{ language }}" href="{{ _link(kind + '_' + link_postfix, classification, language) }}">
+    {% if translations|length > 1 %}
+        <link rel="alternate" type="{{ link_type }}" title="{{ link_name|e }} ({{ language }})" hreflang="{{ language }}" href="{{ _link(kind + '_' + link_postfix, classification, language) }}">
+    {% else %}
+        <link rel="alternate" type="{{ link_type }}" title="{{ link_name|e }}" hreflang="{{ language }}" href="{{ _link(kind + '_' + link_postfix, classification, language) }}">
+    {% endif %}
 {% endmacro %}
 
 {% macro _html_feed_link(link_type, link_name, link_postfix, classification, kind, language, name=None) %}
-    <a href="{{ _link(kind + '_' + link_postfix, classification, language) }}" hreflang="{{ language }}" type="{{ link_type }}">{{ messages(link_name, language) }} {{ _append_name_language(language, kind, name) }}</a>
+    {% if translations|length > 1 %}
+        {% if name and kind != "archive" and kind != "author" %}
+            <a href="{{ _link(kind + '_' + link_postfix, classification, language) }}" hreflang="{{ language }}" type="{{ link_type }}">{{ messages(link_name, language) }} ({{ name|e }}, {{ language }})</a>
+        {% else %}
+            <a href="{{ _link(kind + '_' + link_postfix, classification, language) }}" hreflang="{{ language }}" type="{{ link_type }}">{{ messages(link_name, language) }} ({{ language }})</a>
+        {% endif %}
+    {% else %}
+        {% if name and kind != "archive" and kind != "author" %}
+            <a href="{{ _link(kind + '_' + link_postfix, classification, language) }}" hreflang="{{ language }}" type="{{ link_type }}">{{ messages(link_name, language) }} ({{ name|e }})</a>
+        {% else %}
+            <a href="{{ _link(kind + '_' + link_postfix, classification, language) }}" hreflang="{{ language }}" type="{{ link_type }}">{{ messages(link_name, language) }}</a>
+        {% endif %}
+    {% endif %}
 {% endmacro %}
 
 {% macro _html_translation_link(classification, kind, language, name=None) %}
-    <a href="{{ _link(kind, classification, language) }}" hreflang="{{ language }}" rel="alternate">{{ messages("LANGUAGE", language) }}{{ _append_name(name, kind) }}</a>
+    {% if name and kind != "archive" and kind != "author" %}
+        <a href="{{ _link(kind, classification, language) }}" hreflang="{{ language }}" rel="alternate">{{ messages("LANGUAGE", language) }} ({{ name|e }})</a>
+    {% else %}
+        <a href="{{ _link(kind, classification, language) }}" hreflang="{{ language }}" rel="alternate">{{ messages("LANGUAGE", language) }}</a>
+    {% endif %}
 {% endmacro %}
 
 {% macro _head_rss(classification=None, kind='index', rss_override=True) %}
@@ -28,7 +43,7 @@
             {% endfor %}
         {% else %}
             {% for language in translations|sort %}
-                {% if classification and kind != 'index' %}
+                {% if (classification or classification == '') and kind != 'index' %}
                     {{ _head_feed_link('application/rss+xml', 'RSS for ' + kind + ' ' + classification, 'rss', classification, kind, language) }}
                 {% else %}
                     {{ _head_feed_link('application/rss+xml', 'RSS', 'rss', classification, 'index', language) }}
@@ -46,7 +61,7 @@
             {% endfor %}
         {% else %}
             {% for language in translations|sort %}
-                {% if classification and kind != 'index' %}
+                {% if (classification or classification == '') and kind != 'index' %}
                     {{ _head_feed_link('application/atom+xml', 'Atom for ' + kind + ' ' + classification, 'atom', classification, kind, language) }}
                 {% else %}
                     {{ _head_feed_link('application/atom+xml', 'Atom', 'atom', classification, 'index', language) }}

--- a/nikola/data/themes/base-jinja/templates/index.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index.tmpl
@@ -16,7 +16,7 @@
 
 {% block content %}
 {% block content_header %}
-    {{ feeds_translations.translation_link() }}
+    {{ feeds_translations.translation_link(kind) }}
 {% endblock %}
 {% if 'main_index' in pagekind %}
     {{ front_index_header }}

--- a/nikola/data/themes/base-jinja/templates/list.tmpl
+++ b/nikola/data/themes/base-jinja/templates/list.tmpl
@@ -3,13 +3,17 @@
 {% import 'archive_navigation_helper.tmpl' as archive_nav with context %}
 {% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
 
+{% block extra_head %}
+    {{ feeds_translations.head(kind=kind, rss_override=False, has_no_feeds=has_no_feeds) }}
+{% endblock %}
+
 {% block content %}
 <article class="listpage">
     <header>
         <h1>{{ title|e }}</h1>
     </header>
     {{ archive_nav.archive_navigation() }}
-    {{ feeds_translations.translation_link() }}
+    {{ feeds_translations.translation_link(kind) }}
     {% if items %}
     <ul class="postlist">
     {% for text, link, count in items %}

--- a/nikola/data/themes/base-jinja/templates/list_post.tmpl
+++ b/nikola/data/themes/base-jinja/templates/list_post.tmpl
@@ -3,13 +3,17 @@
 {% import 'archive_navigation_helper.tmpl' as archive_nav with context %}
 {% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
 
+{% block extra_head %}
+    {{ feeds_translations.head(kind=kind, rss_override=False) }}
+{% endblock %}
+
 {% block content %}
 <article class="listpage">
     <header>
         <h1>{{ title|e }}</h1>
     </header>
     {{ archive_nav.archive_navigation() }}
-    {{ feeds_translations.translation_link() }}
+    {{ feeds_translations.translation_link(kind) }}
     {% if posts %}
     <ul class="postlist">
     {% for post in posts %}

--- a/nikola/data/themes/base-jinja/templates/sectionindex.tmpl
+++ b/nikola/data/themes/base-jinja/templates/sectionindex.tmpl
@@ -4,14 +4,17 @@
 
 {% block extra_head %}
     {{ super() }}
-    {{ feeds_translations.head(section) }}
+    {{ feeds_translations.head(section, kind, rss_override=False) }}
 {% endblock %}
 
 {% block content %}
 <div class="sectionindex">
     <header>
         <h2><a href="{{ _link('section_index', section) }}">{{ title|e }}</a></h2>
-        {{ feeds_translations.feed_link(section) }}
+        <div class="metadata">
+            {{ feeds_translations.feed_link(section, kind) }}
+            {{ feeds_translations.translation_link(kind) }}
+        </div>
     </header>
     {{ super() }}
 </div>

--- a/nikola/data/themes/base-jinja/templates/tag.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tag.tmpl
@@ -3,10 +3,8 @@
 {% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
 
 {% block extra_head %}
-    {{ super() }}
-    {{ feeds_translations.head(tag) }}
+    {{ feeds_translations.head(tag, kind, rss_override=False) }}
 {% endblock %}
-
 
 {% block content %}
 <article class="tagpage">
@@ -24,9 +22,9 @@
         </ul>
         {% endif %}
         <div class="metadata">
-            {{ feeds_translations.feed_link(tag) }}
+            {{ feeds_translations.feed_link(tag, kind=kind) }}
         </div>
-        {{ feeds_translations.translation_link() }}
+        {{ feeds_translations.translation_link(kind) }}
     </header>
     {% if posts %}
         <ul class="postlist">

--- a/nikola/data/themes/base-jinja/templates/tagindex.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tagindex.tmpl
@@ -3,7 +3,6 @@
 {% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
 
 {% block content_header %}
-    {{ parent.content_header() }}
     <header>
         <h1>{{ title|e }}</h1>
         {% if description %}
@@ -17,10 +16,14 @@
             {% endfor %}
         </ul>
         {% endif %}
+        <div class="metadata">
+            {{ feeds_translations.feed_link(tag, kind) }}
+            {{ feeds_translations.translation_link(kind) }}
+        </div>
     </header>
 {% endblock %}
 
 {% block extra_head %}
     {{ super() }}
-    {{ feeds_translations.head(tag) }}
+    {{ feeds_translations.head(tag, kind, rss_override=False) }}
 {% endblock %}

--- a/nikola/data/themes/base-jinja/templates/tags.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tags.tmpl
@@ -1,10 +1,18 @@
 {#  -*- coding: utf-8 -*- #}
 {% extends 'base.tmpl' %}
+{% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
+
+{% block extra_head %}
+    {{ feeds_translations.head(kind=kind, feeds=False) }}
+{% endblock %}
 
 {% block content %}
 <article class="tagindex">
     <header>
         <h1>{{ title|e }}</h1>
+        <div class="metadata">
+            {{ feeds_translations.translation_link(kind) }}
+        </div>
     </header>
     {% if cat_items %}
         {% if items %}

--- a/nikola/data/themes/base/templates/archiveindex.tmpl
+++ b/nikola/data/themes/base/templates/archiveindex.tmpl
@@ -5,10 +5,16 @@
 
 <%block name="extra_head">
     ${parent.extra_head()}
-    ${feeds_translations.head(archive_name)}
+    ${feeds_translations.head(archive_name, kind, rss_override=False)}
 </%block>
 
 <%block name="content_header">
-    ${archive_nav.archive_navigation()}
-    ${parent.content_header()}
+    <header>
+        <h1>${title|h}</h1>
+        ${archive_nav.archive_navigation()}
+        <div class="metadata">
+            ${feeds_translations.feed_link(archive, kind)}
+            ${feeds_translations.translation_link(kind)}
+        </div>
+    </header>
 </%block>

--- a/nikola/data/themes/base/templates/author.tmpl
+++ b/nikola/data/themes/base/templates/author.tmpl
@@ -3,10 +3,8 @@
 <%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
 
 <%block name="extra_head">
-    ${parent.extra_head()}
-    ${feeds_translations.head(author)}
+    ${feeds_translations.head(author, kind, rss_override=False)}
 </%block>
-
 
 <%block name="content">
 <article class="authorpage">
@@ -16,7 +14,7 @@
             <p>${description}</p>
         %endif
         <div class="metadata">
-            ${feeds_translations.feed_link(author)}
+            ${feeds_translations.feed_link(author, kind)}
         </div>
     </header>
     %if posts:

--- a/nikola/data/themes/base/templates/authorindex.tmpl
+++ b/nikola/data/themes/base/templates/authorindex.tmpl
@@ -2,7 +2,20 @@
 <%inherit file="index.tmpl"/>
 <%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
 
+<%block name="content_header">
+    <header>
+        <h1>${title|h}</h1>
+        %if description:
+        <p>${description}</p>
+        %endif
+        <div class="metadata">
+            ${feeds_translations.feed_link(author, kind)}
+            ${feeds_translations.translation_link(kind)}
+        </div>
+    </header>
+</%block>
+
 <%block name="extra_head">
     ${parent.extra_head()}
-    ${feeds_translations.head(author)}
+    ${feeds_translations.head(author, kind, rss_override=False)}
 </%block>

--- a/nikola/data/themes/base/templates/authors.tmpl
+++ b/nikola/data/themes/base/templates/authors.tmpl
@@ -1,10 +1,18 @@
 ## -*- coding: utf-8 -*-
 <%inherit file="base.tmpl"/>
+<%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
+
+<%block name="extra_head">
+    ${feeds_translations.head(kind=kind, feeds=False)}
+</%block>
 
 <%block name="content">
 <article class="authorindex">
     %if items:
         <h2>${messages("Authors")}</h2>
+        <div class="metadata">
+            ${feeds_translations.translation_link(kind)}
+        </div>
         <ul class="postlist">
         % for text, link in items:
             % if text not in hidden_authors:

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -42,7 +42,7 @@ lang="${lang}">
     % if meta_generator_tag:
         <meta name="generator" content="Nikola (getnikola.com)">
     % endif
-    ${feeds_translations.head(classification=None, kind=kind, other=False)}
+    ${feeds_translations.head(classification=None, kind='index', other=False)}
     <link rel="canonical" href="${abs_link(permalink)}">
 
     %if favicons:
@@ -101,7 +101,7 @@ lang="${lang}">
 
 ### This function is deprecated; use feed_helper directly.
 <%def name="html_feedlinks()">
-    ${feeds_translations.head(classification=None, kind=kind, other=False)}
+    ${feeds_translations.head(classification=None, kind='index', other=False)}
 </%def>
 
 <%def name="html_translations()">

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -42,7 +42,7 @@ lang="${lang}">
     % if meta_generator_tag:
         <meta name="generator" content="Nikola (getnikola.com)">
     % endif
-    ${feeds_translations.head()}
+    ${feeds_translations.head(classification=None, kind=kind, other=False)}
     <link rel="canonical" href="${abs_link(permalink)}">
 
     %if favicons:
@@ -101,7 +101,7 @@ lang="${lang}">
 
 ### This function is deprecated; use feed_helper directly.
 <%def name="html_feedlinks()">
-    ${feeds_translations.head()}
+    ${feeds_translations.head(classification=None, kind=kind, other=False)}
 </%def>
 
 <%def name="html_translations()">

--- a/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
@@ -1,91 +1,97 @@
 ## -*- coding: utf-8 -*-
 
-## Handles both feeds and translations
-<%def name="head(classification=None)">
-    % if rss_link:
+<%def name="_append_language(language)">${ " (" + language + ")" if len(translations) > 1 else "" }</%def>
+<%def name="_append_name(name, kind)">${ (" (" + name + ")" if name and kind != "archive" and kind != "author" else "") | h }</%def>
+<%def name="_append_name_language_proper(language, kind, name)">${ (" (" + name + ", " + language + ")" if name and kind != "archive" and kind != "author" else " (" + language + ")") | h }</%def>
+<%def name="_append_name_language(language, kind, name=None)">${ _append_name_language_proper(language, kind, name) if len(translations) > 1 else _append_name(name, kind) }</%def>
+
+<%def name="_head_rss(classification=None, kind='index', rss_override=True)">
+    % if rss_link and rss_override:
         ${rss_link}
     % endif
-    % if len(translations) > 1:
-        % for language in sorted(translations):
-            % if classification:
-                % if generate_atom:
-                    <link rel="alternate" type="application/atom+xml" title="Atom for ${kind} ${classification|h} (${language})" hreflang="${language}" href="${_link(kind + "_atom", classification, language)}">
-                % endif
-                % if generate_rss and not rss_link:
-                    <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${classification|h} (${language})" hreflang="${language}" href="${_link(kind + "_rss", classification, language)}">
-                % endif
-            % else:
-                % if generate_atom:
-                    <link rel="alternate" type="application/atom+xml" title="Atom (${language})" hreflang="${language}" href="${_link("index_atom", None, language)}">
-                % endif
-                % if generate_rss and not rss_link:
-                    <link rel="alternate" type="application/rss+xml" title="RSS (${language})" hreflang="${language}" href="${_link("rss", None, language)}">
-                % endif
-            % endif
-        % endfor
-    % else:
-        % if classification:
-            % if generate_atom:
-                <link rel="alternate" type="application/atom+xml" title="Atom for ${kind} ${classification|h}" href="${_link(kind + "_atom", classification)}">
-            % endif
-            % if generate_rss and not rss_link:
-                <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${classification|h}" href="${_link(kind + "_rss", classification)}">
-            % endif
+    % if generate_rss and not (rss_link and rss_override) and kind != 'archive':
+        % if len(translations) > 1 and has_other_languages and classification and kind != 'index':
+            % for language, classification, name in all_languages:
+                <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${name|h} (${language})" hreflang="${language}" href="${_link(kind + "_rss", classification, language)}">
+            % endfor
         % else:
-            % if generate_atom:
-                <link rel="alternate" type="application/atom+xml" title="Atom" href="${_link("index_atom", None)}">
-            % endif
-            % if generate_rss and not rss_link:
-                <link rel="alternate" type="application/rss+xml" title="RSS" href="${_link("rss", None)}">
-            % endif
+            % for language in sorted(translations):
+                % if classification and kind != 'index':
+                    <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${classification|h}${_append_language(language)}" hreflang="${language}" href="${_link(kind + "_rss", classification, language)}">
+                % else:
+                    <link rel="alternate" type="application/rss+xml" title="RSS${_append_language(language)}" hreflang="${language}" href="${_link("index_rss", None, language)}">
+                % endif
+            % endfor
         % endif
     % endif
-    % if has_other_languages and other_languages:
+</%def>
+
+<%def name="_head_atom(classification=None, kind='index')">
+    % if generate_atom:
+        % if len(translations) > 1 and has_other_languages and classification and kind != 'index':
+            % for language, classification, name in all_languages:
+                <link rel="alternate" type="application/atom+xml" title="Atom for ${kind} ${name|h} (${language})" hreflang="${language}" href="${_link(kind + "_atom", classification, language)}">
+            % endfor
+        % else:
+            % for language in sorted(translations):
+                % if classification and kind != 'index':
+                    <link rel="alternate" type="application/atom+xml" title="Atom for ${kind} ${classification|h}${_append_language(language)}" hreflang="${language}" href="${_link(kind + "_atom", classification, language)}">
+                % else:
+                    <link rel="alternate" type="application/atom+xml" title="Atom${_append_language(language)}" hreflang="${language}" href="${_link("index_atom", None, language)}">
+                % endif
+            % endfor
+        % endif
+    % endif
+</%def>
+
+## Handles both feeds and translations
+<%def name="head(classification=None, kind='index', feeds=True, other=True, rss_override=True)">
+    % if feeds:
+        ${_head_rss(classification, 'index' if (kind == 'archive' and rss_override) else kind, rss_override)}
+        ${_head_atom(classification, kind)}
+    % endif
+    % if other and has_other_languages and other_languages:
         % for language, classification, _ in other_languages:
             <link rel="alternate" hreflang="${language}" href="${_link(kind, classification, language)}">
         % endfor
     % endif
 </%def>
 
-<%def name="feed_link(classification)">
-    % if len(translations) > 1:
-        % for language in sorted(translations):
-            % if generate_atom or generate_rss:
+<%def name="feed_link(classification, kind)">
+    % if generate_atom or generate_rss:
+        % if len(translations) > 1 and has_other_languages and kind != 'index':
+            % for language, classification, name in all_languages:
                 <p class="feedlink">
                     % if generate_atom:
-                        <a href="${_link(kind + "_atom", classification, language)}" hreflang="${language}" type="application/atom+xml">${messages('Atom feed', language)} (${language})</a>
+                        <a href="${_link(kind + "_atom", classification, language)}" hreflang="${language}" type="application/atom+xml">${messages('Atom feed', language)} ${_append_name_language(language, kind, name)}</a>
                     % endif
-                    % if generate_rss:
-                        <a href="${_link(kind + "_rss", classification, language)}" hreflang="${language}" type="application/rss+xml">${messages('RSS feed', language)} (${language})</a>
+                    % if generate_rss and kind != 'archive':
+                        <a href="${_link(kind + "_rss", classification, language)}" hreflang="${language}" type="application/rss+xml">${messages('RSS feed', language)} ${_append_name_language(language, kind, name)}</a>
                     % endif
                 </p>
-            % endif
-        % endfor
-    % else:
-        % if generate_atom or generate_rss:
-            <p class="feedlink">
-                % if generate_atom:
-                    <a href="${_link(kind + "_atom", classification)}" type="application/atom+xml">${messages('Atom feed')}</a>
-                % endif
-                % if generate_rss:
-                    <a href="${_link(kind + "_rss", classification)}" type="application/rss+xml">${messages('RSS feed')}</a>
-                % endif
-            </p>
+            % endfor
+        % else:
+            % for language in sorted(translations):
+                <p class="feedlink">
+                    % if generate_atom:
+                        <a href="${_link(kind + "_atom", classification, language)}" hreflang="${language}" type="application/atom+xml">${messages('Atom feed', language)}$_append_language(language)}</a>
+                    % endif
+                    % if generate_rss and kind != 'archive':
+                        <a href="${_link(kind + "_rss", classification, language)}" hreflang="${language}" type="application/rss+xml">${messages('RSS feed', language)}$_append_language(language)}</a>
+                    % endif
+                </p>
+            % endfor
         % endif
     % endif
 </%def>
 
-<%def name="translation_link()">
-    %if has_other_languages and other_languages:
+<%def name="translation_link(kind)">
+    % if has_other_languages and other_languages:
         <div class="translationslist translations">
             <h3 class="translationslist-intro">${messages("Also available in:")}</h3>
-        %for language, classification, name in other_languages:
-            <p><a href="${_link(kind, classification, language)}" hreflang="${language}" rel="alternate">${messages("LANGUAGE", language)}
-            %if kind != 'archive':
-                (${name|h})
-            %endif
-            </a></p>
-        %endfor
+        % for language, classification, name in other_languages:
+            <p><a href="${_link(kind, classification, language)}" hreflang="${language}" rel="alternate">${messages("LANGUAGE", language)} ${_append_name(name, kind)}</a></p>
+        % endfor
         </div>
-    %endif
+    % endif
 </%def>

--- a/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
@@ -1,20 +1,35 @@
 ## -*- coding: utf-8 -*-
 
-<%def name="_append_language(language)">${ " (" + language + ")" if len(translations) > 1 else "" }</%def>
-<%def name="_append_name(name, kind)">${ (" (" + name + ")" if name and kind != "archive" and kind != "author" else "") | h }</%def>
-<%def name="_append_name_language_proper(language, kind, name)">${ (" (" + name + ", " + language + ")" if name and kind != "archive" and kind != "author" else " (" + language + ")") | h }</%def>
-<%def name="_append_name_language(language, kind, name=None)">${ _append_name_language_proper(language, kind, name) if len(translations) > 1 else _append_name(name, kind) }</%def>
-
 <%def name="_head_feed_link(link_type, link_name, link_postfix, classification, kind, language)">
-    <link rel="alternate" type="${link_type}" title="${link_name|h}${_append_language(language)}" hreflang="${language}" href="${_link(kind + '_' + link_postfix, classification, language)}">
+    % if len(translations) > 1:
+        <link rel="alternate" type="${link_type}" title="${link_name|h} (${language})" hreflang="${language}" href="${_link(kind + '_' + link_postfix, classification, language)}">
+    % else:
+        <link rel="alternate" type="${link_type}" title="${link_name|h}" hreflang="${language}" href="${_link(kind + '_' + link_postfix, classification, language)}">
+    % endif
 </%def>
 
 <%def name="_html_feed_link(link_type, link_name, link_postfix, classification, kind, language, name=None)">
-    <a href="${_link(kind + '_' + link_postfix, classification, language)}" hreflang="${language}" type="${link_type}">${messages(link_name, language)} ${_append_name_language(language, kind, name)}</a>
+    % if len(translations) > 1:
+        % if name and kind != "archive" and kind != "author":
+            <a href="${_link(kind + '_' + link_postfix, classification, language)}" hreflang="${language}" type="${link_type}">${messages(link_name, language)} (${name|h}, ${language})</a>
+        % else:
+            <a href="${_link(kind + '_' + link_postfix, classification, language)}" hreflang="${language}" type="${link_type}">${messages(link_name, language)} (${language})</a>
+        % endif
+    % else:
+        % if name and kind != "archive" and kind != "author":
+            <a href="${_link(kind + '_' + link_postfix, classification, language)}" hreflang="${language}" type="${link_type}">${messages(link_name, language)} (${name|h})</a>
+        % else:
+            <a href="${_link(kind + '_' + link_postfix, classification, language)}" hreflang="${language}" type="${link_type}">${messages(link_name, language)}</a>
+        % endif
+    % endif
 </%def>
 
 <%def name="_html_translation_link(classification, kind, language, name=None)">
-    <a href="${_link(kind, classification, language)}" hreflang="${language}" rel="alternate">${messages("LANGUAGE", language)}${_append_name(name, kind)}</a>
+    % if name and kind != "archive" and kind != "author":
+        <a href="${_link(kind, classification, language)}" hreflang="${language}" rel="alternate">${messages("LANGUAGE", language)} (${name|h})</a>
+    % else:
+        <a href="${_link(kind, classification, language)}" hreflang="${language}" rel="alternate">${messages("LANGUAGE", language)}</a>
+    % endif
 </%def>
 
 <%def name="_head_rss(classification=None, kind='index', rss_override=True)">
@@ -28,7 +43,7 @@
             % endfor
         % else:
             % for language in sorted(translations):
-                % if classification and kind != 'index':
+                % if (classification or classification == '') and kind != 'index':
                     ${_head_feed_link('application/rss+xml', 'RSS for ' + kind + ' ' + classification, 'rss', classification, kind, language)}
                 % else:
                     ${_head_feed_link('application/rss+xml', 'RSS', 'rss', classification, 'index', language)}
@@ -46,7 +61,7 @@
             % endfor
         % else:
             % for language in sorted(translations):
-                % if classification and kind != 'index':
+                % if (classification or classification == '') and kind != 'index':
                     ${_head_feed_link('application/atom+xml', 'Atom for ' + kind + ' ' + classification, 'atom', classification, kind, language)}
                 % else:
                     ${_head_feed_link('application/atom+xml', 'Atom', 'atom', classification, 'index', language)}

--- a/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
@@ -5,6 +5,18 @@
 <%def name="_append_name_language_proper(language, kind, name)">${ (" (" + name + ", " + language + ")" if name and kind != "archive" and kind != "author" else " (" + language + ")") | h }</%def>
 <%def name="_append_name_language(language, kind, name=None)">${ _append_name_language_proper(language, kind, name) if len(translations) > 1 else _append_name(name, kind) }</%def>
 
+<%def name="_head_feed_link(link_type, link_name, link_postfix, classification, kind, language)">
+    <link rel="alternate" type="${link_type}" title="${link_name|h}${_append_language(language)}" hreflang="${language}" href="${_link(kind + '_' + link_postfix, classification, language)}">
+</%def>
+
+<%def name="_html_feed_link(link_type, link_name, link_postfix, classification, kind, language, name=None)">
+    <a href="${_link(kind + '_' + link_postfix, classification, language)}" hreflang="${language}" type="${link_type}">${messages(link_name, language)} ${_append_name_language(language, kind, name)}</a>
+</%def>
+
+<%def name="_html_translation_link(classification, kind, language, name=None)">
+    <a href="${_link(kind, classification, language)}" hreflang="${language}" rel="alternate">${messages("LANGUAGE", language)}${_append_name(name, kind)}</a>
+</%def>
+
 <%def name="_head_rss(classification=None, kind='index', rss_override=True)">
     % if rss_link and rss_override:
         ${rss_link}
@@ -17,9 +29,9 @@
         % else:
             % for language in sorted(translations):
                 % if classification and kind != 'index':
-                    <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${classification|h}${_append_language(language)}" hreflang="${language}" href="${_link(kind + "_rss", classification, language)}">
+                    ${_head_feed_link('application/rss+xml', 'RSS for ' + kind + ' ' + classification, 'rss', classification, kind, language)}
                 % else:
-                    <link rel="alternate" type="application/rss+xml" title="RSS${_append_language(language)}" hreflang="${language}" href="${_link("index_rss", None, language)}">
+                    ${_head_feed_link('application/rss+xml', 'RSS', 'rss', classification, 'index', language)}
                 % endif
             % endfor
         % endif
@@ -35,9 +47,9 @@
         % else:
             % for language in sorted(translations):
                 % if classification and kind != 'index':
-                    <link rel="alternate" type="application/atom+xml" title="Atom for ${kind} ${classification|h}${_append_language(language)}" hreflang="${language}" href="${_link(kind + "_atom", classification, language)}">
+                    ${_head_feed_link('application/atom+xml', 'Atom for ' + kind + ' ' + classification, 'atom', classification, kind, language)}
                 % else:
-                    <link rel="alternate" type="application/atom+xml" title="Atom${_append_language(language)}" hreflang="${language}" href="${_link("index_atom", None, language)}">
+                    ${_head_feed_link('application/atom+xml', 'Atom', 'atom', classification, 'index', language)}
                 % endif
             % endfor
         % endif
@@ -63,10 +75,10 @@
             % for language, classification, name in all_languages:
                 <p class="feedlink">
                     % if generate_atom:
-                        <a href="${_link(kind + "_atom", classification, language)}" hreflang="${language}" type="application/atom+xml">${messages('Atom feed', language)} ${_append_name_language(language, kind, name)}</a>
+                        ${_html_feed_link('application/atom+xml', 'Atom feed', 'atom', classification, kind, language, name)}
                     % endif
                     % if generate_rss and kind != 'archive':
-                        <a href="${_link(kind + "_rss", classification, language)}" hreflang="${language}" type="application/rss+xml">${messages('RSS feed', language)} ${_append_name_language(language, kind, name)}</a>
+                        ${_html_feed_link('application/rss+xml', 'RSS feed', 'rss', classification, kind, language, name)}
                     % endif
                 </p>
             % endfor
@@ -74,10 +86,10 @@
             % for language in sorted(translations):
                 <p class="feedlink">
                     % if generate_atom:
-                        <a href="${_link(kind + "_atom", classification, language)}" hreflang="${language}" type="application/atom+xml">${messages('Atom feed', language)}${_append_language(language)}</a>
+                        ${_html_feed_link('application/atom+xml', 'Atom feed', 'atom', classification, kind, language)}
                     % endif
                     % if generate_rss and kind != 'archive':
-                        <a href="${_link(kind + "_rss", classification, language)}" hreflang="${language}" type="application/rss+xml">${messages('RSS feed', language)}${_append_language(language)}</a>
+                        ${_html_feed_link('application/rss+xml', 'RSS feed', 'rss', classification, kind, language)}
                     % endif
                 </p>
             % endfor
@@ -90,7 +102,7 @@
         <div class="translationslist translations">
             <h3 class="translationslist-intro">${messages("Also available in:")}</h3>
         % for language, classification, name in other_languages:
-            <p><a href="${_link(kind, classification, language)}" hreflang="${language}" rel="alternate">${messages("LANGUAGE", language)} ${_append_name(name, kind)}</a></p>
+            <p>${_html_translation_link(classification, kind, language, name)}</p>
         % endfor
         </div>
     % endif

--- a/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
@@ -9,17 +9,17 @@
         % for language in sorted(translations):
             % if classification:
                 % if generate_atom:
-                    <link rel="alternate" type="application/atom+xml" title="Atom for ${kind} ${classification|h} (${language})" href="${_link(kind + "_atom", classification, language)}">
+                    <link rel="alternate" type="application/atom+xml" title="Atom for ${kind} ${classification|h} (${language})" hreflang="${language}" href="${_link(kind + "_atom", classification, language)}">
                 % endif
                 % if generate_rss and not rss_link:
-                    <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${classification|h} (${language})" href="${_link(kind + "_rss", classification, language)}">
+                    <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${classification|h} (${language})" hreflang="${language}" href="${_link(kind + "_rss", classification, language)}">
                 % endif
             % else:
                 % if generate_atom:
-                    <link rel="alternate" type="application/atom+xml" title="Atom (${language})" href="${_link("index_atom", None, language)}">
+                    <link rel="alternate" type="application/atom+xml" title="Atom (${language})" hreflang="${language}" href="${_link("index_atom", None, language)}">
                 % endif
                 % if generate_rss and not rss_link:
-                    <link rel="alternate" type="application/rss+xml" title="RSS (${language})" href="${_link("rss", None, language)}">
+                    <link rel="alternate" type="application/rss+xml" title="RSS (${language})" hreflang="${language}" href="${_link("rss", None, language)}">
                 % endif
             % endif
         % endfor
@@ -80,7 +80,7 @@
         <div class="translationslist translations">
             <h3 class="translationslist-intro">${messages("Also available in:")}</h3>
         %for language, classification, name in other_languages:
-            <p><a href="${_link(kind, classification, language)}" rel="alternate">${messages("LANGUAGE", language)}
+            <p><a href="${_link(kind, classification, language)}" hreflang="${language}" rel="alternate">${messages("LANGUAGE", language)}
             %if kind != 'archive':
                 (${name|h})
             %endif

--- a/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
@@ -45,8 +45,8 @@
 </%def>
 
 ## Handles both feeds and translations
-<%def name="head(classification=None, kind='index', feeds=True, other=True, rss_override=True)">
-    % if feeds:
+<%def name="head(classification=None, kind='index', feeds=True, other=True, rss_override=True, has_no_feeds=False)">
+    % if feeds and not has_no_feeds:
         ${_head_rss(classification, 'index' if (kind == 'archive' and rss_override) else kind, rss_override)}
         ${_head_atom(classification, kind)}
     % endif

--- a/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
@@ -74,10 +74,10 @@
             % for language in sorted(translations):
                 <p class="feedlink">
                     % if generate_atom:
-                        <a href="${_link(kind + "_atom", classification, language)}" hreflang="${language}" type="application/atom+xml">${messages('Atom feed', language)}$_append_language(language)}</a>
+                        <a href="${_link(kind + "_atom", classification, language)}" hreflang="${language}" type="application/atom+xml">${messages('Atom feed', language)}${_append_language(language)}</a>
                     % endif
                     % if generate_rss and kind != 'archive':
-                        <a href="${_link(kind + "_rss", classification, language)}" hreflang="${language}" type="application/rss+xml">${messages('RSS feed', language)}$_append_language(language)}</a>
+                        <a href="${_link(kind + "_rss", classification, language)}" hreflang="${language}" type="application/rss+xml">${messages('RSS feed', language)}${_append_language(language)}</a>
                     % endif
                 </p>
             % endfor

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -16,7 +16,7 @@
 
 <%block name="content">
 <%block name="content_header">
-    ${feeds_translations.translation_link()}
+    ${feeds_translations.translation_link(kind)}
 </%block>
 % if 'main_index' in pagekind:
     ${front_index_header}

--- a/nikola/data/themes/base/templates/list.tmpl
+++ b/nikola/data/themes/base/templates/list.tmpl
@@ -3,13 +3,17 @@
 <%namespace name="archive_nav" file="archive_navigation_helper.tmpl" import="*"/>
 <%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
 
+<%block name="extra_head">
+    ${feeds_translations.head(kind=kind, rss_override=False)}
+</%block>
+
 <%block name="content">
 <article class="listpage">
     <header>
         <h1>${title|h}</h1>
     </header>
     ${archive_nav.archive_navigation()}
-    ${feeds_translations.translation_link()}
+    ${feeds_translations.translation_link(kind)}
     %if items:
     <ul class="postlist">
     % for text, link, count in items:

--- a/nikola/data/themes/base/templates/list.tmpl
+++ b/nikola/data/themes/base/templates/list.tmpl
@@ -4,7 +4,7 @@
 <%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
 
 <%block name="extra_head">
-    ${feeds_translations.head(kind=kind, rss_override=False)}
+    ${feeds_translations.head(kind=kind, rss_override=False, has_no_feeds=has_no_feeds)}
 </%block>
 
 <%block name="content">

--- a/nikola/data/themes/base/templates/list_post.tmpl
+++ b/nikola/data/themes/base/templates/list_post.tmpl
@@ -3,13 +3,17 @@
 <%namespace name="archive_nav" file="archive_navigation_helper.tmpl" import="*"/>
 <%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
 
+<%block name="extra_head">
+    ${feeds_translations.head(kind=kind, rss_override=False)}
+</%block>
+
 <%block name="content">
 <article class="listpage">
     <header>
         <h1>${title|h}</h1>
     </header>
     ${archive_nav.archive_navigation()}
-    ${feeds_translations.translation_link()}
+    ${feeds_translations.translation_link(kind)}
     %if posts:
     <ul class="postlist">
     % for post in posts:

--- a/nikola/data/themes/base/templates/sectionindex.tmpl
+++ b/nikola/data/themes/base/templates/sectionindex.tmpl
@@ -4,14 +4,17 @@
 
 <%block name="extra_head">
     ${parent.extra_head()}
-    ${feeds_translations.head(section)}
+    ${feeds_translations.head(section, kind, rss_override=False)}
 </%block>
 
 <%block name="content">
 <div class="sectionindex">
     <header>
         <h2><a href="${_link('section_index', section)}">${title|h}</a></h2>
-        ${feeds_translations.feed_link(section)}
+        <div class="metadata">
+            ${feeds_translations.feed_link(section, kind)}
+            ${feeds_translations.translation_link(kind)}
+        </div>
     </header>
     ${parent.content()}
 </div>

--- a/nikola/data/themes/base/templates/tag.tmpl
+++ b/nikola/data/themes/base/templates/tag.tmpl
@@ -3,10 +3,8 @@
 <%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
 
 <%block name="extra_head">
-    ${parent.extra_head()}
-    ${feeds_translations.head(tag)}
+    ${feeds_translations.head(tag, kind, rss_override=False)}
 </%block>
-
 
 <%block name="content">
 <article class="tagpage">
@@ -24,9 +22,9 @@
         </ul>
         %endif
         <div class="metadata">
-            ${feeds_translations.feed_link(tag)}
+            ${feeds_translations.feed_link(tag, kind=kind)}
         </div>
-        ${feeds_translations.translation_link()}
+        ${feeds_translations.translation_link(kind)}
     </header>
     %if posts:
         <ul class="postlist">

--- a/nikola/data/themes/base/templates/tagindex.tmpl
+++ b/nikola/data/themes/base/templates/tagindex.tmpl
@@ -3,7 +3,6 @@
 <%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
 
 <%block name="content_header">
-    ${parent.content_header()}
     <header>
         <h1>${title|h}</h1>
         %if description:
@@ -17,10 +16,14 @@
             %endfor
         </ul>
         %endif
+        <div class="metadata">
+            ${feeds_translations.feed_link(tag, kind)}
+            ${feeds_translations.translation_link(kind)}
+        </div>
     </header>
 </%block>
 
 <%block name="extra_head">
     ${parent.extra_head()}
-    ${feeds_translations.head(tag)}
+    ${feeds_translations.head(tag, kind, rss_override=False)}
 </%block>

--- a/nikola/data/themes/base/templates/tags.tmpl
+++ b/nikola/data/themes/base/templates/tags.tmpl
@@ -1,10 +1,18 @@
 ## -*- coding: utf-8 -*-
 <%inherit file="base.tmpl"/>
+<%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
+
+<%block name="extra_head">
+    ${feeds_translations.head(kind=kind, feeds=False)}
+</%block>
 
 <%block name="content">
 <article class="tagindex">
     <header>
         <h1>${title|h}</h1>
+        <div class="metadata">
+            ${feeds_translations.translation_link(kind)}
+        </div>
     </header>
     % if cat_items:
         % if items:

--- a/nikola/data/themes/bootstrap3-jinja/templates/authors.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/authors.tmpl
@@ -1,9 +1,17 @@
 {#  -*- coding: utf-8 -*- #}
 {% extends 'base.tmpl' %}
+{% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
+
+{% block extra_head %}
+    {{ feeds_translations.head(kind=kind, feeds=False) }}
+{% endblock %}
 
 {% block content %}
 {% if items %}
     <h2>{{ messages("Authors") }}</h2>
+    <div class="metadata">
+        {{ feeds_translations.translation_link(kind) }}
+    </div>
 {% endif %}
 {% if items %}
     <ul class="list-inline">

--- a/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
@@ -45,7 +45,7 @@ lang="{{ lang }}">
     {% if meta_generator_tag %}
     <meta name="generator" content="Nikola (getnikola.com)">
     {% endif %}
-    {{ feeds_translations.head(classification=None, kind=kind, other=False) }}
+    {{ feeds_translations.head(classification=None, kind='index', other=False) }}
     <link rel="canonical" href="{{ abs_link(permalink) }}">
 
     {% if favicons %}
@@ -156,7 +156,7 @@ lang="{{ lang }}">
 {% endmacro %}
 
 {% macro html_feedlinks() %}
-    {{ feeds_translations.head(classification=None, kind=kind, other=False) }}
+    {{ feeds_translations.head(classification=None, kind='index', other=False) }}
 {% endmacro %}
 
 {% macro html_translations() %}

--- a/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/base_helper.tmpl
@@ -45,7 +45,7 @@ lang="{{ lang }}">
     {% if meta_generator_tag %}
     <meta name="generator" content="Nikola (getnikola.com)">
     {% endif %}
-    {{ feeds_translations.head() }}
+    {{ feeds_translations.head(classification=None, kind=kind, other=False) }}
     <link rel="canonical" href="{{ abs_link(permalink) }}">
 
     {% if favicons %}
@@ -156,7 +156,7 @@ lang="{{ lang }}">
 {% endmacro %}
 
 {% macro html_feedlinks() %}
-    {{ feeds_translations.head() }}
+    {{ feeds_translations.head(classification=None, kind=kind, other=False) }}
 {% endmacro %}
 
 {% macro html_translations() %}

--- a/nikola/data/themes/bootstrap3-jinja/templates/tags.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/tags.tmpl
@@ -1,8 +1,16 @@
 {#  -*- coding: utf-8 -*- #}
 {% extends 'base.tmpl' %}
+{% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
+
+{% block extra_head %}
+    {{ feeds_translations.head(kind=kind, feeds=False) }}
+{% endblock %}
 
 {% block content %}
 <h1>{{ title|e }}</h1>
+<div class="metadata">
+    {{ feeds_translations.translation_link(kind) }}
+</div>
 {% if cat_items %}
     {% if items %}
         <h2>{{ messages("Categories") }}</h2>

--- a/nikola/data/themes/bootstrap3/templates/authors.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/authors.tmpl
@@ -1,9 +1,17 @@
 ## -*- coding: utf-8 -*-
 <%inherit file="base.tmpl"/>
+<%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
+
+<%block name="extra_head">
+    ${feeds_translations.head(kind=kind, feeds=False)}
+</%block>
 
 <%block name="content">
 % if items:
     <h2>${messages("Authors")}</h2>
+    <div class="metadata">
+        ${feeds_translations.translation_link(kind)}
+    </div>
 % endif
 % if items:
     <ul class="list-inline">

--- a/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
@@ -45,7 +45,7 @@ lang="${lang}">
     % if meta_generator_tag:
     <meta name="generator" content="Nikola (getnikola.com)">
     % endif
-    ${feeds_translations.head(classification=None, kind=kind, other=False)}
+    ${feeds_translations.head(classification=None, kind='index', other=False)}
     <link rel="canonical" href="${abs_link(permalink)}">
 
     %if favicons:
@@ -156,7 +156,7 @@ lang="${lang}">
 </%def>
 
 <%def name="html_feedlinks()">
-    ${feeds_translations.head(classification=None, kind=kind, other=False)}
+    ${feeds_translations.head(classification=None, kind='index', other=False)}
 </%def>
 
 <%def name="html_translations()">

--- a/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base_helper.tmpl
@@ -45,7 +45,7 @@ lang="${lang}">
     % if meta_generator_tag:
     <meta name="generator" content="Nikola (getnikola.com)">
     % endif
-    ${feeds_translations.head()}
+    ${feeds_translations.head(classification=None, kind=kind, other=False)}
     <link rel="canonical" href="${abs_link(permalink)}">
 
     %if favicons:
@@ -156,7 +156,7 @@ lang="${lang}">
 </%def>
 
 <%def name="html_feedlinks()">
-    ${feeds_translations.head()}
+    ${feeds_translations.head(classification=None, kind=kind, other=False)}
 </%def>
 
 <%def name="html_translations()">

--- a/nikola/data/themes/bootstrap3/templates/tags.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/tags.tmpl
@@ -1,8 +1,16 @@
 ## -*- coding: utf-8 -*-
 <%inherit file="base.tmpl"/>
+<%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
+
+<%block name="extra_head">
+    ${feeds_translations.head(kind=kind, feeds=False)}
+</%block>
 
 <%block name="content">
 <h1>${title|h}</h1>
+<div class="metadata">
+    ${feeds_translations.translation_link(kind)}
+</div>
 % if cat_items:
     % if items:
         <h2>${messages("Categories")}</h2>

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -593,10 +593,12 @@ class Taxonomy(BasePlugin):
         Whether post lists resp. indexes should be created for empty
         classifications.
 
-    also_create_classifications_from_other_languages = True:
+    also_create_classifications_from_other_languages = False:
         Whether to include all classifications for all languages in every
         language, or only the classifications for one language in its language's
         pages.
+
+        WARNING: This is deprecated and will be removed eventually.
 
     add_other_languages_variable = False:
         In case this is `True`, each classification page will get a list
@@ -634,7 +636,7 @@ class Taxonomy(BasePlugin):
     apply_to_pages = False
     minimum_post_count_per_classification_in_overview = 1
     omit_empty_classifications = False
-    also_create_classifications_from_other_languages = True
+    also_create_classifications_from_other_languages = False  # deprecated
     add_other_languages_variable = False
     path_handler_docstrings = {
         'taxonomy_index': '',

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -593,13 +593,6 @@ class Taxonomy(BasePlugin):
         Whether post lists resp. indexes should be created for empty
         classifications.
 
-    also_create_classifications_from_other_languages = False:
-        Whether to include all classifications for all languages in every
-        language, or only the classifications for one language in its language's
-        pages.
-
-        WARNING: This is deprecated and will be removed eventually.
-
     add_other_languages_variable = False:
         In case this is `True`, each classification page will get a list
         of triples `(other_lang, other_classification, title)` of classifications
@@ -636,7 +629,6 @@ class Taxonomy(BasePlugin):
     apply_to_pages = False
     minimum_post_count_per_classification_in_overview = 1
     omit_empty_classifications = False
-    also_create_classifications_from_other_languages = False  # deprecated
     add_other_languages_variable = False
     path_handler_docstrings = {
         'taxonomy_index': '',
@@ -781,8 +773,7 @@ class Taxonomy(BasePlugin):
         the second will be put into the uptodate list of all generated tasks.
 
         For hierarchical taxonomies, node is the `hierarchy_utils.TreeNode` element
-        corresponding to the classification. Note that `node` can still be `None`
-        if `also_create_classifications_from_other_languages` is `True`.
+        corresponding to the classification.
 
         Context must contain `title`, which should be something like 'Posts about <classification>'.
         """

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -161,7 +161,7 @@ class TaxonomiesClassifier(SignalHandler):
                 if not taxonomy.is_enabled(lang):
                     continue
                 for tlang in site.config['TRANSLATIONS'].keys():
-                    if lang != tlang and not taxonomy.also_create_classifications_from_other_languages:
+                    if lang != tlang:
                         continue
                     for classification, posts in site.posts_per_classification[taxonomy.classification_name][tlang].items():
                         # Obtain path as tuple

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -52,7 +52,6 @@ class Archive(Taxonomy):
     apply_to_pages = False
     minimum_post_count_per_classification_in_overview = 1
     omit_empty_classifications = False
-    also_create_classifications_from_other_languages = False
     add_other_languages_variable = True
     path_handler_docstrings = {
         'archive_index': False,

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -180,7 +180,7 @@ class Archive(Taxonomy):
             "title": title,
             "pagekind": [page_kind, "archive_page"],
             "create_archive_navigation": self.site.config["CREATE_ARCHIVE_NAVIGATION"],
-            "archive_name": classification if classification else None
+            "archive_name": classification
         }
 
         # Generate links for hierarchies

--- a/nikola/plugins/task/authors.py
+++ b/nikola/plugins/task/authors.py
@@ -132,10 +132,6 @@ link://author_rss/joe => /authors/joe.xml""",
             "description": descriptions[lang][classification] if lang in descriptions and classification in descriptions[lang] else None,
             "pagekind": ["index" if self.show_list_as_index else "list", "author_page"],
         }
-        if self.site.config["GENERATE_RSS"]:
-            rss_link = ("""<link rel="alternate" type="application/rss+xml" title="RSS for author {0} ({1})" href="{2}">""".format(
-                classification, lang, self.site.link('author_rss', classification, lang)))
-            context['rss_link'] = rss_link
         kw.update(context)
         return context, kw
 

--- a/nikola/plugins/task/authors.py
+++ b/nikola/plugins/task/authors.py
@@ -46,7 +46,6 @@ class ClassifyAuthors(Taxonomy):
     apply_to_pages = False
     minimum_post_count_per_classification_in_overview = 1
     omit_empty_classifications = False
-    also_create_classifications_from_other_languages = False
     add_other_languages_variable = True
     path_handler_docstrings = {
         'author_index': """ Link to the authors index.

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -52,7 +52,6 @@ class ClassifyCategories(Taxonomy):
     apply_to_pages = False
     minimum_post_count_per_classification_in_overview = 1
     omit_empty_classifications = True
-    also_create_classifications_from_other_languages = False
     add_other_languages_variable = True
     path_handler_docstrings = {
         'category_index': """A link to the category index.

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -179,8 +179,6 @@ link://category_rss/dogs => /categories/dogs.xml""",
             "category_path": cat_path,
             "subcategories": subcats,
         }
-        if self.show_list_as_index:
-            context["rss_link"] = """<link rel="alternate" type="application/rss+xml" type="application/rss+xml" title="RSS for tag {0} ({1})" href="{2}">""".format(friendly_name, lang, self.site.link("category_rss", classification, lang))
         kw.update(context)
         return context, kw
 

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -52,7 +52,7 @@ class ClassifyCategories(Taxonomy):
     apply_to_pages = False
     minimum_post_count_per_classification_in_overview = 1
     omit_empty_classifications = True
-    also_create_classifications_from_other_languages = True
+    also_create_classifications_from_other_languages = False
     add_other_languages_variable = True
     path_handler_docstrings = {
         'category_index': """A link to the category index.

--- a/nikola/plugins/task/indexes.py
+++ b/nikola/plugins/task/indexes.py
@@ -45,7 +45,6 @@ class Indexes(Taxonomy):
     apply_to_posts = True
     apply_to_pages = False
     omit_empty_classifications = False
-    also_create_classifications_from_other_languages = False
     path_handler_docstrings = {
         'index_index': False,
         'index': """Link to a numbered index.

--- a/nikola/plugins/task/page_index.py
+++ b/nikola/plugins/task/page_index.py
@@ -95,6 +95,9 @@ class PageIndex(Taxonomy):
         context = {
             "title": self.site.config['BLOG_TITLE'](lang),
             "pagekind": ["list", "front_page", "page_index"] if dirname == '' else ["list", "page_index"],
+            "kind": "page_index_folder",
+            "classification": dirname,
+            "has_no_feeds": True,
         }
         kw.update(context)
         return context, kw

--- a/nikola/plugins/task/page_index.py
+++ b/nikola/plugins/task/page_index.py
@@ -48,7 +48,6 @@ class PageIndex(Taxonomy):
     apply_to_posts = False
     apply_to_pages = True
     omit_empty_classifications = True
-    also_create_classifications_from_other_languages = False
     path_handler_docstrings = {
         'page_index_folder_index': None,
         'page_index_folder': None,

--- a/nikola/plugins/task/sections.py
+++ b/nikola/plugins/task/sections.py
@@ -45,7 +45,6 @@ class ClassifySections(Taxonomy):
     apply_to_posts = True
     apply_to_pages = False
     omit_empty_classifications = True
-    also_create_classifications_from_other_languages = False
     add_other_languages_variable = True
     path_handler_docstrings = {
         'section_index_index': False,

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -48,7 +48,7 @@ class ClassifyTags(Taxonomy):
     apply_to_posts = True
     apply_to_pages = False
     omit_empty_classifications = True
-    also_create_classifications_from_other_languages = True
+    also_create_classifications_from_other_languages = False
     add_other_languages_variable = True
     path_handler_docstrings = {
         'tag_index': """A link to the tag index.

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -147,8 +147,6 @@ link://tag_rss/cats => /tags/cats.xml""",
             "pagekind": ["tag_page", "index" if self.show_list_as_index else "list"],
             "tag": classification,
         }
-        if self.show_list_as_index:
-            context["rss_link"] = """<link rel="alternate" type="application/rss+xml" type="application/rss+xml" title="RSS for tag {0} ({1})" href="{2}">""".format(classification, lang, self.site.link("tag_rss", classification, lang))
         kw.update(context)
         return context, kw
 

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -48,7 +48,6 @@ class ClassifyTags(Taxonomy):
     apply_to_posts = True
     apply_to_pages = False
     omit_empty_classifications = True
-    also_create_classifications_from_other_languages = False
     add_other_languages_variable = True
     path_handler_docstrings = {
         'tag_index': """A link to the tag index.

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -258,6 +258,8 @@ class RenderTaxonomies(Task):
             context["posts"] = filtered_posts
         if "pagekind" not in context:
             context["pagekind"] = ["list", "tag_page"]
+        if not (taxonomy.generate_atom_feeds_for_post_lists and self.site.config['GENERATE_ATOM']):
+            context["generate_atom"] = False
         task = self.site.generic_post_list_renderer(lang, filtered_posts, output_name, template_name, kw['filters'], context)
         task['uptodate'] = task['uptodate'] + [utils.config_changed(kw, 'nikola.plugins.task.taxonomies:list')]
         task['basename'] = str(self.name)

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -253,7 +253,7 @@ class RenderTaxonomies(Task):
         context["lang"] = lang
         # list.tmpl expects a different format than list_post.tmpl (Issue #2701)
         if template_name == 'list.tmpl':
-            context["items"] = [(post.title(), post.permalink(), None) for post in filtered_posts]
+            context["items"] = [(post.title(lang), post.permalink(lang), None) for post in filtered_posts]
         else:
             context["posts"] = filtered_posts
         if "pagekind" not in context:

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -51,6 +51,17 @@ class RenderTaxonomies(Task):
         context, kw = taxonomy.provide_overview_context_and_uptodate(lang)
 
         context = copy(context)
+        context["kind"] = "{}_index".format(taxonomy.classification_name)
+        sorted_links = []
+        sorted_links_all = []
+        for other_lang in sorted(self.site.config['TRANSLATIONS'].keys()):
+            sorted_links_all.append((other_lang, None, None))
+            if other_lang != lang:
+                sorted_links.append((other_lang, None, None))
+        context['has_other_languages'] = True
+        context['other_languages'] = sorted_links
+        context['all_languages'] = sorted_links_all
+
         kw = copy(kw)
         kw["messages"] = self.site.MESSAGES
         kw["translations"] = self.site.config['TRANSLATIONS']

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -425,7 +425,7 @@ class RenderTaxonomies(Task):
             for lang in self.site.config["TRANSLATIONS"]:
                 classifications = {}
                 for tlang, posts_per_classification in self.site.posts_per_classification[taxonomy.classification_name].items():
-                    if lang != tlang and not taxonomy.also_create_classifications_from_other_languages:
+                    if lang != tlang:
                         continue
                     classifications.update(posts_per_classification)
                 result = {}

--- a/scripts/jinjify.py
+++ b/scripts/jinjify.py
@@ -108,7 +108,7 @@ def mako2jinja(input_file):
 
     # TODO: OMG, this code is so horrible. Look at it; just look at it:
 
-    macro_start = re.compile(r'(.*)<%.*def name="(.*?)".*>(.*)', re.IGNORECASE)
+    macro_start = re.compile(r'(.*)<%\s*def name="([^"]*?)"\s*>(.*)', re.IGNORECASE)
     macro_end = re.compile(r'(.*)</%def>(.*)', re.IGNORECASE)
 
     if_start = re.compile(r'(.*)% *if (.*):(.*)', re.IGNORECASE)
@@ -158,6 +158,14 @@ def mako2jinja(input_file):
         if m_func_len:
             line = func_len.sub(r'\1|length', line)
 
+        # Macro start/end
+        m_macro_start = macro_start.search(line)
+        if m_macro_start:
+            line = m_macro_start.expand(r'\1{% macro \2 %}\3') + '\n'
+        m_macro_end = macro_end.search(line)
+        if m_macro_end:
+            line = m_macro_end.expand(r'\1{% endmacro %}\2') + '\n'
+
         # Process line for single 'whole line' replacements
         m_macro_start = macro_start.search(line)
         m_macro_end = macro_end.search(line)
@@ -177,11 +185,6 @@ def mako2jinja(input_file):
 
         if m_comment_single_line:
             output += m_comment_single_line.expand(r'{# \1 #}') + '\n'
-
-        elif m_macro_start:
-            output += m_macro_start.expand(r'\1{% macro \2 %}\3') + '\n'
-        elif m_macro_end:
-            output += m_macro_end.expand(r'\1{% endmacro %}\1') + '\n'
 
         elif m_if_start:
             output += m_if_start.expand(r'\1{% if \2 %}\3') + '\n'

--- a/scripts/jinjify.py
+++ b/scripts/jinjify.py
@@ -99,7 +99,7 @@ def jinjify(in_theme, out_theme):
 
 
 def error(msg):
-    print(colorama.Fore.RED + "ERROR:" + msg)
+    print(colorama.Fore.RED + "ERROR:" + msg + colorama.Fore.RESET)
 
 
 def mako2jinja(input_file):


### PR DESCRIPTION
This completes some things missing in #2778:
 * Adding some missing `hreflang`s
 * Get rid of `also_create_classifications_from_other_languages` for tags and categories, and marking this option as deprecated
 * Refactored feed link creation to create correct translated feed links, also simplified code a bit
 * Got rid of `rss_link` overriding in tags, categories and some more taxonomies, which prevented correct translated RSS feed links
 * Now really *all* generated .html pages should have links to main RSS and Atom feeds
 * Fixed bug: language was not passed for title and link generation when `list.tmpl` was used for a classification page

(fixes #993; fixes #2785)

