### PR TITLE
Fix itemprop errors from w3c validator in jinja themes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,7 +38,7 @@ Features
 Bugfixes
 --------
 
-* Fix w3c validation errors for itemscope entries in jinja themes
+* Fix w3c validation errors for itemscope entries in default themes
 * Hide “Incomplete language” message for overrides of complete
   languages
 * Handle '/' and other absolute paths better in POSTS / PAGES / TRANSLATIONS

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,7 @@ Features
 Bugfixes
 --------
 
+* Fix w3c validation errors for itemscope entries in jinja themes
 * Hide “Incomplete language” message for overrides of complete
   languages
 * Handle '/' and other absolute paths better in POSTS / PAGES / TRANSLATIONS

--- a/nikola/data/themes/base-jinja/templates/index.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index.tmpl
@@ -26,7 +26,7 @@
 {% endif %}
 <div class="postindex">
 {% for post in posts %}
-    <article class="h-entry post-{{ post.meta('type') }}">
+    <article class="h-entry post-{{ post.meta('type') }}" itemscope="itemscope" itemtype="http://schema.org/Article">
     <header>
         <h1 class="p-name entry-title"><a href="{{ post.permalink() }}" class="u-url">{{ post.title()|e }}</a></h1>
         <div class="metadata">

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -26,7 +26,7 @@
 % endif
 <div class="postindex">
 % for post in posts:
-    <article class="h-entry post-${post.meta('type')}">
+    <article class="h-entry post-${post.meta('type')}" itemscope="itemscope" itemtype="http://schema.org/Article">
     <header>
         <h1 class="p-name entry-title"><a href="${post.permalink()}" class="u-url">${post.title()|h}</a></h1>
         <div class="metadata">

--- a/nikola/data/themes/bootblog4-jinja/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/index.tmpl
@@ -26,7 +26,7 @@
 {% endif %}
 <div class="postindex">
 {% for post in posts %}
-    <article class="h-entry post-{{ post.meta('type') }}">
+    <article class="h-entry post-{{ post.meta('type') }}" itemscope="itemscope" itemtype="http://schema.org/Article">
     <header>
         <h1 class="p-name entry-title"><a href="{{ post.permalink() }}" class="u-url">{{ post.title()|e }}</a></h1>
         <div class="metadata">

--- a/nikola/data/themes/bootblog4/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4/templates/index.tmpl
@@ -26,7 +26,7 @@
 % endif
 <div class="postindex">
 % for post in posts:
-    <article class="h-entry post-${post.meta('type')}">
+    <article class="h-entry post-${post.meta('type')}" itemscope="itemscope" itemtype="http://schema.org/Article">
     <header>
         <h1 class="p-name entry-title"><a href="${post.permalink()}" class="u-url">${post.title()|h}</a></h1>
         <div class="metadata">


### PR DESCRIPTION
https://validator.w3c.org flags itemprop attributes as an error
on any element that specifies them unless the itemtype attribute
in a parent element references a valid schema. The validation
error is:

"Error: the itemprop attribute was specified but the element is
 not a property of any item"

This change fixes the validation error.

### Pull Request Checklist

- [/] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [/] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [/] I tested my changes.

### Description
