### PR TITLE
Make crumbs available in all pages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Make ``crumbs`` available to all pages
 * Allowing to customize RSS and Atom feed extensions with
   ``RSS_EXTENSION``, ``ATOM_EXTENSION`` settings (Issue #3041)
 * Allowing to customize filename base appended to RSS_PATH

--- a/docs/template-variables.rst
+++ b/docs/template-variables.rst
@@ -134,6 +134,7 @@ Name                Type        Description
 ``title``           str         Title of the page (taken from post, config, etc.)
 ``formatmsg``       function    Wrapper over ``%`` string formatting
 ``striphtml``       function    Strips HTML tags (Mako only)
+``crumbs``          list        Breadcrumbs for this page
 ==================  ==========  ===============================================================
 
 __ https://getnikola.com/theming.html#identifying-and-customizing-different-kinds-of-pages-with-a-shared-template

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2184,7 +2184,9 @@ class Nikola(object):
         context['description'] = post.description(lang)
         context['permalink'] = post.permalink(lang)
         if 'crumbs' not in context:
-            crumb_path = post.permalink(lang).lstrip('/').rstrip(self.config['INDEX_FILE'])
+            crumb_path = post.permalink(lang).lstrip('/')
+            if crumb_path.endswith(self.config['INDEX_FILE']):
+                crumb_path = crumb_path[:-len(self.config['INDEX_FILE'])]
             if crumb_path.endswith('/'):
                 context['crumbs'] = utils.get_crumbs(crumb_path.rstrip('/'), is_file=False)
             else:

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2183,6 +2183,12 @@ class Nikola(object):
         context['title'] = post.title(lang)
         context['description'] = post.description(lang)
         context['permalink'] = post.permalink(lang)
+        if 'crumbs' not in context:
+            crumb_path = post.permalink(lang).lstrip('/').rstrip(self.config['INDEX_FILE'])
+            if crumb_path.endswith('/'):
+                context['crumbs'] = utils.get_crumbs(crumb_path.rstrip('/'), is_file=False)
+            else:
+                context['crumbs'] = utils.get_crumbs(crumb_path, is_file=True)
         if 'pagekind' not in context:
             context['pagekind'] = ['generic_page']
         if post.use_in_feeds:


### PR DESCRIPTION
Make the crumbs variable available in all pages so templates can
have access to it.

@Kwpolska suggested I create a plugin to have breadcrumbs for pages but I don't see any reason not to make `crumbs` available all the time so templates can have access to it.