### PR TITLE
Add ALL_PAGE_DEPENDENCIES feature to clean up global context

### DIFF
--- a/docs/template-variables.rst
+++ b/docs/template-variables.rst
@@ -88,7 +88,6 @@ Name                                Type                                Descript
 ``posts_section_title``             TranslatableSetting<str>            ``POSTS_SECTION_TITLE`` setting
 ``rel_link``                        function                            ``Nikola.rel_link`` function
 ``rss_link``                        str                                 ``RSS_LINK`` setting
-``rss_path``                        TranslatableSetting<str>            ``RSS_PATH`` setting
 ``search_form``                     TranslatableSetting<str>            ``SEARCH_FORM`` setting
 ``set_locale``                      function                            ``LocaleBorg.set_locale`` function (or None if not available)
 ``show_blog_title``                 bool                                ``SHOW_BLOG_TITLE`` setting

--- a/docs/template-variables.rst
+++ b/docs/template-variables.rst
@@ -93,8 +93,6 @@ Name                                Type                                Descript
 ``show_blog_title``                 bool                                ``SHOW_BLOG_TITLE`` setting
 ``show_sourcelink``                 bool                                ``SHOW_SOURCELINK`` setting
 ``site_has_comments``               bool                                whether or not a comment system is configured
-``SLUG_AUTHOR_PATH``                bool                                ``SLUG_AUTHOR_PATH`` setting
-``SLUG_TAG_PATH``                   bool                                ``SLUG_TAG_PATH`` setting
 ``social_buttons_code``             TranslatableSetting<str>            ``SOCIAL_BUTTONS_CODE`` setting
 ``sort_posts``                      function                            ``utils.sort_posts`` function
 ``template_hooks``                  dict<str, TemplateHookRegistry>     Template hooks registered by plugins

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -603,7 +603,7 @@ class Nikola(object):
         self._GLOBAL_CONTEXT = {}
 
         # dependencies for all pages, not included in global context
-        self.ALL_PAGE_DEPENDENCIES = {}
+        self.ALL_PAGE_DEPS = {}
 
         self.config.update(config)
 
@@ -687,9 +687,9 @@ class Nikola(object):
                                              'front_index_header',
                                              )
 
-        self._ALL_PAGE_DEPENDENCIES_TRANSLATABLE = ('rss_path',
-                                                    'rss_filename_base',
-                                                    )
+        self._ALL_PAGE_DEPS_TRANSLATABLE = ('rss_path',
+                                            'rss_filename_base',
+                                            )
         # WARNING: navigation_links SHOULD NOT be added to the list above.
         #          Themes ask for [lang] there and we should provide it.
 
@@ -852,7 +852,7 @@ class Nikola(object):
             self.register_filter(filter_name_format.format(filter_name), filter_definition)
 
         self._set_global_context_from_config()
-        self._set_all_page_dependencies_from_config()
+        self._set_all_page_deps_from_config()
         # Read data files only if a site exists (Issue #2708)
         if self.configured:
             self._set_global_context_from_data()
@@ -1170,18 +1170,18 @@ class Nikola(object):
         # Offer global_data as an alias for data (Issue #2488)
         self._GLOBAL_CONTEXT['global_data'] = self._GLOBAL_CONTEXT['data']
 
