### PR TITLE
fix #2997 strip ws from igored assets filenames

### DIFF
--- a/nikola/plugins/task/copy_assets.py
+++ b/nikola/plugins/task/copy_assets.py
@@ -67,6 +67,7 @@ class CopyAssets(Task):
         theme_ini = utils.parse_theme_meta(main_theme)
         if theme_ini:
             ignored_assets = theme_ini.get("Nikola", "ignored_assets", fallback='').split(',')
+            ignored_assets = [asset_name.strip() for asset_name in ignored_assets]
         else:
             ignored_assets = []
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
Fix minor annoyance #2997. Strip whitespace from filenames in ignored_assets list in theme meta files.