### PR TITLE
Add support for yaml bundles definitions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,7 @@ Features
 
 * Don’t generate gallery index if the destination directory is
   site root and it would conflict with blog index (Issue #3133)
+* Theme bundles may now be defined using yaml as ``bundles.yaml``
 
 Bugfixes
 --------

--- a/docs/creating-a-theme.rst
+++ b/docs/creating-a-theme.rst
@@ -814,14 +814,26 @@ Bundles
 -------
 
 If you have ``webassets`` installed and the ``USE_BUNDLES`` option set to True, Nikola can put several CSS or JS files together in a larger file,
-which makes sites load faster. To do that, your theme needs a ``bundles`` file where the syntax is::
+which makes sites load faster. To do that, your theme needs a ``bundles.yaml`` file where the syntax is::
 
-    outputfile1.js=thing1.js,thing2.js,...
-    outputfile2.css=thing1.css,thing2.css,...
+    outputfile1.js:
+      - thing1.js
+      - thing2.js
+      - ...
+    outputfile2.css:
+      - thing1.css
+      - thing2.css
+      - ...
 
-For the Lanyon theme, it should be like this::
+For the Lanyon theme, it should look like this::
 
-    assets/css/all.css=rst_base.css,nikola_rst.css,code.css,poole.css,lanyon.css,custom.css
+    assets/css/all.css:
+      - rst_base.css
+      - nikola_rst.css
+      - code.css
+      - poole.css
+      - lanyon.css
+      - custom.css
 
 **Note:** Some themes also support the ``USE_CDN`` option meaning that in some cases it will load one bundle with all CSS and in other will load some CSS files
 from a CDN and others from a bundle. This is complicated and probably not worth the effort.

--- a/docs/theming.rst
+++ b/docs/theming.rst
@@ -72,13 +72,20 @@ parent, engine
     respectively.  Those are needed for older versions (Nikola v7.8.5 and
     older).
 
-bundles
-    A text file containing a list of files to be turned into bundles using WebAssets.
+bundles.yaml
+    A yaml file containing a mapping of WebAsset bundles to input files.
     For example:
 
-    .. code:: text
+    .. code:: yaml
 
-        assets/css/all.css=bootstrap.min.css,rst_base.css,nikola_rst.css,code.css,baguetteBox.min.css,theme.css,custom.css
+        assets/css/all.css:
+          - bootstrap.min.css
+          - rst_base.css
+          - nikola_rst.css
+          - code.css
+          - baguetteBox.min.css
+          - theme.css
+          - custom.css
 
     This creates a file called "assets/css/all.css" in your output that is the
     combination of all the other file paths, relative to the output file.
@@ -89,6 +96,14 @@ bundles
 
     Templates should use either the bundle or the individual files based on the ``use_bundles``
     variable, which in turn is set by the ``USE_BUNDLES`` option.
+
+bundles (deprecated)
+    A text file containing a list of files to be turned into bundles using WebAssets.
+    For example:
+
+    .. code:: text
+
+        assets/css/all.css=bootstrap.min.css,rst_base.css,nikola_rst.css,code.css,baguetteBox.min.css,theme.css,custom.css
 
 Theme meta files
 ----------------

--- a/nikola/data/symlinked.txt
+++ b/nikola/data/symlinked.txt
@@ -23,6 +23,7 @@ nikola/data/themes/base/assets/js/html5shiv-printshiv.min.js
 nikola/data/themes/base/assets/js/justified-layout.min.js
 nikola/data/themes/base/assets/js/moment-with-locales.min.js
 nikola/data/themes/base/messages/messages_cz.py
+nikola/data/themes/base-jinja/bundles
 nikola/data/themes/bootblog4-jinja/assets/css/bootblog.css
 nikola/data/themes/bootblog4-jinja/bundles
 nikola/data/themes/bootstrap4-jinja/assets/css/bootstrap.min.css

--- a/nikola/data/themes/base-jinja/bundles.yaml
+++ b/nikola/data/themes/base-jinja/bundles.yaml
@@ -1,0 +1,1 @@
+../base/bundles.yaml

--- a/nikola/data/themes/base/bundles
+++ b/nikola/data/themes/base/bundles
@@ -1,3 +1,0 @@
-assets/css/all.css=rst_base.css,nikola_rst.css,code.css,theme.css
-assets/css/all-nocdn.css=rst_base.css,nikola_rst.css,code.css,theme.css,baguetteBox.min.css
-assets/js/all-nocdn.js=baguetteBox.min.js

--- a/nikola/data/themes/base/bundles.yaml
+++ b/nikola/data/themes/base/bundles.yaml
@@ -1,0 +1,13 @@
+assets/css/all.css:
+  - rst_base.css
+  - nikola_rst.css
+  - code.css
+  - theme.css
+assets/css/all-nocdn.css:
+  - rst_base.css
+  - nikola_rst.css
+  - code.css
+  - theme.css
+  - baguetteBox.min.css
+assets/js/all-nocdn.js:
+  - baguetteBox.min.js

--- a/nikola/data/themes/bootblog4-jinja/bundles
+++ b/nikola/data/themes/bootblog4-jinja/bundles
@@ -1,1 +1,0 @@
-../bootblog4/bundles

--- a/nikola/data/themes/bootblog4-jinja/bundles.yaml
+++ b/nikola/data/themes/bootblog4-jinja/bundles.yaml
@@ -1,0 +1,1 @@
+../bootblog4/bundles.yaml

--- a/nikola/data/themes/bootblog4/bundles
+++ b/nikola/data/themes/bootblog4/bundles
@@ -1,4 +1,0 @@
-assets/css/all-nocdn.css=bootstrap.min.css,rst_base.css,nikola_rst.css,code.css,baguetteBox.min.css,theme.css,bootblog.css,custom.css
-assets/css/all.css=rst_base.css,nikola_rst.css,code.css,baguetteBox.min.css,theme.css,bootblog.css,custom.css
-assets/js/all-nocdn.js=jquery.min.js,popper.min.js,bootstrap.min.js,baguetteBox.min.js,moment-with-locales.min.js,fancydates.min.js
-assets/js/all.js=fancydates.min.js

--- a/nikola/data/themes/bootblog4/bundles.yaml
+++ b/nikola/data/themes/bootblog4/bundles.yaml
@@ -1,0 +1,26 @@
+assets/css/all-nocdn.css:
+  - bootstrap.min.css
+  - rst_base.css
+  - nikola_rst.css
+  - code.css
+  - baguetteBox.min.css
+  - theme.css
+  - bootblog.css
+  - custom.css
+assets/css/all.css:
+  - rst_base.css
+  - nikola_rst.css
+  - code.css
+  - baguetteBox.min.css
+  - theme.css
+  - bootblog.css
+  - custom.css
+assets/js/all-nocdn.js:
+  - jquery.min.js
+  - popper.min.js
+  - bootstrap.min.js
+  - baguetteBox.min.js
+  - moment-with-locales.min.js
+  - fancydates.min.js
+assets/js/all.js:
+  - fancydates.min.js

--- a/nikola/data/themes/bootstrap4-jinja/bundles
+++ b/nikola/data/themes/bootstrap4-jinja/bundles
@@ -1,1 +1,0 @@
-../bootstrap4/bundles

--- a/nikola/data/themes/bootstrap4-jinja/bundles.yaml
+++ b/nikola/data/themes/bootstrap4-jinja/bundles.yaml
@@ -1,0 +1,1 @@
+../bootstrap4/bundles.yaml

--- a/nikola/data/themes/bootstrap4/bundles
+++ b/nikola/data/themes/bootstrap4/bundles
@@ -1,4 +1,0 @@
-assets/css/all-nocdn.css=bootstrap.min.css,rst_base.css,nikola_rst.css,code.css,baguetteBox.min.css,theme.css,custom.css
-assets/css/all.css=rst_base.css,nikola_rst.css,code.css,baguetteBox.min.css,theme.css,custom.css
-assets/js/all-nocdn.js=jquery.min.js,popper.min.js,bootstrap.min.js,baguetteBox.min.js,moment-with-locales.min.js,fancydates.min.js
-assets/js/all.js=fancydates.min.js

--- a/nikola/data/themes/bootstrap4/bundles.yaml
+++ b/nikola/data/themes/bootstrap4/bundles.yaml
@@ -1,0 +1,24 @@
+assets/css/all-nocdn.css:
+  - bootstrap.min.css
+  - rst_base.css
+  - nikola_rst.css
+  - code.css
+  - baguetteBox.min.css
+  - theme.css
+  - custom.css
+assets/css/all.css:
+  - rst_base.css
+  - nikola_rst.css
+  - code.css
+  - baguetteBox.min.css
+  - theme.css
+  - custom.css
+assets/js/all-nocdn.js:
+  - jquery.min.js
+  - popper.min.js
+  - bootstrap.min.js
+  - baguetteBox.min.js
+  - moment-with-locales.min.js
+  - fancydates.min.js
+assets/js/all.js:
+  - fancydates.min.js

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -2197,7 +2197,7 @@ class Nikola(object):
 
         deps = post.deps(lang)
         uptodate_deps = post.deps_uptodate(lang)
-        deps.extend(utils.get_asset_path(x, self.THEMES) for x in ('bundles', 'parent', 'engine'))
+        deps.extend(utils.get_asset_path(x, self.THEMES) for x in ('bundles', 'bundles.yaml', 'bundles.yml', 'parent', 'engine'))
         _theme_ini = utils.get_asset_path(self.config['THEME'] + '.theme', self.THEMES)
         if _theme_ini:
             deps.append(_theme_ini)

--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -34,9 +34,58 @@ try:
 except ImportError:
     webassets = None  # NOQA
 
+import yaml
+try:
+    YamlLoader = yaml.CSafeLoader
+except AttributeError:
+    YamlLoader = yaml.SafeLoader
+
 from nikola.plugin_categories import LateTask
 from nikola import utils
 
+
+def legacy_loader(bundlefilename):
+    """Load bundle files in legacy bundle format.
+
+    Format is of the form:
+
+        targetpath=sourcepath,sourcepath2
+        targetpath2=sourcepath3,sourcepath4
+    """
+    bundles = {}
+    with open(bundlefilename, 'rt') as fd:
+        for line in fd:
+            try:
+                name, files = line.split('=')
+                name = name.strip().replace('/', os.sep)
+                files = [f.strip() for f in files.split(',')]
+                bundles[name] = files
+            except ValueError:
+                # for empty lines
+                pass
+
+
+def yaml_loader(bundlefilename):
+    """Load bundle files in yaml format.
+
+    Format is of the form:
+
+        targetpath:
+          - sourcepath
+          - sourcepath2
+        targetpath2:
+          - sourcepath3
+          - sourcepath4
+    """
+    with open(bundlefilename, 'rt') as fd:
+        return yaml.load(fd, Loader=YamlLoader)
+
+
+EXTENSION_AND_LOADER = [
+    ('.yaml', yaml_loader),
+    ('.yml', yaml_loader),
+    ('', legacy_loader),
+]
 
 class BuildBundles(LateTask):
     """Bundle assets using WebAssets."""
@@ -125,19 +174,11 @@ class BuildBundles(LateTask):
 
 def get_theme_bundles(themes):
     """Given a theme chain, return the bundle definitions."""
-    bundles = {}
     for theme_name in themes:
-        bundles_path = os.path.join(
-            utils.get_theme_path(theme_name), 'bundles')
-        if os.path.isfile(bundles_path):
-            with open(bundles_path) as fd:
-                for line in fd:
-                    try:
-                        name, files = line.split('=')
-                        files = [f.strip() for f in files.split(',')]
-                        bundles[name.strip().replace('/', os.sep)] = files
-                    except ValueError:
-                        # for empty lines
-                        pass
-                break
-    return bundles
+        theme_path = utils.get_theme_path(theme_name)
+        for extension, loader in EXTENSION_AND_LOADER:
+            bundle_filename = 'bundles' + extension
+            bundle_path = os.path.join(theme_path, bundle_filename)
+            if os.path.isfile(bundle_path):
+                return loader(bundle_path)
+    return {}

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -12,6 +12,5 @@ ipykernel>=4.0.0
 ghp-import2>=1.0.0
 aiohttp>=2.3.8
 watchdog>=0.8.3
-PyYAML>=3.12,<=3.13
 toml>=0.9.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ natsort>=3.5.2
 requests>=2.2.0
 piexif>=1.0.3
 Babel>=2.6.0
+PyYAML>=3.12,<=3.13


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

This PR adds support for `bundles.yaml` or `bundles.yml` as alternatives to `bundles` files in themes.

If both are present, the yaml files take precedence. If only `bundles` is present, behavior is unchanged.

`bundles.yaml` takes the form:

```yaml
assets/css/all.css:
  - input1.css
  - input2.css
```

and would replace `bundles` file of the form:

```
assets/css/all.css=input1.css,input2.css
```