### PR TITLE
snap: Use the current checkout as source of the snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: nikola
-version: 7.8.8
+version: 8-dev
 summary: A static website generator
 description: A static website generator
 confinement: strict
@@ -15,7 +15,7 @@ parts:
         plugin: dump
         source: scripts/snapcraft
     nikola:
-        source: git://github.com/getnikola/nikola.git
+        source: .
         stage-packages:
             - locales
             - libc-bin


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

With this PR, the currently active checkout is used when creating the snap package
instead of the head of the github master.

I'm not sure if this PR is actually a good idea. I just needed a similar approach to build a
snap package of nikola-7.8.9.