### PR TITLE
Remove all leftover loghandlers support

### DIFF
--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -616,7 +616,6 @@ class Nikola(object):
             'DEPLOY_FUTURE': False,
             'SCHEDULE_ALL': False,
             'SCHEDULE_RULE': '',
-            'LOGGING_HANDLERS': {'stderr': {'loglevel': 'WARNING', 'bubble': True}},
             'DEMOTE_HEADERS': 1,
             'GITHUB_SOURCE_BRANCH': 'master',
             'GITHUB_DEPLOY_BRANCH': 'gh-pages',

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -61,7 +61,7 @@ except ImportError:
     PatternMatchingEventHandler = object
 
 from nikola.plugin_categories import Command
-from nikola.utils import dns_sd, req_missing, get_logger, get_theme_path, STDERR_HANDLER
+from nikola.utils import dns_sd, req_missing, get_logger, get_theme_path
 LRJS_PATH = os.path.join(os.path.dirname(__file__), 'livereload.js')
 error_signal = signal('error')
 refresh_signal = signal('refresh')
@@ -129,7 +129,7 @@ class CommandAuto(Command):
 
     def _execute(self, options, args):
         """Start the watcher."""
-        self.logger = get_logger('auto', STDERR_HANDLER)
+        self.logger = get_logger('auto')
         LRSocket.logger = self.logger
 
         if WebSocket is object and watchdog is None:

--- a/nikola/plugins/command/bootswatch_theme.py
+++ b/nikola/plugins/command/bootswatch_theme.py
@@ -32,7 +32,7 @@ import requests
 from nikola.plugin_categories import Command
 from nikola import utils
 
-LOGGER = utils.get_logger('bootswatch_theme', utils.STDERR_HANDLER)
+LOGGER = utils.get_logger('bootswatch_theme')
 
 
 def _check_for_theme(theme, themes):

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -43,7 +43,7 @@ import lxml.html
 import requests
 
 from nikola.plugin_categories import Command
-from nikola.utils import get_logger, STDERR_HANDLER
+from nikola.utils import get_logger
 
 
 def _call_nikola_list(site, cache=None):
@@ -158,7 +158,7 @@ class CommandCheck(Command):
 
     def _execute(self, options, args):
         """Check the generated site."""
-        self.logger = get_logger('check', STDERR_HANDLER)
+        self.logger = get_logger('check')
 
         if not options['links'] and not options['files'] and not options['clean']:
             print(self.help())

--- a/nikola/plugins/command/console.py
+++ b/nikola/plugins/command/console.py
@@ -31,9 +31,9 @@ import os
 
 from nikola import __version__
 from nikola.plugin_categories import Command
-from nikola.utils import get_logger, STDERR_HANDLER, req_missing, Commands
+from nikola.utils import get_logger, req_missing, Commands
 
-LOGGER = get_logger('console', STDERR_HANDLER)
+LOGGER = get_logger('console')
 
 
 class CommandConsole(Command):

--- a/nikola/plugins/command/deploy.py
+++ b/nikola/plugins/command/deploy.py
@@ -37,7 +37,7 @@ import time
 from blinker import signal
 
 from nikola.plugin_categories import Command
-from nikola.utils import get_logger, clean_before_deployment, STDERR_HANDLER
+from nikola.utils import get_logger, clean_before_deployment
 
 
 class CommandDeploy(Command):
@@ -52,7 +52,7 @@ class CommandDeploy(Command):
 
     def _execute(self, command, args):
         """Execute the deploy command."""
-        self.logger = get_logger('deploy', STDERR_HANDLER)
+        self.logger = get_logger('deploy')
         # Get last successful deploy date
         timestamp_path = os.path.join(self.site.config['CACHE_FOLDER'], 'lastdeploy')
 

--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -32,7 +32,7 @@ from textwrap import dedent
 
 from nikola.plugin_categories import Command
 from nikola.plugins.command.check import real_scan_files
-from nikola.utils import get_logger, req_missing, clean_before_deployment, STDERR_HANDLER
+from nikola.utils import get_logger, req_missing, clean_before_deployment
 from nikola.__main__ import main
 from nikola import __version__
 
@@ -82,7 +82,7 @@ class CommandGitHubDeploy(Command):
 
     def _execute(self, options, args):
         """Run the deployment."""
-        self.logger = get_logger(CommandGitHubDeploy.name, STDERR_HANDLER)
+        self.logger = get_logger(CommandGitHubDeploy.name)
 
         # Check if ghp-import is installed
         check_ghp_import_installed()

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -58,7 +58,7 @@ from nikola.utils import req_missing, unicode_str
 from nikola.plugins.basic_import import ImportMixin, links
 from nikola.plugins.command.init import SAMPLE_CONF, prepare_config, format_default_translations_config
 
