### PR TITLE
Fix #2847 – non-fatal rev-parse failures in github_deploy

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Features
 Bugfixes
 --------
 
+* Make failures to get source commit hash non-fatal in
+  ``github_deploy`` (Issue #2847)
 * Less cryptic error when guessing format from extension in ``new_post``
   fails
 * Use Jupyter name more consistently in docs

--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -146,7 +146,14 @@ class CommandGitHubDeploy(Command):
                 else:
                     self.logger.notice('Nothing to commit to source branch.')
 
-            source_commit = uni_check_output(['git', 'rev-parse', source])
+            try:
+                source_commit = uni_check_output(['git', 'rev-parse', source])
+            except subprocess.CalledProcessError:
+                try:
+                    source_commit = uni_check_output(['git', 'rev-parse', 'HEAD'])
+                except subprocess.CalledProcessError:
+                    source_commit = '?'
+
             commit_message = (
                 '{0}\n\n'
                 'Source commit: {1}'


### PR DESCRIPTION
This is #2847. cc @asmeurer

*(note to future self: this goes to v7-maintenance as well)*