### PR TITLE
Fix #3000 -- add / properly if there’s a query string (in nikola serve)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,8 @@ Features
 Bugfixes
 --------
 
+* Handle trailing slash redirects with query strings correctly in
+  ``nikola serve`` (Issue #3000)
 * Fix w3c validation errors for itemscope entries in default themes
 * Hide “Incomplete language” message for overrides of complete
   languages

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -217,7 +217,9 @@ class OurHTTPRequestHandler(SimpleHTTPRequestHandler):
             if not self.path.endswith('/'):
                 # redirect browser - doing basically what apache does
                 self.send_response(301)
-                self.send_header("Location", self.path + "/")
+                path_parts = list(self.path.partition('?'))
+                path_parts[0] += '/'
+                self.send_header("Location", ''.join(path_parts))
                 # begin no-cache patch
                 # For redirects.  With redirects, caching is even worse and can
                 # break more.  Especially with 301 Moved Permanently redirects,


### PR DESCRIPTION
Fixes #3000. This used to be a much dumber fix — but issue #3000 deserves better.