### PR TITLE
Fixed snap - error message about doit

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -114,6 +114,7 @@
 * `Tolu Sonaike <https://github.com/tolusonaike>`_
 * `Troy Toman <https://github.com/troytoman>`_
 * `Udo Spallek <https://github.com/udono>`_
+* `Uli Heller <https://github.com/uli-heller>`_
 * `Yamila Moreno <https://github.com/yamila-moreno>`_
 * `yarko <https://github.com/yarko>`_
 * `Yasuhiko Shiga <https://github.com/quoth>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,7 @@ New in v7-maintenance
 =====================
 
 * Fix crash when compiling empty ``.html`` posts (Issue #2851)
+* Fixed dependency to "doit" for snap creation
 
 New in v7.8.9
 =============

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -32,7 +32,7 @@ parts:
             - ghp-import2>=1.0.0
             - ws4py==0.3.5
             - watchdog==0.8.3
-            - doit>=0.28.0,<=0.29.0
+            - doit>=0.30.1
             - Pygments>=1.6
             - python-dateutil>=2.4.0
             - docutils>=0.12


### PR DESCRIPTION
pkg_resources.DistributionNotFound: The 'doit>=0.30.1' distribution was not found and is required by Nikola

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] Updated AUTHORS.txt
- [x] I tested my changes.

### Description

I created the snap using snapcraft.yaml and got this error when executing the snap:

```
...
  File "/snap/nikola/x1/lib/python3.5/site-packages/pkg_resources/__init__.py", line 862, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (doit 0.29.0 (/snap/nikola/x1/lib/python3.5/site-packages), Requirement.parse('doit>=0.30.1'), {'Nikola'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/snap/nikola/x1/bin/nikola", line 6, in <module>
    from pkg_resources import load_entry_point
...
  File "/snap/nikola/x1/lib/python3.5/site-packages/pkg_resources/__init__.py", line 857, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'doit>=0.30.1' distribution was not found and is required by Nikola
```

The change is trivial, so I didn't update CHANGES.txt.