### PR TITLE
Fix #2987, fix #3008 — treat compiler metadata as fallback-ish

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -61,7 +61,9 @@ Features
 Bugfixes
 --------
 
-* Renamed ``DISABLE_INDEXES_PLUGIN_INDEX_AND_ATOM_FEED`` to ``DISABLE_INDEXES``
+* Read file metadata if compiler metadata exists and prefer it over
+  compiler metadata (Issue #3008)
+* Rename ``DISABLE_INDEXES_PLUGIN_INDEX_AND_ATOM_FEED`` to ``DISABLE_INDEXES``
   and ``DISABLE_INDEXES_PLUGIN_RSS_FEED`` to ``DISABLE_MAIN_RSS_FEED`` (Issue #3039)
 * Make chart shortcode its own plugin and make the reST directive
   depend on it.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -131,6 +131,8 @@ Other changes
 
 * Rename ``crumbs.tmpl`` to ``ui_helper.tmpl`` and the breadcrumbs
   ``bar`` function to ``breadcrumbs``
+* Reading reST docinfo metadata, including first heading as title,
+  requires ``USE_REST_DOCINFO_METADATA`` now (Issue #2987)
 
 New in v7.8.8
 =============

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -69,6 +69,8 @@ class CompileRest(PageCompiler):
             lang = LocaleBorg().current_lang
         source_path = post.translated_source_path(lang)
 
+        # Silence reST errors, some of which are due to a different
+        # environment. Real issues will be reported while compiling.
         null_logger = logbook.Logger('NULL')
         null_logger.handlers = [logbook.NullHandler()]
         with io.open(source_path, 'r', encoding='utf-8') as inf:

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -28,6 +28,7 @@
 
 import io
 import os
+import logbook
 import logbook.base
 
 import docutils.core
@@ -68,9 +69,11 @@ class CompileRest(PageCompiler):
             lang = LocaleBorg().current_lang
         source_path = post.translated_source_path(lang)
 
+        null_logger = logbook.Logger('NULL')
+        null_logger.handlers = [logbook.NullHandler()]
         with io.open(source_path, 'r', encoding='utf-8') as inf:
             data = inf.read()
-            _, _, _, document = rst2html(data, logger=self.logger, source_path=source_path, transforms=self.site.rst_transforms, no_title_transform=False)
+            _, _, _, document = rst2html(data, logger=null_logger, source_path=source_path, transforms=self.site.rst_transforms, no_title_transform=False)
         meta = {}
         if 'title' in document:
             meta['title'] = document['title']

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1012,9 +1012,9 @@ def get_meta(post, lang):
         metadata_extractors_by = metadata_extractors.default_metadata_extractors_by()
 
     # If meta file exists, use it
-    meta.update(get_metadata_from_meta_file(post.metadata_path, post, config, lang, metadata_extractors_by))
+    metafile_meta = get_metadata_from_meta_file(post.metadata_path, post, config, lang, metadata_extractors_by)
 
-    if not meta:
+    if not metafile_meta:
         post.is_two_file = False
 
     # Fetch compiler metadata.
@@ -1026,11 +1026,12 @@ def get_meta(post, lang):
         used_extractor = post.compiler
         meta.update(compiler_meta)
 
-    if not post.is_two_file and not compiler_meta:
-        # Meta file has precedence over file, which can contain garbage.
-        # Moreover, we should not read the file if we have compiler meta.
+    # Meta files and inter-file metadata override compiler metadata
+    if not post.is_two_file:
         new_meta, used_extractor = get_metadata_from_file(post.source_path, post, config, lang, metadata_extractors_by)
         meta.update(new_meta)
+    else:
+        meta.update(metafile_meta)
 
     # Filename-based metadata extractors (fallback only)
     if not meta:


### PR DESCRIPTION
Fix #2987 and fix #3008 by reordering metadata so that compiler meta can be overridden with comment/YAML metadata.