### PR TITLE
Remove doctitle if not using reST docinfo metadata

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,8 @@ Features
 Bugfixes
 --------
 
+* Do not remove first heading in document (reST document title)
+  if ``USE_REST_DOCINFO_METADATA`` is disabled (Issue #3124)
 * Remove ``NO_DOCUTILS_TITLE_TRANSFORM`` setting,
   this is now default behavior if ``USE_REST_DOCINFO_METADATA``
   is disabled (Issue #2382, #3124)

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Features
 Bugfixes
 --------
 
+* Remove ``NO_DOCUTILS_TITLE_TRANSFORM`` setting,
+  this is now default behavior if ``USE_REST_DOCINFO_METADATA``
+  is disabled (Issue #2382, #3124)
 * Enforce trailing slash for directories in ``nikola auto``
   (Issue #3140)
 * Galleries with baguetteBox don’t glitch out on the first image

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1139,7 +1139,9 @@ MARKDOWN_EXTENSIONS = ['markdown.extensions.fenced_code', 'markdown.extensions.c
 # Should titles fetched from file metadata be unslugified (made prettier?)
 # FILE_METADATA_UNSLUGIFY_TITLES = True
 
-# If enabled, extract metadata from docinfo fields in reST documents
+# If enabled, extract metadata from docinfo fields in reST documents.
+# If your text files start with a level 1 heading, it will be treated as the
+# document title and will be removed from the text.
 # USE_REST_DOCINFO_METADATA = False
 
 # If enabled, hide docinfo fields in reST document output

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1232,12 +1232,6 @@ MARKDOWN_EXTENSIONS = ['markdown.extensions.fenced_code', 'markdown.extensions.c
 # (defaults to 1.)
 # DEMOTE_HEADERS = 1
 
-# Docutils, by default, will perform a transform in your documents
-# extracting unique titles at the top of your document and turning
-# them into metadata. This surprises a lot of people, and setting
-# this option to True will prevent it.
-# NO_DOCUTILS_TITLE_TRANSFORM = False
-
 # If you don’t like slugified file names ([a-z0-9] and a literal dash),
 # and would prefer to use all the characters your file system allows.
 # USE WITH CARE!  This is also not guaranteed to be perfect, and may

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -75,7 +75,7 @@ class CompileRest(PageCompiler):
         null_logger.handlers = [logbook.NullHandler()]
         with io.open(source_path, 'r', encoding='utf-8') as inf:
             data = inf.read()
-            _, _, _, document = rst2html(data, logger=null_logger, source_path=source_path, transforms=self.site.rst_transforms, no_title_transform=False)
+            _, _, _, document = rst2html(data, logger=null_logger, source_path=source_path, transforms=self.site.rst_transforms)
         meta = {}
         if 'title' in document:
             meta['title'] = document['title']
@@ -132,8 +132,7 @@ class CompileRest(PageCompiler):
         if self.site.config.get('HIDE_REST_DOCINFO', False):
             self.site.rst_transforms.append(RemoveDocinfo)
         output, error_level, deps, _ = rst2html(
-            new_data, settings_overrides=settings_overrides, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms,
-            no_title_transform=self.site.config.get('NO_DOCUTILS_TITLE_TRANSFORM', False))
+            new_data, settings_overrides=settings_overrides, logger=self.logger, source_path=source_path, l_add_ln=add_ln, transforms=self.site.rst_transforms)
         if not isinstance(output, unicode_str):
             # To prevent some weird bugs here or there.
             # Original issue: empty files.  `output` became a bytestring.
@@ -230,15 +229,11 @@ class NikolaReader(docutils.readers.standalone.Reader):
     def __init__(self, *args, **kwargs):
         """Initialize the reader."""
         self.transforms = kwargs.pop('transforms', [])
-        self.no_title_transform = kwargs.pop('no_title_transform', False)
         docutils.readers.standalone.Reader.__init__(self, *args, **kwargs)
 
     def get_transforms(self):
         """Get docutils transforms."""
-        transforms = docutils.readers.standalone.Reader(self).get_transforms() + self.transforms
-        if self.no_title_transform:
-            transforms = [t for t in transforms if str(t) != "<class 'docutils.transforms.frontmatter.DocTitle'>"]
-        return transforms
+        return docutils.readers.standalone.Reader(self).get_transforms() + self.transforms
 
     def new_document(self):
         """Create and return a new empty document tree (root node)."""
@@ -304,8 +299,7 @@ def rst2html(source, source_path=None, source_class=docutils.io.StringInput,
              parser=None, parser_name='restructuredtext', writer=None,
              writer_name='html', settings=None, settings_spec=None,
              settings_overrides=None, config_section=None,
-             enable_exit_status=None, logger=None, l_add_ln=0, transforms=None,
-             no_title_transform=False):
+             enable_exit_status=None, logger=None, l_add_ln=0, transforms=None):
     """Set up & run a ``Publisher``, and return a dictionary of document parts.
 
     Dictionary keys are the names of parts, and values are Unicode strings;

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -124,7 +124,8 @@ class CompileRest(PageCompiler):
             # warnings about it from reST.
             'math_output': 'mathjax /assets/js/mathjax.js',
             'template': default_template_path,
-            'language_code': LEGAL_VALUES['DOCUTILS_LOCALES'].get(LocaleBorg().current_lang, 'en')
+            'language_code': LEGAL_VALUES['DOCUTILS_LOCALES'].get(LocaleBorg().current_lang, 'en'),
+            'doctitle_xform': not self.site.config.get('USE_REST_DOCINFO_METADATA'),
         }
 
         from nikola import shortcodes as sc

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -229,6 +229,7 @@ class NikolaReader(docutils.readers.standalone.Reader):
     def __init__(self, *args, **kwargs):
         """Initialize the reader."""
         self.transforms = kwargs.pop('transforms', [])
+        self.logging_settings = kwargs.pop('nikola_logging_settings', {})
         docutils.readers.standalone.Reader.__init__(self, *args, **kwargs)
 
     def get_transforms(self):
@@ -239,7 +240,7 @@ class NikolaReader(docutils.readers.standalone.Reader):
         """Create and return a new empty document tree (root node)."""
         document = docutils.utils.new_document(self.source.source_path, self.settings)
         document.reporter.stream = False
-        document.reporter.attach_observer(get_observer(self.l_settings))
+        document.reporter.attach_observer(get_observer(self.logging_settings))
         return document
 
 
@@ -317,14 +318,16 @@ def rst2html(source, source_path=None, source_class=docutils.io.StringInput,
              reStructuredText syntax errors.
     """
     if reader is None:
-        reader = NikolaReader(transforms=transforms, no_title_transform=no_title_transform)
         # For our custom logging, we have special needs and special settings we
         # specify here.
         # logger    a logger from Nikola
         # source   source filename (docutils gets a string)
         # add_ln   amount of metadata lines (see comment in CompileRest.compile above)
-        reader.l_settings = {'logger': logger, 'source': source_path,
-                             'add_ln': l_add_ln}
+        reader = NikolaReader(transforms=transforms,
+                              nikola_logging_settings={
+                                  'logger': logger, 'source': source_path,
+                                  'add_ln': l_add_ln
+                              })
 
     pub = docutils.core.Publisher(reader, parser, writer, settings=settings,
                                   source_class=source_class,


### PR DESCRIPTION
This is #2382, #3124, and probably a lot of other issues.

New behavior: doctitle (first header) disappears only if `USE_REST_DOCINFO_METADATA` is true. I also re-implemented the feature in a less hacky way.

The old (but not well-known, even by the core devs) setting `NO_DOCUTILS_TITLE_TRANSFORM` was removed.