### PR TITLE
Fix #2863 — allow light navbar in bootstrap4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,8 @@ Features
 * All built-in themes now support the ``DATE_FANCINESS`` option.
 * Theme bundles are now parsed using the configparser module and
   can support newlines inside entries as well as comments
+* Make bootstrap4 navbar color configurable with
+  ``THEME_CONFIG['navbar_light']`` (Issue #2863)
 
 Bugfixes
 --------

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -101,6 +101,9 @@ THEME_COLOR = '#5670d4'
 
 # Theme configuration. Fully theme-dependent. (translatable)
 # Examples below are for bootblog4.
+# bootblog4 supports: featured_large featured_small featured_on_mobile
+#                     featured_large_image_on_mobile featured_strip_html sidebar
+# bootstrap4 supports: navbar_light (defaults to False)
 THEME_CONFIG = {
     DEFAULT_LANG: {
         # Show the latest featured post in a large box, with the previewimage as its background.

--- a/nikola/data/themes/bootstrap4-jinja/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base.tmpl
@@ -13,7 +13,13 @@
 
 <!-- Menubar -->
 
-<nav class="navbar navbar-expand-md navbar-dark bg-dark static-top mb-4">
+<nav class="navbar navbar-expand-md static-top mb-4
+{% if theme_config.get('navbar_light') %}
+navbar-light bg-light
+{% else %}
+navbar-dark bg-dark
+{% endif %}
+">
     <div class="container"><!-- This keeps the margins nice -->
         <a class="navbar-brand" href="{{ abs_link(_link("root", None, lang)) }}">
         {% if logo_url %}

--- a/nikola/data/themes/bootstrap4/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base.tmpl
@@ -13,7 +13,13 @@ ${template_hooks['extra_head']()}
 
 <!-- Menubar -->
 
-<nav class="navbar navbar-expand-md navbar-dark bg-dark static-top mb-4">
+<nav class="navbar navbar-expand-md static-top mb-4
+% if theme_config.get('navbar_light'):
+navbar-light bg-light
+% else:
+navbar-dark bg-dark
+% endif
+">
     <div class="container"><!-- This keeps the margins nice -->
         <a class="navbar-brand" href="${abs_link(_link("root", None, lang))}">
         %if logo_url:


### PR DESCRIPTION
Make bootstrap4 navbar color configurable with `THEME_CONFIG['navbar_light']` (Issue #2863)