### PR TITLE
Eddiefiggie patch 1

### DIFF
--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -449,7 +449,7 @@ class CommandNewPost(Command):
             if editor:
                 subprocess.call(to_run)
             else:
-                LOGGER.error('$EDITOR environmental variable not set within the operating system. Edits for posts must be made manually.')
+                LOGGER.error('$EDITOR not set within the operating system, cannot edit the post with \'-e\'.  Post must be altered manually.')
 
     def filter_post_pages(self, compiler, is_post):
         """Return the correct entry from post_pages.

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -449,7 +449,7 @@ class CommandNewPost(Command):
             if editor:
                 subprocess.call(to_run)
             else:
-                LOGGER.error('$EDITOR not set, cannot edit the post.  Please do it manually.')
+                LOGGER.error('$EDITOR environmental variable not set within the operating system. Edits for posts must be made manually.')
 
     def filter_post_pages(self, compiler, is_post):
         """Return the correct entry from post_pages.


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

When your environmental variable $EDITOR is not mapped, and you use the following command "nikola new_post -e", you currently get the following error message: 

"$EDITOR not set, cannot edit the post.  Please do it manually."

As a user, I was a little confused by this.  The first sentence sent me searching for a Nikola setting where I can set the preferred editor.  The second sentence had me contemplating if I needed to edit the "setting" within Nikola manually or the post I just made.  These were first thoughts when I read the message.

I thought, perhaps, you might use this proposed message so to be a bit more explicit.  I tried to keep the words to a minimum while still being as clear as possible.

"$EDITOR not set within the operating system, cannot edit the post with \'-e\'.  Post must be altered manually."

I'm hopeful this might prove valuable to some users in the future.  