### PR TITLE
Remove warning about Debian from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,7 +7,7 @@ If you are reporting a bug:
 * provide information about your environment (below)
 * include all the output you get, and any other information related to your problem
 
-Nikola v7.6.4, as provided by Debian/Ubuntu, is NOT SUPPORTED.
+Nikola v7.6.4, as provided by Ubuntu, is NOT SUPPORTED.
 If you are using this version, you should upgrade: https://getnikola.com/getting-started.html
 -->
 


### PR DESCRIPTION
Debian no longer offers Nikola, neither in the development tree
("Debian unstable") nor in any supported releases.

Fixes #3057
