### PR TITLE
Only listing directories that exist.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Features
 Bugfixes
 --------
 
+* Fix listing installed themes if theme directory is missing.
 * Watch correct output folder in ``nikola auto`` (Issue #3119)
 * Fix post fragment dependencies when posts are only available in a
   non-default language (Issue #3112)

--- a/nikola/plugins/command/theme.py
+++ b/nikola/plugins/command/theme.py
@@ -290,7 +290,9 @@ class CommandTheme(Command):
         themes = []
         themes_dirs = self.site.themes_dirs + [resource_filename('nikola', os.path.join('data', 'themes'))]
         for tdir in themes_dirs:
-            themes += [(i, os.path.join(tdir, i)) for i in os.listdir(tdir)]
+            if os.path.isdir(tdir):
+                themes += [(i, os.path.join(tdir, i)) for i in os.listdir(tdir)]
+
         for tname, tpath in sorted(set(themes)):
             if os.path.isdir(tpath):
                 print("{0} at {1}".format(tname, tpath))


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated CHANGES.txt.
- [x] I tested my changes.

### Description

While testing Nikola 8.0.0b2 I discovered that listing installed themes does not work for me (setup with pipenv).

```
Traceback (most recent call last):
  File "/Users/niko/.virtualenvs/bikes.bembel.bytes-CZ5WGSwq/lib/python3.6/site-packages/doit/doit_cmd.py", line 177, in run
    return command.parse_execute(args)
  File "/Users/niko/.virtualenvs/bikes.bembel.bytes-CZ5WGSwq/lib/python3.6/site-packages/doit/cmd_base.py", line 127, in parse_execute
    return self.execute(params, args)
  File "/Users/niko/.virtualenvs/bikes.bembel.bytes-CZ5WGSwq/lib/python3.6/site-packages/nikola/plugin_categories.py", line 147, in execute
    return self._execute(options, args)
  File "/Users/niko/.virtualenvs/bikes.bembel.bytes-CZ5WGSwq/lib/python3.6/site-packages/nikola/plugins/command/theme.py", line 173, in _execute
    return self.list_installed()
  File "/Users/niko/.virtualenvs/bikes.bembel.bytes-CZ5WGSwq/lib/python3.6/site-packages/nikola/plugins/command/theme.py", line 293, in list_installed
    themes += [(i, os.path.join(tdir, i)) for i in os.listdir(tdir)]
FileNotFoundError: [Errno 2] No such file or directory: 'themes'
```

This PR fixes this by only listing existing directories.