### PR TITLE
Don’t silence errors that occur while reading metadata

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,6 +40,8 @@ Features
 Bugfixes
 --------
 
+* Don’t silence syntax errors and other exceptions that occur while
+  reading metadata
 * Use documented dateutil API for time zone list (Issue #3006)
 * Handle trailing slash redirects with query strings correctly in
   ``nikola serve`` (Issue #3000)

--- a/nikola/metadata_extractors.py
+++ b/nikola/metadata_extractors.py
@@ -126,7 +126,7 @@ def default_metadata_extractors_by() -> dict:
     return d
 
 
-def _register_default(extractor: MetadataExtractor) -> MetadataExtractor:
+def _register_default(extractor: type) -> type:
     """Register a default extractor."""
     _default_extractors.append(extractor())
     return extractor

--- a/nikola/metadata_extractors.py
+++ b/nikola/metadata_extractors.py
@@ -239,6 +239,11 @@ class FilenameRegexMetadata(MetadataExtractor):
     priority = MetaPriority.fallback
     conditions = [(MetaCondition.config_bool, 'FILE_METADATA_REGEXP')]
 
+    def _extract_metadata_from_text(self, source_text: str) -> dict:
+        """Extract metadata from text."""
+        # This extractor does not use the source text, and as such, this method returns an empty dict.
+        return {}
+
     def extract_filename(self, filename: str, lang: str) -> dict:
         """Try to read the metadata from the filename based on the given re.
 

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -959,7 +959,6 @@ def get_metadata_from_file(source_path, post, config, lang, metadata_extractors_
     except Exception:  # The file may not exist, for multilingual sites
         return {}, None
 
-
     meta = {}
     used_extractor = None
     for priority in metadata_extractors.MetaPriority:

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -952,34 +952,35 @@ def get_metadata_from_file(source_path, post, config, lang, metadata_extractors_
             source_path += '.' + lang
         with io.open(source_path, "r", encoding="utf-8-sig") as meta_file:
             source_text = meta_file.read()
-
-        meta = {}
-        used_extractor = None
-        for priority in metadata_extractors.MetaPriority:
-            found_in_priority = False
-            for extractor in metadata_extractors_by['priority'].get(priority, []):
-                if not metadata_extractors.check_conditions(post, source_path, extractor.conditions, config, source_text):
-                    continue
-                extractor.check_requirements()
-                new_meta = extractor.extract_text(source_text)
-                if new_meta:
-                    found_in_priority = True
-                    used_extractor = extractor
-                    # Map metadata from other platforms to names Nikola expects (Issue #2817)
-                    map_metadata(new_meta, extractor.map_from, config)
-
-                    meta.update(new_meta)
-                    break
-
-            if found_in_priority:
-                break
-        return meta, used_extractor
     except (UnicodeDecodeError, UnicodeEncodeError):
         msg = 'Error reading {0}: Nikola only supports UTF-8 files'.format(source_path)
         LOGGER.error(msg)
         raise ValueError(msg)
     except Exception:  # The file may not exist, for multilingual sites
         return {}, None
+
+
+    meta = {}
+    used_extractor = None
+    for priority in metadata_extractors.MetaPriority:
+        found_in_priority = False
+        for extractor in metadata_extractors_by['priority'].get(priority, []):
+            if not metadata_extractors.check_conditions(post, source_path, extractor.conditions, config, source_text):
+                continue
+            extractor.check_requirements()
+            new_meta = extractor.extract_text(source_text)
+            if new_meta:
+                found_in_priority = True
+                used_extractor = extractor
+                # Map metadata from other platforms to names Nikola expects (Issue #2817)
+                map_metadata(new_meta, extractor.map_from, config)
+
+                meta.update(new_meta)
+                break
+
+        if found_in_priority:
+            break
+    return meta, used_extractor
 
 
 def get_metadata_from_meta_file(path, post, config, lang, metadata_extractors_by=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,13 +95,15 @@ class GetMetaTest(unittest.TestCase):
         self.assertFalse('description' in meta)
 
     def test_extracting_metadata_from_filename(self):
+        dummy_opener_mock = mock.mock_open(read_data="No metadata in the file!")
+
         post = dummy()
         post.source_path = '2013-01-23-the_slug-dub_dub_title.md'
         post.metadata_path = '2013-01-23-the_slug-dub_dub_title.meta'
         post.config['FILE_METADATA_REGEXP'] = r'(?P<date>\d{4}-\d{2}-\d{2})-(?P<slug>.*)-(?P<title>.*)\.md'
         for unslugify, title in ((True, 'Dub dub title'), (False, 'dub_dub_title')):
             post.config['FILE_METADATA_UNSLUGIFY_TITLES'] = unslugify
-            with mock.patch('nikola.post.io.open', create=True):
+            with mock.patch('nikola.post.io.open', dummy_opener_mock, create=True):
                 meta = get_meta(post, None)[0]
 
             self.assertEqual(title, meta['title'])
@@ -109,10 +111,11 @@ class GetMetaTest(unittest.TestCase):
             self.assertEqual('2013-01-23', meta['date'])
 
     def test_get_meta_slug_only_from_filename(self):
+        dummy_opener_mock = mock.mock_open(read_data="No metadata in the file!")
         post = dummy()
         post.source_path = 'some/path/the_slug.md'
         post.metadata_path = 'some/path/the_slug.meta'
-        with mock.patch('nikola.post.io.open', create=True):
+        with mock.patch('nikola.post.io.open', dummy_opener_mock, create=True):
             meta = get_meta(post, None)[0]
 
         self.assertEqual('the_slug', meta['slug'])
@@ -218,10 +221,7 @@ class TranslatableSettingsTest(unittest.TestCase):
         S.default_lang = 'xx'
         S.lang = 'xx'
 
-        try:
-            u = unicode(S)
-        except NameError:  # Python 3
-            u = str(S)
+        u = str(S)
 
         cn = S()      # no language specified
         cr = S('xx')  # real language specified
@@ -243,10 +243,7 @@ class TranslatableSettingsTest(unittest.TestCase):
         S.default_lang = 'xx'
         S.lang = 'xx'
 
-        try:
-            u = unicode(S)
-        except NameError:  # Python 3
-            u = str(S)
+        u = str(S)
 
         cn = S()
         cx = S('xx')
@@ -268,10 +265,7 @@ class TranslatableSettingsTest(unittest.TestCase):
         S.default_lang = 'xx'
         S.lang = 'xx'
 
-        try:
-            u = unicode(S)
-        except NameError:  # Python 3
-            u = str(S)
+        u = str(S)
 
         cn = S()
 


### PR DESCRIPTION
I tried to create a YAML version of *Dr Nikola’s Vendetta* while debugging an issue. I had a silent failure (no metadata was read). Poking around with `pdb` revealed a syntax error (apostrophes clashing).

Turns out there was a `try-except` whose clause was too broad. New output is much more useful:

```pytb
Scanning posts.....[2018-04-14T17:37:13Z] ERROR: scan_posts: Error reading post pages/dr-nikolas-vendetta.rst
[2018-04-14T17:37:13Z] ERROR: Nikola: Error reading timeline
[2018-04-14T17:37:13Z] ERROR: Nikola: Error loading tasks. An unhandled exception occurred.
Traceback (most recent call last):
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/doit/doit_cmd.py", line 172, in run
    return command.parse_execute(args)
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/doit/cmd_base.py", line 127, in parse_execute
    return self.execute(params, args)
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/doit/cmd_base.py", line 389, in execute
    self, params, args)
  File "/Users/kwpolska/git/nikola/nikola/__main__.py", line 277, in load_tasks
    self.nikola.gen_tasks('render_site', "Task", 'Group of tasks to render the site.'))
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/doit/loader.py", line 313, in generate_tasks
    for task_dict, x_doc in flat_generator(gen_result, gen_doc):
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/doit/loader.py", line 26, in flat_generator
    for item in gen:
  File "/Users/kwpolska/git/nikola/nikola/nikola.py", line 1902, in gen_tasks
    for task in flatten(pluginInfo.plugin_object.gen_tasks()):
  File "/Users/kwpolska/git/nikola/nikola/nikola.py", line 1896, in flatten
    for t in task:
  File "/Users/kwpolska/git/nikola/nikola/plugins/task/tagcloud.py", line 43, in gen_tasks
    self.site.scan_posts()
  File "/Users/kwpolska/git/nikola/nikola/nikola.py", line 2021, in scan_posts
    timeline = p.plugin_object.scan()
  File "/Users/kwpolska/git/nikola/nikola/plugins/misc/scan_posts.py", line 101, in scan
    metadata_extractors_by=self.site.metadata_extractors_by
  File "/Users/kwpolska/git/nikola/nikola/post.py", line 164, in __init__
    default_metadata, default_used_extractor = get_meta(self, lang=None)
  File "/Users/kwpolska/git/nikola/nikola/post.py", line 1032, in get_meta
    new_meta, used_extractor = get_metadata_from_file(post.source_path, post, config, lang, metadata_extractors_by)
  File "/Users/kwpolska/git/nikola/nikola/post.py", line 971, in get_metadata_from_file
    new_meta = extractor.extract_text(source_text)
  File "/Users/kwpolska/git/nikola/nikola/plugin_categories.py", line 435, in extract_text
    meta = self._extract_metadata_from_text(split[0])
  File "/Users/kwpolska/git/nikola/nikola/metadata_extractors.py", line 196, in _extract_metadata_from_text
    meta = yaml.safe_load(source_text[4:])
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/__init__.py", line 94, in safe_load
    return load(stream, SafeLoader)
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/__init__.py", line 72, in load
    return loader.get_single_data()
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/constructor.py", line 35, in get_single_data
    node = self.get_single_node()
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/composer.py", line 36, in get_single_node
    document = self.compose_document()
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/composer.py", line 55, in compose_document
    node = self.compose_node(None, None)
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/composer.py", line 84, in compose_node
    node = self.compose_mapping_node(anchor)
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/composer.py", line 127, in compose_mapping_node
    while not self.check_event(MappingEndEvent):
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/parser.py", line 98, in check_event
    self.current_event = self.state()
  File "/Users/kwpolska/virtualenvs/nikola/lib/python3.6/site-packages/yaml/parser.py", line 439, in parse_block_mapping_key
    "expected <block end>, but found %r" % token.id, token.start_mark)
yaml.parser.ParserError: while parsing a block mapping
  in "<unicode string>", line 1, column 1:
    title: 'A BID FOR FORTUNE OR; DR ...
    ^
expected <block end>, but found '<scalar>'
  in "<unicode string>", line 1, column 42:
     ...  BID FOR FORTUNE OR; DR. NIKOLA'S VENDETTA'
                                         ^
```