### PR TITLE
Add a reasonable self.logger to all plugins

### DIFF
--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -26,14 +26,15 @@
 
 """Nikola plugin categories."""
 
-import sys
-import os
 import io
+import os
+import sys
 
-from yapsy.IPlugin import IPlugin
+import logbook
 from doit.cmd_base import Command as DoitCommand
+from yapsy.IPlugin import IPlugin
 
-from .utils import LOGGER, first_line, req_missing
+from .utils import LOGGER, first_line, get_logger, req_missing
 
 try:
     import typing  # NOQA
@@ -63,10 +64,15 @@ __all__ = (
 class BasePlugin(IPlugin):
     """Base plugin class."""
 
+    logger = None
+
     def set_site(self, site):
         """Set site, which is a Nikola instance."""
         self.site = site
         self.inject_templates()
+        self.logger = get_logger(self.name)
+        if not site.debug:
+            self.logger.level = logbook.base.WARNING
 
     def inject_templates(self):
         """Inject 'templates/<engine>' (if exists) very early in the theme chain."""

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -55,7 +55,7 @@ import webbrowser
 import pkg_resources
 
 from nikola.plugin_categories import Command
-from nikola.utils import dns_sd, req_missing, get_logger, get_theme_path
+from nikola.utils import dns_sd, req_missing, get_theme_path
 LRJS_PATH = os.path.join(os.path.dirname(__file__), 'livereload.js')
 
 if sys.platform == 'win32':
@@ -66,7 +66,6 @@ class CommandAuto(Command):
     """Automatic rebuilds for Nikola."""
 
     name = "auto"
-    logger = None
     has_server = True
     doc_purpose = "builds and serves a site; automatically detects site changes, rebuilds, and optionally refreshes a browser"
     dns_sd = None
@@ -116,7 +115,6 @@ class CommandAuto(Command):
 
     def _execute(self, options, args):
         """Start the watcher."""
-        self.logger = get_logger('auto')
         self.sockets = []
         self.rebuild_queue = asyncio.Queue()
         self.last_rebuild = datetime.datetime.now()

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -43,7 +43,6 @@ import lxml.html
 import requests
 
 from nikola.plugin_categories import Command
-from nikola.utils import get_logger
 
 
 def _call_nikola_list(site, cache=None):
@@ -103,7 +102,6 @@ class CommandCheck(Command):
     """Check the generated site."""
 
     name = "check"
-    logger = None
 
     doc_usage = "[-v] (-l [--find-sources] [-r] | -f [--clean-files])"
     doc_purpose = "check links and files in the generated site"
@@ -158,7 +156,6 @@ class CommandCheck(Command):
 
     def _execute(self, options, args):
         """Check the generated site."""
-        self.logger = get_logger('check')
 
         if not options['links'] and not options['files'] and not options['clean']:
             print(self.help())

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -156,7 +156,6 @@ class CommandCheck(Command):
 
     def _execute(self, options, args):
         """Check the generated site."""
-
         if not options['links'] and not options['files'] and not options['clean']:
             print(self.help())
             return False

--- a/nikola/plugins/command/deploy.py
+++ b/nikola/plugins/command/deploy.py
@@ -37,7 +37,7 @@ import time
 from blinker import signal
 
 from nikola.plugin_categories import Command
-from nikola.utils import get_logger, clean_before_deployment
+from nikola.utils import clean_before_deployment
 
 
 class CommandDeploy(Command):
@@ -48,11 +48,9 @@ class CommandDeploy(Command):
     doc_usage = "[preset [preset...]]"
     doc_purpose = "deploy the site"
     doc_description = "Deploy the site by executing deploy commands from the presets listed on the command line.  If no presets are specified, `default` is executed."
-    logger = None
 
     def _execute(self, command, args):
         """Execute the deploy command."""
-        self.logger = get_logger('deploy')
         # Get last successful deploy date
         timestamp_path = os.path.join(self.site.config['CACHE_FOLDER'], 'lastdeploy')
 

--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -32,7 +32,7 @@ from textwrap import dedent
 
 from nikola.plugin_categories import Command
 from nikola.plugins.command.check import real_scan_files
-from nikola.utils import get_logger, req_missing, clean_before_deployment
+from nikola.utils import req_missing, clean_before_deployment
 from nikola.__main__ import main
 from nikola import __version__
 
@@ -76,11 +76,9 @@ class CommandGitHubDeploy(Command):
             'help': 'Commit message (default: Nikola auto commit.)',
         },
     ]
-    logger = None
 
     def _execute(self, options, args):
         """Run the deployment."""
-        self.logger = get_logger(CommandGitHubDeploy.name)
 
         # Check if ghp-import is installed
         check_ghp_import_installed()

--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -79,7 +79,6 @@ class CommandGitHubDeploy(Command):
 
     def _execute(self, options, args):
         """Run the deployment."""
