### PR TITLE
Fixing RSS_PATH behavior.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Fixing behavior of RSS_PATH to do what the documentation
+  says it does (Issue #3024)
 * Add support for fragments in path handlers (Issue #3032)
 * Recognize both TEASER_END and (new) END_TEASER (Issue #3010)
 * New MARKDOWN_EXTENSION_CONFIGS setting (Issue #2970)

--- a/nikola/plugins/task/indexes.py
+++ b/nikola/plugins/task/indexes.py
@@ -91,7 +91,7 @@ Example:
     def get_path(self, classification, lang, dest_type='page'):
         """Return a path for the given classification."""
         if dest_type == 'rss':
-            return [self.site.config['RSS_PATH'](lang)], True
+            return [self.site.config['RSS_PATH'](lang), 'rss'], 'auto'
         # 'page' (index) or 'feed' (Atom)
         page_number = None
         if dest_type == 'page':


### PR DESCRIPTION
Fixes #3024 so that `RSS_PATH` behaves as advertised.