### PR TITLE
gallery: use JS appendChild instead of append

### DIFF
--- a/nikola/data/themes/base-jinja/templates/gallery.tmpl
+++ b/nikola/data/themes/base-jinja/templates/gallery.tmpl
@@ -91,9 +91,9 @@ function renderGallery() {
         div.style.height = boxes[i].height + 'px';
         div.style.top = boxes[i].top + 'px';
         div.style.left = boxes[i].left + 'px';
-        link.append(img);
-        div.append(link);
-        container.append(div);
+        link.appendChild(img);
+        div.appendChild(link);
+        container.appendChild(div);
     }
     baguetteBox.run('#gallery_container', {
         captions: function(element) {

--- a/nikola/data/themes/base/templates/gallery.tmpl
+++ b/nikola/data/themes/base/templates/gallery.tmpl
@@ -91,9 +91,9 @@ function renderGallery() {
         div.style.height = boxes[i].height + 'px';
         div.style.top = boxes[i].top + 'px';
         div.style.left = boxes[i].left + 'px';
-        link.append(img);
-        div.append(link);
-        container.append(div);
+        link.appendChild(img);
+        div.appendChild(link);
+        container.appendChild(div);
     }
     baguetteBox.run('#gallery_container', {
         captions: function(element) {

--- a/nikola/data/themes/bootstrap4-jinja/templates/gallery.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/gallery.tmpl
@@ -89,9 +89,9 @@ function renderGallery() {
         div.style.height = boxes[i].height + 'px';
         div.style.top = boxes[i].top + 'px';
         div.style.left = boxes[i].left + 'px';
-        link.append(img);
-        div.append(link);
-        container.append(div);
+        link.appendChild(img);
+        div.appendChild(link);
+        container.appendChild(div);
     }
     baguetteBox.run('#gallery_container', {
         captions: function(element) {

--- a/nikola/data/themes/bootstrap4/templates/gallery.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/gallery.tmpl
@@ -89,9 +89,9 @@ function renderGallery() {
         div.style.height = boxes[i].height + 'px';
         div.style.top = boxes[i].top + 'px';
         div.style.left = boxes[i].left + 'px';
-        link.append(img);
-        div.append(link);
-        container.append(div);
+        link.appendChild(img);
+        div.appendChild(link);
+        container.appendChild(div);
     }
     baguetteBox.run('#gallery_container', {
         captions: function(element) {


### PR DESCRIPTION
It's only appending one child anyway, and append is not supported (yet?) by
IE and Edge.

Fixes #3095.

### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description
Hopefully self-explanatory.  The Disqus JS appears to already by calling appendChild too.