### PR TITLE
Fix #3074 — get rid of the webassets library

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,12 @@ Features
 Bugfixes
 --------
 
+Removed features
+----------------
+
+* The ``webassets`` library is no longer required, we now manually
+  bundle files (Issue #3074)
+
 New in v8.0.0b3 (changes since Beta 2)
 ======================================
 

--- a/docs/creating-a-theme.rst
+++ b/docs/creating-a-theme.rst
@@ -813,7 +813,7 @@ Doing the same for layout-reverse, sidebar-overlay and the rest is left as an ex
 Bundles
 -------
 
-If you have ``webassets`` installed and the ``USE_BUNDLES`` option set to True,
+If the ``USE_BUNDLES`` option set to True,
 Nikola can put several CSS or JS files together in a larger file, which can
 makes site load faster for some deployments. To do this, your theme needs
 a ``bundles`` file. The file format is a modified

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2342,7 +2342,7 @@ different ones, or about other web servers, please share!
 4. Optionally you can create static compressed copies and save some CPU on your server
    with the GZIP_FILES option in Nikola.
 
-5. The webassets Nikola plugin can drastically decrease the number of CSS and JS files your site fetches.
+5. The bundles Nikola plugin can drastically decrease the number of CSS and JS files your site fetches.
 
 6. Through the filters feature, you can run your files through arbitrary commands, so that images
    are recompressed, JavaScript is minimized, etc.

--- a/docs/theming.rst
+++ b/docs/theming.rst
@@ -74,8 +74,7 @@ parent, engine
 
 bundles
     A `config <https://docs.python.org/3/library/configparser.html>`_ file
-    containing a list of files to be turned into bundles using WebAssets. For
-    example:
+    containing a list of files to be turned into bundles. For example:
 
     .. code:: ini
 
@@ -93,7 +92,7 @@ bundles
     This makes the page much more efficient because it avoids multiple connections to the server,
     at the cost of some extra difficult debugging.
 
-    WebAssets supports bundling CSS and JS files.
+    Bundling applies to CSS and JS files.
 
     Templates should use either the bundle or the individual files based on the ``use_bundles``
     variable, which in turn is set by the ``USE_BUNDLES`` option.

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1191,9 +1191,9 @@ MARKDOWN_EXTENSIONS = ['markdown.extensions.fenced_code', 'markdown.extensions.c
 #     # 'creator': '@username',     # Username for the content creator / author.
 # }
 
-# If webassets is installed, bundle JS and CSS into single files to make
-# site loading faster in a HTTP/1.1 environment but is not recommended for
-# HTTP/2.0 when caching is used. Defaults to True.
+# Bundle JS and CSS into single files to make site loading faster in a HTTP/1.1
+# environment but is not recommended for HTTP/2.0 when caching is used.
+# Defaults to True.
 # USE_BUNDLES = True
 
 # Plugins you don't want to use. Be careful :-)

--- a/nikola/plugins/task/bundles.plugin
+++ b/nikola/plugins/task/bundles.plugin
@@ -6,7 +6,7 @@ module = bundles
 author = Roberto Alsina
 version = 1.0
 website = https://getnikola.com/
-description = Theme bundles using WebAssets
+description = Bundle assets
 
 [Nikola]
 PluginCategory = Task

--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -67,7 +67,7 @@ class BuildBundles(LateTask):
                 for i in inputs:
                     with open(i, 'rb') as in_fh:
                         shutil.copyfileobj(in_fh, out_fh)
-                out_fh.write(b'\n')
+                    out_fh.write(b'\n')
 
         yield self.group_task()
 

--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -67,6 +67,7 @@ class BuildBundles(LateTask):
                 for i in inputs:
                     with open(i, 'rb') as in_fh:
                         shutil.copyfileobj(in_fh, out_fh)
+                out_fh.write(b'\n')
 
         yield self.group_task()
 

--- a/nikola/plugins/task/bundles.py
+++ b/nikola/plugins/task/bundles.py
@@ -24,39 +24,26 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"""Bundle assets using WebAssets."""
+"""Bundle assets."""
 
 
 import configparser
 import io
 import itertools
 import os
-
-try:
-    import webassets
-except ImportError:
-    webassets = None  # NOQA
+import shutil
 
 from nikola.plugin_categories import LateTask
 from nikola import utils
 
 
 class BuildBundles(LateTask):
-    """Bundle assets using WebAssets."""
+    """Bundle assets."""
 
     name = "create_bundles"
 
-    def set_site(self, site):
-        """Set Nikola site."""
-        super(BuildBundles, self).set_site(site)
-        if webassets is None and site.configured and site.config['USE_BUNDLES']:
-            utils.req_missing(['webassets'], 'USE_BUNDLES', optional=True)
-            self.logger.warn('Setting USE_BUNDLES to False.')
-            site.config['USE_BUNDLES'] = False
-            site._GLOBAL_CONTEXT['use_bundles'] = False
-
     def gen_tasks(self):
-        """Bundle assets using WebAssets."""
+        """Bundle assets."""
         kw = {
             'filters': self.site.config['FILTERS'],
             'output_folder': self.site.config['OUTPUT_FOLDER'],
@@ -70,28 +57,20 @@ class BuildBundles(LateTask):
         def build_bundle(output, inputs):
             out_dir = os.path.join(kw['output_folder'],
                                    os.path.dirname(output))
-            inputs = [os.path.relpath(i, out_dir) for i in inputs if os.path.isfile(i)]
-            cache_dir = os.path.join(kw['cache_folder'], 'webassets')
-            utils.makedirs(cache_dir)
-            env = webassets.Environment(out_dir, os.path.dirname(output),
-                                        cache=cache_dir)
-            if inputs:
-                bundle = webassets.Bundle(*inputs, output=os.path.basename(output))
-                env.register(output, bundle)
-                # This generates the file
-                try:
-                    env[output].build(force=True)
-                except Exception as e:
-                    self.logger.error("Failed to build bundles.")
-                    self.logger.exception(e)
-                    self.logger.notice("Try running ``nikola clean`` and building again.")
-            else:
-                with open(os.path.join(out_dir, os.path.basename(output)), 'wb+'):
-                    pass  # Create empty file
+            inputs = [
+                os.path.join(
+                    out_dir,
+                    os.path.relpath(i, out_dir))
+                for i in inputs if os.path.isfile(i)
+            ]
+            with open(os.path.join(out_dir, os.path.basename(output)), 'wb+') as out_fh:
+                for i in inputs:
+                    with open(i, 'rb') as in_fh:
+                        shutil.copyfileobj(in_fh, out_fh)
 
         yield self.group_task()
-        if (webassets is not None and self.site.config['USE_BUNDLES'] is not
-                False):
+
+        if self.site.config['USE_BUNDLES']:
             for name, _files in kw['theme_bundles'].items():
                 output_path = os.path.join(kw['output_folder'], name)
                 dname = os.path.dirname(name)

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -6,7 +6,6 @@ micawber>=0.3.0
 pygal>=2.0.0
 typogrify>=2.0.4
 phpserialize>=1.3
-webassets>=0.10.1
 notebook>=4.0.0
 ipykernel>=4.0.0
 ghp-import2>=1.0.0

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -28,7 +28,6 @@ parts:
             - pygal>=2.0.0
             - typogrify>=2.0.4
             - phpserialize>=1.3
-            - webassets>=0.10.1
             - ghp-import2>=1.0.0
             - ws4py==0.3.5
             - watchdog==0.8.3


### PR DESCRIPTION
This is #3074. cc @dvzrv.

(Added bonus, no more USE_BUNDLES dependency warning by default.)