### PR TITLE
Switch to classic confinement for snap packages

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -114,6 +114,7 @@
 * `Tolu Sonaike <https://github.com/tolusonaike>`_
 * `Troy Toman <https://github.com/troytoman>`_
 * `Udo Spallek <https://github.com/udono>`_
+* `Will DeBerry <https://github.com/willdeberry>`_
 * `Yamila Moreno <https://github.com/yamila-moreno>`_
 * `yarko <https://github.com/yarko>`_
 * `Yasuhiko Shiga <https://github.com/quoth>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,6 +32,7 @@ Bugfixes
 * Use Jupyter name more consistently in docs
 * Support CODE_COLOR_SCHEME in Jupyter notebooks (Issue #2093)
 * Language was not passed to title and link generation for page indexes
+* Addressed issue with snaps not allowing certain functions to work properly.
 
 Removed features
 ----------------

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: nikola
 version: 8-dev
 summary: A static website generator
 description: A static website generator
-confinement: strict
+confinement: classic
 grade: stable
 
 apps:


### PR DESCRIPTION
This allows things like `nikola deploy` to work again since they would have
access to the running system's version of `rsync`.

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
