### PR TITLE
gallery: don't generate index page on empty output folder

### DIFF
--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -366,7 +366,12 @@ class Galleries(Task, ImageProcessor):
         self.gallery_list = []
         for input_folder, output_folder in self.kw['gallery_folders'].items():
             for root, dirs, files in os.walk(input_folder, followlinks=True):
-                self.gallery_list.append((root, input_folder, output_folder))
+                # If output folder is empty, the top-level gallery
+                # index will collide with the main page for the site.
+                # Don't generate the top-level gallery index in that
+                # case.
+                if output_folder or root != input_folder:
+                    self.gallery_list.append((root, input_folder, output_folder))
 
     def create_galleries_paths(self):
         """Given a list of galleries, put their paths into self.gallery_links."""


### PR DESCRIPTION
Empty output folder allows galleries to be placed at the site's top directory,
instead of inside e.g. a "galleries" subdirectory.  But without this change, the
plugin would want to generate an index page that collides with the site's main
index page.

### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description

I don't think this requires a documentation change?  Attempting to use an empty output folder for galleries I think just follows naturally without needing it explicitly mentioned?