-    def _set_all_page_dependencies_from_config(self):
-        """Create dependencies for all pages from configuration.
+    def _set_all_page_deps_from_config(self):
+        """Save dependencies for all pages from configuration.
 
         Changes of values in this dict will force a rebuild of all pages.
         Unlike global context, contents are NOT available to templates.
         """
-        self.ALL_PAGE_DEPENDENCIES['atom_extension'] = self.config.get('ATOM_EXTENSION')
-        self.ALL_PAGE_DEPENDENCIES['rss_extension'] = self.config.get('RSS_EXTENSION')
-        self.ALL_PAGE_DEPENDENCIES['rss_path'] = self.config.get('RSS_PATH')
-        self.ALL_PAGE_DEPENDENCIES['rss_filename_base'] = self.config.get('RSS_FILENAME_BASE')
-        self.ALL_PAGE_DEPENDENCIES['slug_author_path'] = self.config.get('SLUG_AUTHOR_PATH')
-        self.ALL_PAGE_DEPENDENCIES['slug_tag_path'] = self.config.get('SLUG_TAG_PATH')
+        self.ALL_PAGE_DEPS['atom_extension'] = self.config.get('ATOM_EXTENSION')
+        self.ALL_PAGE_DEPS['rss_extension'] = self.config.get('RSS_EXTENSION')
+        self.ALL_PAGE_DEPS['rss_path'] = self.config.get('RSS_PATH')
+        self.ALL_PAGE_DEPS['rss_filename_base'] = self.config.get('RSS_FILENAME_BASE')
+        self.ALL_PAGE_DEPS['slug_author_path'] = self.config.get('SLUG_AUTHOR_PATH')
+        self.ALL_PAGE_DEPS['slug_tag_path'] = self.config.get('SLUG_TAG_PATH')
 
     def _activate_plugins_of_category(self, category):
         """Activate all the plugins of a given category and return them."""
@@ -2155,7 +2155,7 @@ class Nikola(object):
         deps_dict['OUTPUT_FOLDER'] = self.config['OUTPUT_FOLDER']
         deps_dict['TRANSLATIONS'] = self.config['TRANSLATIONS']
         deps_dict['global'] = self.GLOBAL_CONTEXT
-        deps_dict['all_page_dependencies'] = self.ALL_PAGE_DEPENDENCIES
+        deps_dict['all_page_deps'] = self.ALL_PAGE_DEPS
         if post_deps_dict:
             deps_dict.update(post_deps_dict)
 
@@ -2164,8 +2164,8 @@ class Nikola(object):
 
         for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
             deps_dict[k] = deps_dict['global'][k](lang)
-        for k in self._ALL_PAGE_DEPENDENCIES_TRANSLATABLE:
-            deps_dict[k] = deps_dict['all_page_dependencies'][k](lang)
+        for k in self._ALL_PAGE_DEPS_TRANSLATABLE:
+            deps_dict[k] = deps_dict['all_page_deps'][k](lang)
 
         deps_dict['navigation_links'] = deps_dict['global']['navigation_links'](lang)
 
@@ -2291,12 +2291,12 @@ class Nikola(object):
         deps_context["posts"] = [(p.meta[lang]['title'], p.permalink(lang)) for p in
                                  posts]
         deps_context["global"] = self.GLOBAL_CONTEXT
-        deps_context["all_page_dependencies"] = self.ALL_PAGE_DEPENDENCIES
+        deps_context["all_page_deps"] = self.ALL_PAGE_DEPS
 
         for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
             deps_context[k] = deps_context['global'][k](lang)
-        for k in self._ALL_PAGE_DEPENDENCIES_TRANSLATABLE:
-            deps_context[k] = deps_context['all_page_dependencies'][k](lang)
+        for k in self._ALL_PAGE_DEPS_TRANSLATABLE:
+            deps_context[k] = deps_context['all_page_deps'][k](lang)
 
         deps_context['navigation_links'] = deps_context['global']['navigation_links'](lang)
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1089,8 +1089,6 @@ class Nikola(object):
         self._GLOBAL_CONTEXT['rel_link'] = self.rel_link
         self._GLOBAL_CONTEXT['abs_link'] = self.abs_link
         self._GLOBAL_CONTEXT['exists'] = self.file_exists
-        self._GLOBAL_CONTEXT['SLUG_AUTHOR_PATH'] = self.config['SLUG_AUTHOR_PATH']
-        self._GLOBAL_CONTEXT['SLUG_TAG_PATH'] = self.config['SLUG_TAG_PATH']
         self._GLOBAL_CONTEXT['index_display_post_count'] = self.config[
             'INDEX_DISPLAY_POST_COUNT']
         self._GLOBAL_CONTEXT['index_file'] = self.config['INDEX_FILE']
@@ -1182,6 +1180,8 @@ class Nikola(object):
         self.ALL_PAGE_DEPENDENCIES['rss_extension'] = self.config.get('RSS_EXTENSION')
         self.ALL_PAGE_DEPENDENCIES['rss_path'] = self.config.get('RSS_PATH')
         self.ALL_PAGE_DEPENDENCIES['rss_filename_base'] = self.config.get('RSS_FILENAME_BASE')
+        self.ALL_PAGE_DEPENDENCIES['slug_author_path'] = self.config.get('SLUG_AUTHOR_PATH')
+        self.ALL_PAGE_DEPENDENCIES['slug_tag_path'] = self.config.get('SLUG_TAG_PATH')
 
     def _activate_plugins_of_category(self, category):
         """Activate all the plugins of a given category and return them."""

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2147,7 +2147,7 @@ class Nikola(object):
         deps_dict['OUTPUT_FOLDER'] = self.config['OUTPUT_FOLDER']
         deps_dict['TRANSLATIONS'] = self.config['TRANSLATIONS']
         deps_dict['global'] = self.GLOBAL_CONTEXT
-        deps_dict["all_page_dependencies"] = self.ALL_PAGE_DEPENDENCIES
+        deps_dict['all_page_dependencies'] = self.ALL_PAGE_DEPENDENCIES
         if post_deps_dict:
             deps_dict.update(post_deps_dict)
 
@@ -2288,7 +2288,7 @@ class Nikola(object):
         for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
             deps_context[k] = deps_context['global'][k](lang)
         for k in self._ALL_PAGE_DEPENDENCIES_TRANSLATABLE:
-            deps_dict[k] = deps_dict['all_page_dependencies'][k](lang)
+            deps_context[k] = deps_context['all_page_dependencies'][k](lang)
 
         deps_context['navigation_links'] = deps_context['global']['navigation_links'](lang)
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -682,6 +682,9 @@ class Nikola(object):
                                              'posts_section_title',
                                              'front_index_header',
                                              )
+
+        self._ALL_PAGE_DEPENDENCIES_TRANSLATABLE = ('rss_path',
+                                                    )
         # WARNING: navigation_links SHOULD NOT be added to the list above.
         #          Themes ask for [lang] there and we should provide it.
 
@@ -2153,6 +2156,8 @@ class Nikola(object):
 
         for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
             deps_dict[k] = deps_dict['global'][k](lang)
+        for k in self._ALL_PAGE_DEPENDENCIES_TRANSLATABLE:
+            deps_dict[k] = deps_dict['all_page_dependencies'][k](lang)
 
         deps_dict['navigation_links'] = deps_dict['global']['navigation_links'](lang)
 
@@ -2282,6 +2287,8 @@ class Nikola(object):
 
         for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
             deps_context[k] = deps_context['global'][k](lang)
+        for k in self._ALL_PAGE_DEPENDENCIES_TRANSLATABLE:
+            deps_dict[k] = deps_dict['all_page_dependencies'][k](lang)
 
         deps_context['navigation_links'] = deps_context['global']['navigation_links'](lang)
 


### PR DESCRIPTION
Add `ALL_PAGE_DEPENDENCIES` feature to clean up global context. As mentioned in #3042 discussion. (The new settings would go in this dict instead of global.)

Or perhaps this should be ALL_TASK_DEPENDENCIES?