### PR TITLE
Fix #3167 — fix docinfo removal for sites that use reST docinfo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,15 @@
+New in master
+=============
+
+Features
+--------
+
+Bugfixes
+--------
+
+* Fix docinfo removal for sites that use reST docinfo metadata
+  (Issue #3167)
+
 New in v8.0.0
 =============
 

--- a/docs/creating-a-site.rst
+++ b/docs/creating-a-site.rst
@@ -1,13 +1,10 @@
+.. title: Creating a Site (Not a Blog) with Nikola
 .. slug: creating-a-site-not-a-blog-with-nikola
 .. date: 2015-01-10 10:00:00 UTC
 .. tags: nikola, python
 .. link:
 .. description:
-.. title: Creating a Site (Not a Blog) with Nikola
 .. author: The Nikola Team
-
-Creating a Site (Not a Blog) with Nikola
-========================================
 
 .. class:: lead
 

--- a/docs/creating-a-theme.rst
+++ b/docs/creating-a-theme.rst
@@ -7,9 +7,6 @@
 .. description:
 .. type: text
 
-Creating a Theme
-================
-
 Nikola is a static site and blog generator. So is Jekyll. While I like what we have done with Nikola,
 I do admit that Jekyll (and others!) have many more, and nicer themes than Nikola does.
 

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -6,9 +6,6 @@
 .. description:
 .. author: The Nikola Team
 
-Extending Nikola
-================
-
 :Version: 8.0.0
 :Author: Roberto Alsina <ralsina@netmanagers.com.ar>
 

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -6,9 +6,6 @@
 .. description:
 .. author: The Nikola Team
 
-Nikola Internals
-================
-
 .. class:: lead
 
 When trying to guide someone into adding a feature in Nikola, it hit me that
@@ -97,7 +94,7 @@ posts are added into RSS feeds and pages are not. All of them are in a list call
 
 When you are creating a task that needs the list of posts and/or pages (for example,
 the RSS creation plugin) on task execution time, your plugin should call ``self.site.scan_posts()``
-in ``gen_tasks`` to ensure the timeline is created and available in 
+in ``gen_tasks`` to ensure the timeline is created and available in
 ``self.site.timeline``. You should not modify the timeline, because it will cause consistency issues.
 
 .. sidebar:: scan_posts

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -7,9 +7,6 @@
 .. has_math: true
 .. author: The Nikola Team
 
-The Nikola Handbook
-===================
-
 :Version: 8.0.0
 
 .. class:: alert alert-primary float-md-right

--- a/docs/social_buttons.rst
+++ b/docs/social_buttons.rst
@@ -1,13 +1,10 @@
-.. title: Alternative Social Buttons
+.. title: Using Alternative Social Buttons with Nikola
 .. slug: social_buttons
 .. date: 2013-08-19 23:00:00 UTC-03:00
 .. tags:
 .. link:
 .. description:
 .. author: The Nikola Team
-
-Using Alternative Social Buttons with Nikola
-============================================
 
 :Version: 8.0.0
 

--- a/docs/theming.rst
+++ b/docs/theming.rst
@@ -6,9 +6,6 @@
 .. description:
 .. author: The Nikola Team
 
-Theming Nikola
-==============
-
 :Version: 8.0.0
 :Author: Roberto Alsina <ralsina@netmanagers.com.ar>
 

--- a/nikola/data/samplesite/pages/quickstart.rst
+++ b/nikola/data/samplesite/pages/quickstart.rst
@@ -5,9 +5,6 @@
 .. link:
 .. description:
 
-A ReStructuredText Primer
-=========================
-
 :Author: Richard Jones
 :Version: $Revision: 5801 $
 :Copyright: This document has been placed in the public domain.

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -842,12 +842,12 @@ class Nikola(object):
                 metadata_extractors.DEFAULT_EXTRACTOR_NAME))
             sys.exit(1)
 
-        # The pelican metadata format requires a markdown extension
+        # The Pelican metadata format requires a markdown extension
         if config.get('METADATA_FORMAT', 'nikola').lower() == 'pelican':
             if 'markdown.extensions.meta' not in config.get('MARKDOWN_EXTENSIONS', []) \
                     and 'markdown' in self.config['COMPILERS']:
                 utils.LOGGER.warn(
-                    'To use the pelican metadata format you need to add '
+                    'To use the Pelican metadata format, you need to add '
                     '"markdown.extensions.meta" to your MARKDOWN_EXTENSIONS setting.')
 
         # We use one global tzinfo object all over Nikola.

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -125,7 +125,7 @@ class CompileRest(PageCompiler):
             'math_output': 'mathjax /assets/js/mathjax.js',
             'template': default_template_path,
             'language_code': LEGAL_VALUES['DOCUTILS_LOCALES'].get(LocaleBorg().current_lang, 'en'),
-            'doctitle_xform': not self.site.config.get('USE_REST_DOCINFO_METADATA'),
+            'doctitle_xform': self.site.config.get('USE_REST_DOCINFO_METADATA'),
         }
 
         from nikola import shortcodes as sc


### PR DESCRIPTION
This fixes #3167. cc @gwax.

It *seems* to work properly now with my testing, but it would be good if someone else also tested it (in particular, title removal with reST docinfo metadata both on and off)