### PR TITLE
Arbitrary metadata for galleries (#3050)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,7 +18,9 @@ Features
 
 * Produce a better error message when a template referenced in another
   template is missing (Issue #3055)
-* Support captioned images and image ordering in galleries (Issue #3017)
+* Support captioned images and image ordering in galleries, as well as
+  arbitrary metadata through a new ``metadata.yml`` file (Issue #3017,
+  Issue #3050, Issue #2837)
 * New ``ATOM_PATH`` setting (Issue #2971)
 * Make ``crumbs`` available to all pages
 * Allowing to customize RSS and Atom feed extensions with

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1864,12 +1864,13 @@ its settings, change the layout, etc.).
 
 Images in galleries may be provided with captions and given a specific
 ordering, by creating a file in the gallery directory called ``metadata.yml``.
-This YAML file should contain a 'name' field for each image in the gallery
+This YAML file should contain a ``name`` field for each image in the gallery
 for which you wish to provide either a caption or specific ordering. You can also
 create localized versions (``metadata.xx.yml``).
 
 Only one ``metadata.yml`` is needed per gallery. Here is an example, showing names,
-captions and ordering.
+captions and ordering. ``caption`` and ``order`` are given special treatment,
+anything else is available to templates, as keys of ``photo_array`` images.
 
 .. code:: yaml
 
@@ -1885,6 +1886,7 @@ captions and ordering.
     ---
     name: waterline-tiles.jpg
     order: 2
+    custom: metadata is supported
     ---
 
 

--- a/nikola/data/samplesite/galleries/demo/metadata.yml
+++ b/nikola/data/samplesite/galleries/demo/metadata.yml
@@ -1,0 +1,13 @@
+---
+name: tesla_tower1_lg.jpg
+caption: Wardenclyffe Tower
+built_in: 1904
+order: 2
+---
+name: tesla4_lg.jpg
+order: 0
+---
+name: tesla_conducts_lg.jpg
+caption: Nikola Tesla conducts electricity
+order: 1
+---


### PR DESCRIPTION
This fixes #3050.

cc @jmcp.  (btw, there was a bug with `order: 0` being ignored)