### PR TITLE
Fix #3078 — make gallery metadata work for multilingual sites

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Features
 Bugfixes
 --------
 
+* Respect ``USE_FILENAME_AS_TITLE`` in galleries with a meta file
 * Fix gallery metadata for multilingual sites (Issue #3078)
 
 New in v8.0.0b1

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Features
 Bugfixes
 --------
 
+* Fix gallery metadata for multilingual sites (Issue #3078)
+
 New in v8.0.0b1
 ===============
 

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -661,10 +661,11 @@ class Galleries(Task, ImageProcessor):
                     im = Image.open(thumb)
                     w, h = im.size
                     _image_size_cache[thumb] = w, h
-            # Thumbs are files in output, we need URLs
-            url = url_from_path(img)
-            photo_info[url] = {
-                'url': url,
+            # Use basename to avoid issues with multilingual sites (Issue #3078)
+            img_basename = os.path.basename(img)
+            photo_info[img_basename] = {
+                # Thumbs are files in output, we need URLs
+                'url': url_from_path(img),
                 'url_thumb': url_from_path(thumb),
                 'title': title,
                 'size': {
@@ -674,8 +675,8 @@ class Galleries(Task, ImageProcessor):
                 'width': w,
                 'height': h
             }
-            if url in img_metadata:
-                photo_info[url].update(img_metadata[url])
+            if img_basename in img_metadata:
+                photo_info[img_basename].update(img_metadata[img_basename])
         photo_array = []
         if context['order']:
             for entry in context['order']:

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -247,7 +247,10 @@ class Galleries(Task, ImageProcessor):
                         if fn in captions:
                             img_titles.append(captions[fn])
                         else:
-                            img_titles.append(fn)
+                            if self.kw['use_filename_as_title']:
+                                img_titles.append(fn)
+                            else:
+                                img_titles.append('')
                             self.logger.debug(
                                 "Image {0} found in gallery but not listed in {1}".
                                 format(fn, context['meta_path']))


### PR DESCRIPTION
This is #3078. Also fixes an oversight which lead to `USE_FILENAME_AS_TITLE` being ignored in galleries with meta files.