### PR TITLE
LocaleBorg date formatting overrides: added missing returns

### DIFF
--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1206,7 +1206,7 @@ class LocaleBorg(object):
             # zone designator for times in UTC and no microsecond precision.
             return date.replace(microsecond=0).isoformat().replace('+00:00', 'Z')
         elif LocaleBorg.datetime_formatter is not None:
-            LocaleBorg.datetime_formatter(date, date_format, lang, locale)
+            return LocaleBorg.datetime_formatter(date, date_format, lang, locale)
         else:
             return babel.dates.format_datetime(date, date_format, locale=locale)
 
@@ -1230,7 +1230,7 @@ class LocaleBorg(object):
             """Format a date as requested."""
             mode, custom_format = match.groups()
             if LocaleBorg.in_string_formatter is not None:
-                LocaleBorg.in_string_formatter(date, mode, custom_format, lang, locale)
+                return LocaleBorg.in_string_formatter(date, mode, custom_format, lang, locale)
             elif custom_format:
                 return babel.dates.format_date(date, custom_format, locale)
             else:


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable). (IMO the change is trivial -- no update ;) )
- [X] I tested my changes.

### Description
I finally got around to adjust my plugin, and found some missing `return`s :)