### PR TITLE
Fixed cleanup of 'terminado' and 'tornado'

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,5 +53,5 @@ parts:
         build-packages: [libjpeg-dev]
         install: |
             find $SNAPCRAFT_PART_INSTALL -name '*.a' -exec rm {} \;
-            find $SNAPCRAFT_PART_INSTALL -name 'terminado' -type d -exec rm {} \;
-            find $SNAPCRAFT_PART_INSTALL -name 'tornado' -type d -exec rm {} \;
+            find $SNAPCRAFT_PART_INSTALL -name 'terminado' -type d -exec rm -rf {} \;
+            find $SNAPCRAFT_PART_INSTALL -name 'tornado' -type d -exec rm -rf {} \;

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -52,6 +52,6 @@ parts:
             - ipykernel>=4.0.0
         build-packages: [libjpeg-dev]
         install: |
-            find $SNAPCRAFT_PART_INSTALL -name '*.a' -exec rm {} \;
-            find $SNAPCRAFT_PART_INSTALL -name 'terminado' -type d -exec rm -rf {} \;
-            find $SNAPCRAFT_PART_INSTALL -name 'tornado' -type d -exec rm -rf {} \;
+            find $SNAPCRAFT_PART_INSTALL -name '*.a'|xargs -r rm
+            find $SNAPCRAFT_PART_INSTALL -name 'terminado' -type d|xargs -r rm -rf
+            find $SNAPCRAFT_PART_INSTALL -name 'tornado' -type d|xargs -r rm -rf


### PR DESCRIPTION
After creating the snap, these are directories containing files. So you
cannot delete them via 'rm'

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Without this change, you'll get an error message towards the end of the
creation of the snap. Unfortunately, I don't have a copy of it available at the moment.
I can recreate it when required.