-
         # Check if ghp-import is installed
         check_ghp_import_installed()
 

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -46,7 +46,7 @@ except ImportError:
 
 
 from nikola.plugin_categories import Command
-from nikola.utils import dns_sd, get_logger
+from nikola.utils import dns_sd
 
 
 class IPv6Server(HTTPServer):
@@ -61,7 +61,6 @@ class CommandServe(Command):
     name = "serve"
     doc_usage = "[options]"
     doc_purpose = "start the test webserver"
-    logger = None
     dns_sd = None
 
     cmd_options = (
@@ -120,7 +119,6 @@ class CommandServe(Command):
 
     def _execute(self, options, args):
         """Start test server."""
-        self.logger = get_logger('serve')
         out_dir = self.site.config['OUTPUT_FOLDER']
         if not os.path.isdir(out_dir):
             self.logger.error("Missing '{0}' folder?".format(out_dir))

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -42,7 +42,7 @@ except ImportError:
 
 from nikola import shortcodes as sc
 from nikola.plugin_categories import PageCompiler
-from nikola.utils import makedirs, req_missing, get_logger, LocaleBorg
+from nikola.utils import makedirs, req_missing, LocaleBorg
 
 
 class CompileIPynb(PageCompiler):
@@ -53,11 +53,6 @@ class CompileIPynb(PageCompiler):
     demote_headers = True
     default_kernel = 'python3'
     supports_metadata = True
-
-    def set_site(self, site):
-        """Set Nikola site."""
-        self.logger = get_logger('compile_ipynb')
-        super(CompileIPynb, self).set_site(site)
 
     def _compile_string(self, nb_json):
         """Export notebooks as HTML strings."""

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -185,10 +185,6 @@ class CompileRest(PageCompiler):
             self.config_dependencies.append(plugin_info.name)
             plugin_info.plugin_object.short_help = plugin_info.description
 
-        self.logger = get_logger('compile_rest')
-        if not site.debug:
-            self.logger.level = logbook.base.WARNING
-
 
 def get_observer(settings):
     """Return an observer for the docutils Reporter."""

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -45,7 +45,6 @@ from nikola.metadata_extractors import MetaCondition
 from nikola.plugin_categories import PageCompiler
 from nikola.utils import (
     unicode_str,
-    get_logger,
     makedirs,
     write_metadata,
     LocaleBorg,

--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -45,13 +45,12 @@ class BuildBundles(LateTask):
 
     def set_site(self, site):
         """Set Nikola site."""
-        self.logger = utils.get_logger('bundles')
+        super(BuildBundles, self).set_site(site)
         if webassets is None and site.config['USE_BUNDLES']:
             utils.req_missing(['webassets'], 'USE_BUNDLES', optional=True)
             self.logger.warn('Setting USE_BUNDLES to False.')
             site.config['USE_BUNDLES'] = False
             site._GLOBAL_CONTEXT['use_bundles'] = False
-        super(BuildBundles, self).set_site(site)
 
     def gen_tasks(self):
         """Bundle assets using WebAssets."""

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -62,11 +62,10 @@ class Galleries(Task, ImageProcessor):
 
     def set_site(self, site):
         """Set Nikola site."""
+        super(Galleries, self).set_site(site)
         site.register_path_handler('gallery', self.gallery_path)
         site.register_path_handler('gallery_global', self.gallery_global_path)
         site.register_path_handler('gallery_rss', self.gallery_rss_path)
-
-        self.logger = utils.get_logger('render_galleries')
 
         self.kw = {
             'thumbnail_size': site.config['THUMBNAIL_SIZE'],
@@ -103,8 +102,6 @@ class Galleries(Task, ImageProcessor):
         self.find_galleries()
         # Create self.gallery_links
         self.create_galleries_paths()
-
-        return super(Galleries, self).set_site(site)
 
     def _find_gallery_path(self, name):
         # The system using self.proper_gallery_links and self.improper_gallery_links

--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -38,11 +38,6 @@ class ScaleImage(Task, ImageProcessor):
 
     name = "scale_images"
 
-    def set_site(self, site):
-        """Set Nikola site."""
-        self.logger = utils.get_logger('scale_images')
-        return super(ScaleImage, self).set_site(site)
-
     def process_tree(self, src, dst):
         """Process all images in a src tree and put the (possibly) rescaled images in the dst folder."""
         thumb_fmt = self.kw['image_thumbnail_format']

--- a/tests/base.py
+++ b/tests/base.py
@@ -167,6 +167,7 @@ class FakeSite(object):
     def __init__(self):
         self.template_system = self
         self.invariant = False
+        self.debug = True
         self.config = {
             'DISABLED_PLUGINS': [],
             'EXTRA_PLUGINS': [],


### PR DESCRIPTION
We were using self.logger in some plugins and it was never actually initialized.

This fixes that and removes some code it makes redundant in the rest compiler.