### PR TITLE
Exception when using `_link("index", None)` in template

### DIFF
--- a/nikola/plugins/task/indexes.py
+++ b/nikola/plugins/task/indexes.py
@@ -98,7 +98,7 @@ Example:
             # Interpret argument as page number
             try:
                 page_number = int(classification)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
         return [self.site.config['INDEX_PATH'](lang)], 'always', page_number
 


### PR DESCRIPTION
This is caused because the path handler for `index` does `int(classification)` (where `classification` is `None`) and only watches for `ValueError`, while `int(None)` raises a `TypeError`. This bug was introduced in 50c43b7d2.
