### PR TITLE
Fix #3006 — use documented dateutil API for time zone list

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,7 @@ Features
 Bugfixes
 --------
 
+* Use documented dateutil API for time zone list (Issue #3006)
 * Handle trailing slash redirects with query strings correctly in
   ``nikola serve`` (Issue #3000)
 * Fix w3c validation errors for itemscope entries in default themes

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -37,7 +37,6 @@ import dateutil.tz
 import dateutil.zoneinfo
 from mako.template import Template
 from pkg_resources import resource_filename
-import tarfile
 
 import nikola
 from nikola.nikola import DEFAULT_INDEX_READ_MORE_LINK, DEFAULT_FEED_READ_MORE_LINK, LEGAL_VALUES, urlsplit, urlunsplit
@@ -384,15 +383,15 @@ class CommandInit(Command):
 
                 if tz is None:
                     print("    WARNING: Time zone not found.  Searching list of time zones for a match.")
-                    zonesfile = tarfile.open(fileobj=dateutil.zoneinfo.getzoneinfofile_stream())
-                    zonenames = [zone for zone in zonesfile.getnames() if answer.lower() in zone.lower()]
-                    if len(zonenames) == 1:
-                        tz = dateutil.tz.gettz(zonenames[0])
-                        answer = zonenames[0]
+                    all_zones = dateutil.zoneinfo.get_zonefile_instance().zones
+                    matching_zones = [zone for zone in all_zones if answer.lower() in zone.lower()]
+                    if len(matching_zones) == 1:
+                        tz = dateutil.tz.gettz(matching_zones[0])
+                        answer = matching_zones[0]
                         print("    Picking '{0}'.".format(answer))
-                    elif len(zonenames) > 1:
+                    elif len(matching_zones) > 1:
                         print("    The following time zones match your query:")
-                        print('        ' + '\n        '.join(zonenames))
+                        print('        ' + '\n        '.join(matching_zones))
                         continue
 
                 if tz is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 doit>=0.30.1
 Pygments>=1.6
 Pillow>=2.4.0
-python-dateutil>=2.4.0
+python-dateutil>=2.6.0
 docutils>=0.13
 mako>=1.0.0
 Markdown>=2.4.0


### PR DESCRIPTION
This fixes #3006 on our part, although there is still an issue with Gentoo packages for `dateutil`. This will be backported for v7 later.

cc @michaelb42 @hartwork @felixfontein @mgorny