### PR TITLE
Support DATE_FANCINESS and updated in base and base-jinja

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,14 @@ Features
 
 * Don’t generate gallery index if the destination directory is
   site root and it would conflict with blog index (Issue #3133)
+* ``base`` and ``base-jinja`` templates now support updated
+  timestamp fields in posts. The update time, if it is specified and
+  different from the posting time will be displayed as
+  "{postDate} updated {updateDate}". If no update time is specified, the
+  posting time will be displayed alone.
+* ``base`` and ``base-jinja`` templates now support the ``DATE_FANCINESS``
+  parameter in ``conf.py``. If ``DATE_FANCINESS == 0``, the additional
+  JavaScript dependencies will **not** be pulled in.
 
 Bugfixes
 --------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,13 +8,12 @@ Features
 
 * Don’t generate gallery index if the destination directory is
   site root and it would conflict with blog index (Issue #3133)
-* All built-in themes now support updated timestamp fields in
+* All built-in themes now support ``updated`` timestamp fields in
   posts. The update time, if it is specified and different from
-  the posting time will be displayed as
-  "{postDate} ${messages("updated") {updateDate}". If no update
+  the posting time, will be displayed as
+  "{postDate} (${messages("updated")} {updateDate})". If no update
   time is specified, the posting time will be displayed alone.
-* All built-in themes now support the ``DATE_FANCINESS``
-  parameter in ``conf.py``.
+* All built-in themes now support the ``DATE_FANCINESS`` option.
 
 Bugfixes
 --------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,14 +8,13 @@ Features
 
 * Don’t generate gallery index if the destination directory is
   site root and it would conflict with blog index (Issue #3133)
-* ``base`` and ``base-jinja`` templates now support updated
-  timestamp fields in posts. The update time, if it is specified and
-  different from the posting time will be displayed as
-  "{postDate} updated {updateDate}". If no update time is specified, the
-  posting time will be displayed alone.
-* ``base`` and ``base-jinja`` templates now support the ``DATE_FANCINESS``
-  parameter in ``conf.py``. If ``DATE_FANCINESS == 0``, the additional
-  JavaScript dependencies will **not** be pulled in.
+* All built-in themes now support updated timestamp fields in
+  posts. The update time, if it is specified and different from
+  the posting time will be displayed as
+  "{postDate} ${messages("updated") {updateDate}". If no update
+  time is specified, the posting time will be displayed alone.
+* All built-in themes now support the ``DATE_FANCINESS``
+  parameter in ``conf.py``.
 
 Bugfixes
 --------

--- a/nikola/data/themes/base-jinja/templates/base.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base.tmpl
@@ -20,6 +20,14 @@
          {{ footer.html_footer() }}
     </div>
     {{ base.late_load_js() }}
+    {% if date_fanciness != 0 %}
+    <!-- fancy dates -->
+    <script>
+    moment.locale("{{ momentjs_locales[lang] }}");
+    fancydates({{ date_fanciness }}, {{ js_date_format }});
+    </script>
+    <!-- end fancy dates -->
+    {% endif %}
     {% block extra_js %}{% endblock %}
     <script>
     baguetteBox.run('div#content', {

--- a/nikola/data/themes/base-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_helper.tmpl
@@ -66,14 +66,27 @@ lang="{{ lang }}">
     {% if use_bundles %}
         {% if use_cdn %}
             <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.9.1/baguetteBox.min.js" integrity="sha256-SoEATAB7PgNWyyK100I7yQXYm5V08k5SFupDP0h72MY=" crossorigin="anonymous"></script>
+            {% if date_fanciness != 0 %}
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
+            {% endif %}
+            <script src="/assets/js/all.js"></script>
         {% else %}
             <script src="/assets/js/all-nocdn.js"></script>
         {% endif %}
     {% else %}
         {% if use_cdn %}
             <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.9.1/baguetteBox.min.js" integrity="sha256-SoEATAB7PgNWyyK100I7yQXYm5V08k5SFupDP0h72MY=" crossorigin="anonymous"></script>
+            {% if date_fanciness != 0 %}
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
+            {% endif %}
         {% else %}
             <script src="/assets/js/baguetteBox.min.js"></script>
+            {% if date_fanciness != 0 %}
+                <script src="/assets/js/moment-with-locales.min.js"></script>
+            {% endif %}
+        {% endif %}
+        {% if date_fanciness != 0 %}
+            <script src="/assets/js/fancydates.js"></script>
         {% endif %}
     {% endif %}
     {{ social_buttons_code }}

--- a/nikola/data/themes/base-jinja/templates/index.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index.tmpl
@@ -41,8 +41,9 @@
             <a href="{{ post.permalink() }}" rel="bookmark">
             <time class="published dt-published" datetime="{{ post.formatted_date('webiso') }}" itemprop="datePublished" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time>
             {% if post.updated and post.updated != post.date %}
-                <span class="updated"> updated </span>
-                <time class="updated dt-updated" datetime="{{ post.formatted_updated('webiso') }}" itemprop="dateUpdated" title="{{ post.formatted_updated(date_format)|e }}">{{ post.formatted_updated(date_format)|e }}</time>
+                <span class="updated">{{ messages("updated") }}
+                    <time class="dt-updated" datetime="{{ post.formatted_updated('webiso') }}" itemprop="dateUpdated" title="{{ post.formatted_updated(date_format)|e }}">{{ post.formatted_updated(date_format)|e }}</time>
+                </span>
             {% endif %}
             </a>
             </p>

--- a/nikola/data/themes/base-jinja/templates/index.tmpl
+++ b/nikola/data/themes/base-jinja/templates/index.tmpl
@@ -37,7 +37,15 @@
                 {{ post.author()|e }}
             {% endif %}
             </span></p>
-            <p class="dateline"><a href="{{ post.permalink() }}" rel="bookmark"><time class="published dt-published" datetime="{{ post.formatted_date('webiso') }}" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time></a></p>
+            <p class="dateline">
+            <a href="{{ post.permalink() }}" rel="bookmark">
+            <time class="published dt-published" datetime="{{ post.formatted_date('webiso') }}" itemprop="datePublished" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time>
+            {% if post.updated and post.updated != post.date %}
+                <span class="updated"> updated </span>
+                <time class="updated dt-updated" datetime="{{ post.formatted_updated('webiso') }}" itemprop="dateUpdated" title="{{ post.formatted_updated(date_format)|e }}">{{ post.formatted_updated(date_format)|e }}</time>
+            {% endif %}
+            </a>
+            </p>
             {% if not post.meta('nocomments') and site_has_comments %}
                 <p class="commentline">{{ comments.comment_link(post.permalink(), post._base_path) }}
             {% endif %}

--- a/nikola/data/themes/base-jinja/templates/post_header.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_header.tmpl
@@ -38,7 +38,15 @@
                     {{ post.author()|e }}
                 {% endif %}
             </span></p>
-            <p class="dateline"><a href="{{ post.permalink() }}" rel="bookmark"><time class="published dt-published" datetime="{{ post.formatted_date('webiso') }}" itemprop="datePublished" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time></a></p>
+            <p class="dateline">
+            <a href="{{ post.permalink() }}" rel="bookmark">
+            <time class="published dt-published" datetime="{{ post.formatted_date('webiso') }}" itemprop="datePublished" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time>
+            {% if post.updated and post.updated != post.date %}
+                <span class="updated"> updated </span>
+                <time class="updated dt-updated" datetime="{{ post.formatted_updated('webiso') }}" itemprop="dateUpdated" title="{{ post.formatted_updated(date_format)|e }}">{{ post.formatted_updated(date_format)|e }}</time>
+            {% endif %}
+            </a>
+            </p>
             {% if not post.meta('nocomments') and site_has_comments %}
                 <p class="commentline">{{ comments.comment_link(post.permalink(), post._base_path) }}
             {% endif %}

--- a/nikola/data/themes/base-jinja/templates/post_header.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post_header.tmpl
@@ -42,8 +42,9 @@
             <a href="{{ post.permalink() }}" rel="bookmark">
             <time class="published dt-published" datetime="{{ post.formatted_date('webiso') }}" itemprop="datePublished" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time>
             {% if post.updated and post.updated != post.date %}
-                <span class="updated"> updated </span>
-                <time class="updated dt-updated" datetime="{{ post.formatted_updated('webiso') }}" itemprop="dateUpdated" title="{{ post.formatted_updated(date_format)|e }}">{{ post.formatted_updated(date_format)|e }}</time>
+                <span class="updated">{{ messages("updated") }}
+                    <time class="updated dt-updated" datetime="{{ post.formatted_updated('webiso') }}" itemprop="dateUpdated" title="{{ post.formatted_updated(date_format)|e }}">{{ post.formatted_updated(date_format)|e }}</time>
+                </span>
             {% endif %}
             </a>
             </p>

--- a/nikola/data/themes/base/assets/js/fancydates.js
+++ b/nikola/data/themes/base/assets/js/fancydates.js
@@ -3,7 +3,7 @@ function fancydates(fanciness, date_format) {
         return;
     }
 
-    var dates = document.getElementsByClassName('dt-published');
+    var dates = document.querySelectorAll('.dt-published, .dt-updated');
 
     var l = dates.length;
 

--- a/nikola/data/themes/base/assets/js/fancydates.min.js
+++ b/nikola/data/themes/base/assets/js/fancydates.min.js
@@ -1,1 +1,1 @@
-function fancydates(e,t){if(0!=e)for(var a=document.getElementsByClassName("dt-published"),n=a.length,m=0;m<n;m++){var o,l=moment(a[m].attributes.datetime.value);o=1==e?l.local().format(t):l.fromNow(),a[m].innerHTML=o}}
+function fancydates(t,e){if(0!=t)for(var a=document.querySelectorAll(".dt-published, .dt-updated"),o=a.length,r=0;r<o;r++){var d,l=moment(a[r].attributes.datetime.value);d=1==t?l.local().format(e):l.fromNow(),a[r].innerHTML=d}}

--- a/nikola/data/themes/base/bundles
+++ b/nikola/data/themes/base/bundles
@@ -1,3 +1,4 @@
 assets/css/all.css=rst_base.css,nikola_rst.css,code.css,theme.css
 assets/css/all-nocdn.css=rst_base.css,nikola_rst.css,code.css,theme.css,baguetteBox.min.css
-assets/js/all-nocdn.js=baguetteBox.min.js
+assets/js/all.js=fancydates.js
+assets/js/all-nocdn.js=baguetteBox.min.js,moment-with-locales.min.js,fancydates.js

--- a/nikola/data/themes/base/messages/messages_ar.py
+++ b/nikola/data/themes/base/messages/messages_ar.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "أكتب مقالك هنا",
     "old posts, page %d": "مقالات قديمة, صفحة %d",
     "page %d": "صفحة %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_az.py
+++ b/nikola/data/themes/base/messages/messages_az.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Öz məqaləni bura yaz",
     "old posts, page %d": "köhnə yazılar, səhifə %s",
     "page %d": "səhifə %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_bg.py
+++ b/nikola/data/themes/base/messages/messages_bg.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Напиши тук текста на твоята публикация.",
     "old posts, page %d": "стари публикации, страница %d",
     "page %d": "страница %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_br.py
+++ b/nikola/data/themes/base/messages/messages_br.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "",
     "old posts, page %d": "",
     "page %d": "",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_bs.py
+++ b/nikola/data/themes/base/messages/messages_bs.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Vaš članak napišite ovdje.",
     "old posts, page %d": "stare objave, strana %d",
     "page %d": "strana %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_ca.py
+++ b/nikola/data/themes/base/messages/messages_ca.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Escribiu la vostra entrada aquí",
     "old posts, page %d": "entrades antigues, pàgina %d",
     "page %d": "pàgina %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_cs.py
+++ b/nikola/data/themes/base/messages/messages_cs.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "",
     "old posts, page %d": "staré příspěvky, strana %d",
     "page %d": "strana %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_da.py
+++ b/nikola/data/themes/base/messages/messages_da.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "",
     "old posts, page %d": "gamle indlæg, side %d",
     "page %d": "side %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_de.py
+++ b/nikola/data/themes/base/messages/messages_de.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Schreibe hier deinen Eintrag hin.",
     "old posts, page %d": "Ältere Einträge, Seite %d",
     "page %d": "Seite %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_el.py
+++ b/nikola/data/themes/base/messages/messages_el.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "",
     "old posts, page %d": "σελίδα παλαιότερων αναρτήσεων %d",
     "page %d": "σελίδα %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_en.py
+++ b/nikola/data/themes/base/messages/messages_en.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Write your post here.",
     "old posts, page %d": "old posts, page %d",
     "page %d": "page %d",
+    "updated": "updated",
 }

--- a/nikola/data/themes/base/messages/messages_eo.py
+++ b/nikola/data/themes/base/messages/messages_eo.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Skribu tie vian artikolon.",
     "old posts, page %d": "%da paĝo de malnovaj artikoloj",
     "page %d": "paĝo %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_es.py
+++ b/nikola/data/themes/base/messages/messages_es.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Escriba su publicación aquí.",
     "old posts, page %d": "publicaciones antiguas, página %d",
     "page %d": "página %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_et.py
+++ b/nikola/data/themes/base/messages/messages_et.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Kirjuta oma postitus siia.",
     "old posts, page %d": "vanade postituste, leht %d",
     "page %d": "leht %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_eu.py
+++ b/nikola/data/themes/base/messages/messages_eu.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Idatzi zure argitalpena hemen",
     "old posts, page %d": "Argitalpen zaharragoak, %d. orria",
     "page %d": "%d. orria",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_fa.py
+++ b/nikola/data/themes/base/messages/messages_fa.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "متن پست‌تان را این‌جا بنویسید.",
     "old posts, page %d": "صفحهٔ ارسال‌های قدیمی %d",
     "page %d": "برگه %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_fi.py
+++ b/nikola/data/themes/base/messages/messages_fi.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Kirjoita sisältö tähän.",
     "old posts, page %d": "vanhoja kirjoituksia, sivu %d",
     "page %d": "sivu %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_fil.py
+++ b/nikola/data/themes/base/messages/messages_fil.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "",
     "old posts, page %d": "",
     "page %d": "",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_fr.py
+++ b/nikola/data/themes/base/messages/messages_fr.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Écrivez votre billet ici.",
     "old posts, page %d": "anciens articles, page %d",
     "page %d": "page %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_gl.py
+++ b/nikola/data/themes/base/messages/messages_gl.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Escribe o teu artigo aquí.",
     "old posts, page %d": "Artigos vellos, páxina %d",
     "page %d": "páxina %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_he.py
+++ b/nikola/data/themes/base/messages/messages_he.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "תכתוב את הפוסט שלך פה.",
     "old posts, page %d": "פוסטים קודמים, דף %d",
     "page %d": "עמוד %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_hi.py
+++ b/nikola/data/themes/base/messages/messages_hi.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "अपनी पोस्ट यहाँ लिखिए",
     "old posts, page %d": "पुरानी पोस्टें, पृष्‍ठ %d",
     "page %d": "पृष्‍ठ %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_hr.py
+++ b/nikola/data/themes/base/messages/messages_hr.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Napiši svoju objavu ovdje",
     "old posts, page %d": "stari postovi, stranice %d",
     "page %d": "stranice %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_hu.py
+++ b/nikola/data/themes/base/messages/messages_hu.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Ide írd a bejegyzésed.",
     "old posts, page %d": "régi bejegyzések, %d. oldal",
     "page %d": "%d. oldal",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_id.py
+++ b/nikola/data/themes/base/messages/messages_id.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Tulis tulisan Anda disini.",
     "old posts, page %d": "tulisan lama, halaman %d",
     "page %d": "halaman %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_it.py
+++ b/nikola/data/themes/base/messages/messages_it.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Scrivi qui il tuo post.",
     "old posts, page %d": "vecchi articoli, pagina %d",
     "page %d": "pagina %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_ja.py
+++ b/nikola/data/themes/base/messages/messages_ja.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "ここに文書を記述してください。",
     "old posts, page %d": "過去の文書 %dページ目",
     "page %d": "ページ%d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_ko.py
+++ b/nikola/data/themes/base/messages/messages_ko.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "이곳에 글을 작성하세요.",
     "old posts, page %d": "이전 포스트, 페이지 %d",
     "page %d": "페이지 %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_lt.py
+++ b/nikola/data/themes/base/messages/messages_lt.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Čia rašykite įrašo tekstą.",
     "old posts, page %d": "seni įrašai, %d puslapis",
     "page %d": "%d puslapis",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_nb.py
+++ b/nikola/data/themes/base/messages/messages_nb.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Skriv innlegget din her.",
     "old posts, page %d": "eldre innlegg, side %d",
     "page %d": "side %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_nl.py
+++ b/nikola/data/themes/base/messages/messages_nl.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Schrijf hier je bericht.",
     "old posts, page %d": "oude berichten, pagina %d",
     "page %d": "pagina %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_pa.py
+++ b/nikola/data/themes/base/messages/messages_pa.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "ਆਪਣੀ ਲਿਖਤ ਏਥੇ ਲਿਖੋ |",
     "old posts, page %d": "ਪੁਰਾਣੀਆਂ ਲਿਖਤਾਂ , ਸਫ਼ਾ %d",
     "page %d": "ਸਫ਼ਾ %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_pl.py
+++ b/nikola/data/themes/base/messages/messages_pl.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Tu wpisz treść postu.",
     "old posts, page %d": "stare posty, strona %d",
     "page %d": "strona %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_pt.py
+++ b/nikola/data/themes/base/messages/messages_pt.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Escreva o seu texto para publicar aqui.",
     "old posts, page %d": "Textos publicados antigos, página %d",
     "page %d": "página %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_pt_br.py
+++ b/nikola/data/themes/base/messages/messages_pt_br.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Escreva o seu comentário aqui.",
     "old posts, page %d": "Posts antigos, página %d",
     "page %d": "página %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_ru.py
+++ b/nikola/data/themes/base/messages/messages_ru.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Создайте Вашу запись здесь.",
     "old posts, page %d": "%d страница со старыми записями",
     "page %d": "%d страница",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_si_lk.py
+++ b/nikola/data/themes/base/messages/messages_si_lk.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "",
     "old posts, page %d": "",
     "page %d": "",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_sk.py
+++ b/nikola/data/themes/base/messages/messages_sk.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Tu napíšte svoj príspevok.",
     "old posts, page %d": "staré príspevky, strana %d",
     "page %d": "stránka %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_sl.py
+++ b/nikola/data/themes/base/messages/messages_sl.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "",
     "old posts, page %d": "stare objave, stran %d",
     "page %d": "stran %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_sq.py
+++ b/nikola/data/themes/base/messages/messages_sq.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Shkruaj postin tënd këtu.",
     "old posts, page %d": "Postime të kaluara, faqe %d",
     "page %d": "faqe %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_sr.py
+++ b/nikola/data/themes/base/messages/messages_sr.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Вашу објаву напишите овдје.",
     "old posts, page %d": "стари постови, страна %d",
     "page %d": "страна %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_sr_latin.py
+++ b/nikola/data/themes/base/messages/messages_sr_latin.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Vašu objavu napišite ovdje.",
     "old posts, page %d": "stare objave, strana %d",
     "page %d": "strana %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_sv.py
+++ b/nikola/data/themes/base/messages/messages_sv.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Skriv ditt inlägg här.",
     "old posts, page %d": "gamla inlägg, sida %d",
     "page %d": "sida %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_te.py
+++ b/nikola/data/themes/base/messages/messages_te.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "ఇక్కడ మీ టపా ను వ్రాయండి.",
     "old posts, page %d": "పాత టపాలు, పేజీ %d",
     "page %d": "పేజీ %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_th.py
+++ b/nikola/data/themes/base/messages/messages_th.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "เขียนโพสต์ที่นี่",
     "old posts, page %d": "โพสต์เก่า, หน้า %d",
     "page %d": "หน้า %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_tl.py
+++ b/nikola/data/themes/base/messages/messages_tl.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "",
     "old posts, page %d": "",
     "page %d": "",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_tr.py
+++ b/nikola/data/themes/base/messages/messages_tr.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Yazınızı buraya yazın.",
     "old posts, page %d": "eski yazılar, sayfa %d",
     "page %d": "sayfa %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_uk.py
+++ b/nikola/data/themes/base/messages/messages_uk.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "Напишить Вашу статтю тут.",
     "old posts, page %d": "старі статті, сторінка %d",
     "page %d": "сторінка %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_ur.py
+++ b/nikola/data/themes/base/messages/messages_ur.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "اپنی تحریر یہاں لکھیں۔",
     "old posts, page %d": "پرانی تحاریر صفحہ %d",
     "page %d": "صفحہ %d",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_zh_cn.py
+++ b/nikola/data/themes/base/messages/messages_zh_cn.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "在这里书写你的文章。",
     "old posts, page %d": "旧文章页 %d",
     "page %d": "第 %d 页",
+    "updated": "",
 }

--- a/nikola/data/themes/base/messages/messages_zh_tw.py
+++ b/nikola/data/themes/base/messages/messages_zh_tw.py
@@ -45,4 +45,5 @@ MESSAGES = {
     "Write your post here.": "從這裡開始編輯文章",
     "old posts, page %d": "舊文章，第 %d 頁",
     "page %d": "第 %d 頁",
+    "updated": "",
 }

--- a/nikola/data/themes/base/templates/base.tmpl
+++ b/nikola/data/themes/base/templates/base.tmpl
@@ -20,6 +20,14 @@ ${template_hooks['extra_head']()}
          ${footer.html_footer()}
     </div>
     ${base.late_load_js()}
+    % if date_fanciness != 0:
+    <!-- fancy dates -->
+    <script>
+    moment.locale("${momentjs_locales[lang]}");
+    fancydates(${date_fanciness}, ${js_date_format});
+    </script>
+    <!-- end fancy dates -->
+    % endif
     <%block name="extra_js"></%block>
     <script>
     baguetteBox.run('div#content', {

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -66,14 +66,27 @@ lang="${lang}">
     % if use_bundles:
         % if use_cdn:
             <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.9.1/baguetteBox.min.js" integrity="sha256-SoEATAB7PgNWyyK100I7yQXYm5V08k5SFupDP0h72MY=" crossorigin="anonymous"></script>
+            % if date_fanciness != 0:
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
+            % endif
+            <script src="/assets/js/all.js"></script>
         % else:
             <script src="/assets/js/all-nocdn.js"></script>
         % endif
     % else:
         % if use_cdn:
             <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.9.1/baguetteBox.min.js" integrity="sha256-SoEATAB7PgNWyyK100I7yQXYm5V08k5SFupDP0h72MY=" crossorigin="anonymous"></script>
+            % if date_fanciness != 0:
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
+            % endif
         % else:
             <script src="/assets/js/baguetteBox.min.js"></script>
+            % if date_fanciness != 0:
+                <script src="/assets/js/moment-with-locales.min.js"></script>
+            % endif
+        % endif
+        % if date_fanciness != 0:
+            <script src="/assets/js/fancydates.js"></script>
         % endif
     % endif
     ${social_buttons_code}

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -37,7 +37,15 @@
                 ${post.author()|h}
             % endif
             </span></p>
-            <p class="dateline"><a href="${post.permalink()}" rel="bookmark"><time class="published dt-published" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time></a></p>
+            <p class="dateline">
+            <a href="${post.permalink()}" rel="bookmark">
+            <time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time>
+            % if post.updated and post.updated != post.date:
+                <span class="updated"> updated </span>
+                <time class="updated dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
+            % endif
+            </a>
+            </p>
             % if not post.meta('nocomments') and site_has_comments:
                 <p class="commentline">${comments.comment_link(post.permalink(), post._base_path)}
             % endif

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -41,9 +41,8 @@
             <a href="${post.permalink()}" rel="bookmark">
             <time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time>
             % if post.updated and post.updated != post.date:
-                <span class="updated">${messages("updated")}
-                    <time class="dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
-                </span>
+                <span class="updated">(${messages("updated")}
+                    <time class="dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>)</span>
             % endif
             </a>
             </p>

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -41,8 +41,9 @@
             <a href="${post.permalink()}" rel="bookmark">
             <time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time>
             % if post.updated and post.updated != post.date:
-                <span class="updated"> updated </span>
-                <time class="updated dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
+                <span class="updated">${messages("updated")}
+                    <time class="dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
+                </span>
             % endif
             </a>
             </p>

--- a/nikola/data/themes/base/templates/post_header.tmpl
+++ b/nikola/data/themes/base/templates/post_header.tmpl
@@ -42,9 +42,8 @@
             <a href="${post.permalink()}" rel="bookmark">
             <time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time>
             % if post.updated and post.updated != post.date:
-                <span class="updated">${messages("updated")}
-                    <time class="updated dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
-                </span>
+                <span class="updated">(${messages("updated")}
+                    <time class="updated dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>)</span>
             % endif
             </a>
             </p>

--- a/nikola/data/themes/base/templates/post_header.tmpl
+++ b/nikola/data/themes/base/templates/post_header.tmpl
@@ -42,8 +42,9 @@
             <a href="${post.permalink()}" rel="bookmark">
             <time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time>
             % if post.updated and post.updated != post.date:
-                <span class="updated"> updated </span>
-                <time class="updated dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
+                <span class="updated">${messages("updated")}
+                    <time class="updated dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
+                </span>
             % endif
             </a>
             </p>

--- a/nikola/data/themes/base/templates/post_header.tmpl
+++ b/nikola/data/themes/base/templates/post_header.tmpl
@@ -38,7 +38,15 @@
                     ${post.author()|h}
                 % endif
             </span></p>
-            <p class="dateline"><a href="${post.permalink()}" rel="bookmark"><time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time></a></p>
+            <p class="dateline">
+            <a href="${post.permalink()}" rel="bookmark">
+            <time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time>
+            % if post.updated and post.updated != post.date:
+                <span class="updated"> updated </span>
+                <time class="updated dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
+            % endif
+            </a>
+            </p>
             % if not post.meta('nocomments') and site_has_comments:
                 <p class="commentline">${comments.comment_link(post.permalink(), post._base_path)}
             % endif

--- a/nikola/data/themes/bootblog4-jinja/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/index.tmpl
@@ -37,7 +37,16 @@
                         {{ post.author()|e }}
                     {% endif %}
                     </span></p>
-                    <p class="dateline"><a href="{{ post.permalink() }}" rel="bookmark"><time class="published dt-published" datetime="{{ post.formatted_date('webiso') }}" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time></a></p>
+            <p class="dateline">
+            <a href="{{ post.permalink() }}" rel="bookmark">
+            <time class="published dt-published" datetime="{{ post.formatted_date('webiso') }}" itemprop="datePublished" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time>
+            {% if post.updated and post.updated != post.date %}
+                <span class="updated">{{ messages("updated") }}
+                    <time class="dt-updated" datetime="{{ post.formatted_updated('webiso') }}" itemprop="dateUpdated" title="{{ post.formatted_updated(date_format)|e }}">{{ post.formatted_updated(date_format)|e }}</time>
+                </span>
+            {% endif %}
+            </a>
+            </p>
                     {% if not post.meta('nocomments') and site_has_comments %}
                         <p class="commentline">{{ comments.comment_link(post.permalink(), post._base_path) }}
                     {% endif %}

--- a/nikola/data/themes/bootblog4/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4/templates/index.tmpl
@@ -37,7 +37,16 @@
                         ${post.author()|h}
                     % endif
                     </span></p>
-                    <p class="dateline"><a href="${post.permalink()}" rel="bookmark"><time class="published dt-published" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time></a></p>
+            <p class="dateline">
+            <a href="${post.permalink()}" rel="bookmark">
+            <time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time>
+            % if post.updated and post.updated != post.date:
+                <span class="updated">${messages("updated")}
+                    <time class="dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
+                </span>
+            % endif
+            </a>
+            </p>
                     % if not post.meta('nocomments') and site_has_comments:
                         <p class="commentline">${comments.comment_link(post.permalink(), post._base_path)}
                     % endif

--- a/nikola/data/themes/bootblog4/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4/templates/index.tmpl
@@ -41,9 +41,8 @@
             <a href="${post.permalink()}" rel="bookmark">
             <time class="published dt-published" datetime="${post.formatted_date('webiso')}" itemprop="datePublished" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time>
             % if post.updated and post.updated != post.date:
-                <span class="updated">${messages("updated")}
-                    <time class="dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>
-                </span>
+                <span class="updated">(${messages("updated")}
+                    <time class="dt-updated" datetime="${post.formatted_updated('webiso')}" itemprop="dateUpdated" title="${post.formatted_updated(date_format)|h}">${post.formatted_updated(date_format)|h}</time>)</span>
             % endif
             </a>
             </p>

--- a/tests/data/1-nolinks.rst
+++ b/tests/data/1-nolinks.rst
@@ -1,6 +1,7 @@
 .. title: Welcome to Nikola
 .. slug: welcome-to-nikola
 .. date: 2012-03-30 23:00:00 UTC-03:00
+.. updated: 2018-08-10 06:54:00Z
 .. tags: nikola, python, demo, blog
 .. author: Roberto Alsina
 .. link: https://getnikola.com/


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

This PR changes two things relating to base/base-jinja handling of datetime in posts:

1. addition of "updated" time, if specified in the post metadata (output is unchanged if "updated" no specified)
1. DATE_FANCINESS is supported for published and updated dates (output is unchanged if ``DATE_FANCINESS=0``