### PR TITLE
Add NIKOLA_SHOW_TRACEBACKS environment variable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Add ``NIKOLA_SHOW_TRACEBACKS`` environment variable that shows
+  full tracebacks instead of one-line summaries
 * Use ``PRETTY_URLS`` by default on all sites (Issue #1838)
 * Feed link generation is completely refactored (Issue #2844)
 * Added ``extract_metadata`` and ``split_metadata`` to the

--- a/docs/manual.txt
+++ b/docs/manual.txt
@@ -2862,7 +2862,8 @@ stderr.  Thus, you must use the different call.  (Alternatively, you could run
 with ``nikola build -v 2``, which disables the redirections.)
 
 To show more logging messages, as well as full tracebacks, you need to set an
-environment variable: ``NIKOLA_DEBUG=1``
+environment variable: ``NIKOLA_DEBUG=1``. If you want to only see tracebacks,
+set ``NIKOLA_SHOW_TRACEBACKS=1``.
 
 Shell Tab Completion
 ~~~~~~~~~~~~~~~~~~~~

--- a/nikola/__init__.py
+++ b/nikola/__init__.py
@@ -31,6 +31,7 @@ import sys
 
 __version__ = '8.0.0.dev0'
 DEBUG = bool(os.getenv('NIKOLA_DEBUG'))
+SHOW_TRACEBACKS = bool(os.getenv('NIKOLA_SHOW_TRACEBACKS'))
 
 if sys.version_info[0] == 2:
     raise Exception("Nikola does not support Python 2.")

--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -280,7 +280,7 @@ class NikolaTaskLoader(TaskLoader):
             signal('initialized').send(self.nikola)
         except Exception:
             LOGGER.error('Error loading tasks. An unhandled exception occurred.')
-            if self.nikola.debug:
+            if self.nikola.debug or self.nikola.show_tracebacks:
                 raise
             _print_exception()
             sys.exit(3)
@@ -369,7 +369,7 @@ class DoitNikola(DoitMain):
             return super(DoitNikola, self).run(cmd_args)
         except Exception:
             LOGGER.error('An unhandled exception occurred.')
-            if self.nikola.debug:
+            if self.nikola.debug or self.nikola.show_tracebacks:
                 raise
             _print_exception()
             return 1
@@ -412,7 +412,7 @@ def _print_exception():
     """Print an exception in a friendlier, shorter style."""
     etype, evalue, _ = sys.exc_info()
     LOGGER.error(''.join(traceback.format_exception(etype, evalue, None, limit=0, chain=False)).strip())
-    LOGGER.notice("To see more details, run Nikola in debug mode (set environment variable NIKOLA_DEBUG=1)")
+    LOGGER.notice("To see more details, run Nikola in debug mode (set environment variable NIKOLA_DEBUG=1) or use NIKOLA_SHOW_TRACEBACKS=1")
 
 
 if __name__ == "__main__":

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -60,7 +60,7 @@ from blinker import signal
 
 from .post import Post  # NOQA
 from .state import Persistor
-from . import DEBUG, filters, utils, hierarchy_utils, shortcodes
+from . import DEBUG, SHOW_TRACEBACKS, filters, utils, hierarchy_utils, shortcodes
 from .plugin_categories import (
     Command,
     LateTask,
@@ -413,6 +413,7 @@ class Nikola(object):
         self._MESSAGES = None
         self.filters = {}
         self.debug = DEBUG
+        self.show_tracebacks = SHOW_TRACEBACKS
         self.colorful = config.pop('__colorful__', False)
         self.invariant = config.pop('__invariant__', False)
         self.quiet = config.pop('__quiet__', False)


### PR DESCRIPTION
Not showing tracebacks to end-users is generally fine, but as a developer, it’s pretty annoying. On the other hand, ``NIKOLA_DEBUG=1`` floods the console with useless Yapsy debug messages.

So, the fix: add ``NIKOLA_SHOW_TRACEBACKS`` that shows tracebacks but no debug stuff (as a middle ground).