### PR TITLE
Add element role to navigation bar

### DIFF
--- a/nikola/data/themes/bootstrap3-jinja/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap3-jinja/templates/base.tmpl
@@ -32,7 +32,7 @@
             {% endif %}
             </a>
         </div><!-- /.navbar-header -->
-        <div class="collapse navbar-collapse" id="bs-navbar" aria-expanded="false">
+        <div class="collapse navbar-collapse" id="bs-navbar" role="navigation" aria-expanded="false">
             <ul class="nav navbar-nav">
                 {{ base.html_navigation_links() }}
                 {{ template_hooks['menu']() }}

--- a/nikola/data/themes/bootstrap3/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap3/templates/base.tmpl
@@ -32,7 +32,7 @@ ${template_hooks['extra_head']()}
             % endif
             </a>
         </div><!-- /.navbar-header -->
-        <div class="collapse navbar-collapse" id="bs-navbar" aria-expanded="false">
+        <div class="collapse navbar-collapse" id="bs-navbar" role="navigation" aria-expanded="false">
             <ul class="nav navbar-nav">
                 ${base.html_navigation_links()}
                 ${template_hooks['menu']()}


### PR DESCRIPTION
Add element `role` to the navigation bar to avoid the validation
error: `Element div is missing one or more of the following
attributes: role.`

Fixes #3035