-LOGGER = utils.get_logger('import_wordpress', utils.STDERR_HANDLER)
+LOGGER = utils.get_logger('import_wordpress')
 
 
 def install_plugin(site, plugin_name, output_dir=None, show_install_notes=False):

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -42,11 +42,11 @@ import tarfile
 import nikola
 from nikola.nikola import DEFAULT_INDEX_READ_MORE_LINK, DEFAULT_FEED_READ_MORE_LINK, LEGAL_VALUES, urlsplit, urlunsplit
 from nikola.plugin_categories import Command
-from nikola.utils import ask, ask_yesno, get_logger, makedirs, STDERR_HANDLER, load_messages
+from nikola.utils import ask, ask_yesno, get_logger, makedirs, load_messages
 from nikola.packages.tzlocal import get_localzone
 
 
-LOGGER = get_logger('init', STDERR_HANDLER)
+LOGGER = get_logger('init')
 
 SAMPLE_CONF = {
     'BLOG_AUTHOR': "Your Name",

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -41,8 +41,8 @@ from nikola.plugin_categories import Command
 from nikola import utils
 
 COMPILERS_DOC_LINK = 'https://getnikola.com/handbook.html#configuring-other-input-formats'
-POSTLOGGER = utils.get_logger('new_post', utils.STDERR_HANDLER)
-PAGELOGGER = utils.get_logger('new_page', utils.STDERR_HANDLER)
+POSTLOGGER = utils.get_logger('new_post')
+PAGELOGGER = utils.get_logger('new_page')
 LOGGER = POSTLOGGER
 
 

--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -41,7 +41,7 @@ from pygments.formatters import TerminalFormatter
 from nikola.plugin_categories import Command
 from nikola import utils
 
-LOGGER = utils.get_logger('plugin', utils.STDERR_HANDLER)
+LOGGER = utils.get_logger('plugin')
 
 
 class CommandPlugin(Command):

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -46,7 +46,7 @@ except ImportError:
 
 
 from nikola.plugin_categories import Command
-from nikola.utils import dns_sd, get_logger, STDERR_HANDLER
+from nikola.utils import dns_sd, get_logger
 
 
 class IPv6Server(HTTPServer):
@@ -120,7 +120,7 @@ class CommandServe(Command):
 
     def _execute(self, options, args):
         """Start test server."""
-        self.logger = get_logger('serve', STDERR_HANDLER)
+        self.logger = get_logger('serve')
         out_dir = self.site.config['OUTPUT_FOLDER']
         if not os.path.isdir(out_dir):
             self.logger.error("Missing '{0}' folder?".format(out_dir))

--- a/nikola/plugins/command/theme.py
+++ b/nikola/plugins/command/theme.py
@@ -41,7 +41,7 @@ from pkg_resources import resource_filename
 from nikola.plugin_categories import Command
 from nikola import utils
 
-LOGGER = utils.get_logger('theme', utils.STDERR_HANDLER)
+LOGGER = utils.get_logger('theme')
 
 
 class CommandTheme(Command):

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -42,7 +42,7 @@ except ImportError:
 
 from nikola import shortcodes as sc
 from nikola.plugin_categories import PageCompiler
-from nikola.utils import makedirs, req_missing, get_logger, STDERR_HANDLER, LocaleBorg
+from nikola.utils import makedirs, req_missing, get_logger, LocaleBorg
 
 
 class CompileIPynb(PageCompiler):
@@ -55,7 +55,7 @@ class CompileIPynb(PageCompiler):
 
     def set_site(self, site):
         """Set Nikola site."""
-        self.logger = get_logger('compile_ipynb', STDERR_HANDLER)
+        self.logger = get_logger('compile_ipynb')
         super(CompileIPynb, self).set_site(site)
 
     def _compile_string(self, nb_json):

--- a/nikola/plugins/compile/markdown/mdx_gist.py
+++ b/nikola/plugins/compile/markdown/mdx_gist.py
@@ -87,11 +87,11 @@ except ImportError:
     Extension = Pattern = object
 
 from nikola.plugin_categories import MarkdownExtension
-from nikola.utils import get_logger, STDERR_HANDLER
+from nikola.utils import get_logger
 
 import requests
 
-LOGGER = get_logger('compile_markdown.mdx_gist', STDERR_HANDLER)
+LOGGER = get_logger('compile_markdown.mdx_gist')
 
 GIST_JS_URL = "https://gist.github.com/{0}.js"
 GIST_FILE_JS_URL = "https://gist.github.com/{0}.js?file={1}"

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -46,7 +46,6 @@ from nikola.utils import (
     get_logger,
     makedirs,
     write_metadata,
-    STDERR_HANDLER,
     LocaleBorg,
     map_metadata
 )
@@ -186,7 +185,7 @@ class CompileRest(PageCompiler):
             self.config_dependencies.append(plugin_info.name)
             plugin_info.plugin_object.short_help = plugin_info.description
 
-        self.logger = get_logger('compile_rest', STDERR_HANDLER)
+        self.logger = get_logger('compile_rest')
         if not site.debug:
             self.logger.level = 4
 

--- a/nikola/plugins/misc/scan_posts.py
+++ b/nikola/plugins/misc/scan_posts.py
@@ -34,7 +34,7 @@ from nikola.plugin_categories import PostScanner
 from nikola import utils
 from nikola.post import Post
 
-LOGGER = utils.get_logger('scan_posts', utils.STDERR_HANDLER)
+LOGGER = utils.get_logger('scan_posts')
 
 
 class ScanPosts(PostScanner):

--- a/nikola/plugins/shortcode/emoji/__init__.py
+++ b/nikola/plugins/shortcode/emoji/__init__.py
@@ -12,7 +12,7 @@ from nikola import utils
 
 TABLE = {}
 
-LOGGER = utils.get_logger('scan_posts', utils.STDERR_HANDLER)
+LOGGER = utils.get_logger('scan_posts')
 
 
 def _populate():

--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -45,7 +45,7 @@ class BuildBundles(LateTask):
 
     def set_site(self, site):
         """Set Nikola site."""
-        self.logger = utils.get_logger('bundles', utils.STDERR_HANDLER)
+        self.logger = utils.get_logger('bundles')
         if webassets is None and site.config['USE_BUNDLES']:
             utils.req_missing(['webassets'], 'USE_BUNDLES', optional=True)
             self.logger.warn('Setting USE_BUNDLES to False.')

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -66,7 +66,7 @@ class Galleries(Task, ImageProcessor):
         site.register_path_handler('gallery_global', self.gallery_global_path)
         site.register_path_handler('gallery_rss', self.gallery_rss_path)
 
-        self.logger = utils.get_logger('render_galleries', utils.STDERR_HANDLER)
+        self.logger = utils.get_logger('render_galleries')
 
         self.kw = {
             'thumbnail_size': site.config['THUMBNAIL_SIZE'],

--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -40,7 +40,7 @@ class ScaleImage(Task, ImageProcessor):
 
     def set_site(self, site):
         """Set Nikola site."""
-        self.logger = utils.get_logger('scale_images', utils.STDERR_HANDLER)
+        self.logger = utils.get_logger('scale_images')
         return super(ScaleImage, self).set_site(site)
 
     def process_tree(self, src, dst):

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -36,9 +36,9 @@ from mako.template import Template
 from markupsafe import Markup  # It's ok, Mako requires it
 
 from nikola.plugin_categories import TemplateSystem
-from nikola.utils import makedirs, get_logger, STDERR_HANDLER
+from nikola.utils import makedirs, get_logger
 
-LOGGER = get_logger('mako', STDERR_HANDLER)
+LOGGER = get_logger('mako')
 
 
 class MakoTemplates(TemplateSystem):

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -129,14 +129,10 @@ class ColorfulStderrHandler(ColorizedStderrHandler):
         return self._colorful
 
 
-def get_logger(name, handlers):
+def get_logger(name, handlers=None):
     """Get a logger with handlers attached."""
     l = logbook.Logger(name)
-    for h in handlers:
-        if isinstance(h, list):
-            l.handlers += h
-        else:
-            l.handlers.append(h)
+    l.handlers += STDERR_HANDLER
     return l
 
 
@@ -146,7 +142,7 @@ STDERR_HANDLER = [ColorfulStderrHandler(
 )]
 
 
-LOGGER = get_logger('Nikola', STDERR_HANDLER)
+LOGGER = get_logger('Nikola')
 STRICT_HANDLER = ExceptionHandler(ApplicationWarning, level='WARNING')
 
 USE_SLUGIFY = True
@@ -165,7 +161,7 @@ def showwarning(message, category, filename, lineno, file=None, line=None):
         n = category.__name__
     except AttributeError:
         n = str(category)
-    get_logger(n, STDERR_HANDLER).warn('{0}:{1}: {2}'.format(filename, lineno, message))
+    get_logger(n).warn('{0}:{1}: {2}'.format(filename, lineno, message))
 
 
 warnings.showwarning = showwarning

--- a/tests/data/translated_titles/conf.py
+++ b/tests/data/translated_titles/conf.py
@@ -719,21 +719,6 @@ COMMENT_SYSTEM_ID = "nikolademo"
 # (defaults to 1.)
 # DEMOTE_HEADERS = 1
 
-# You can configure the logging handlers installed as plugins or change the
-# log level of the default stdout handler.
-LOGGING_HANDLERS = {
-    'stderr': {'loglevel': 'WARNING', 'bubble': True},
-    # 'smtp': {
-    #     'from_addr': 'test-errors@example.com',
-    #     'recipients': ('test@example.com'),
-    #     'credentials':('testusername', 'password'),
-    #     'server_addr': ('127.0.0.1', 25),
-    #     'secure': (),
-    #     'level': 'DEBUG',
-    #     'bubble': True
-    # }
-}
-
 # Templates will use those filters, along with the defaults.
 # Consult your engine's documentation on filters if you need help defining
 # those.


### PR DESCRIPTION
Since we don’t support the entire log handlers thing, I dropped support for it, which also cleaned up all the imports and calls to `get_logger`.