### PR TITLE
Using Twitter cards does not require an opt-in anymore.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Bugfixes
 
 * Don’t warn if post status is set to ``published`` explicitly
   (Issue #3181)
+* Remove mention of Twitter cards requiring an opt-in.
+  This is not true anymore - anyone can use them.
 
 New in v8.0.1
 =============

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2929,11 +2929,6 @@ to your content.
 Nikola supports `Twitter Cards <https://dev.twitter.com/docs/cards>`_.
 They are implemented to use *Open Graph* tags whenever possible.
 
-.. admonition:: Important
-
-    To use Twitter Cards you need to opt-in on Twitter.
-    To do so, please visit https://cards-dev.twitter.com/validator
-
 Images displayed come from the `previewimage` meta tag.
 
 You can specify the card type by using the `card` parameter in TWITTER_CARD.

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1178,10 +1178,6 @@ MARKDOWN_EXTENSIONS = ['markdown.extensions.fenced_code', 'markdown.extensions.c
 # They make it possible for you to attach media to Tweets that link
 # to your content.
 #
-# IMPORTANT:
-# Please note, that you need to opt-in for using Twitter Cards!
-# To do this please visit https://cards-dev.twitter.com/validator
-#
 # Uncomment and modify to following lines to match your accounts.
 # Images displayed come from the `previewimage` meta tag.
 # You can specify the card type by using the `card` parameter in TWITTER_CARD.


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

When the Twitter card support was implemented this was something that required an opt-in in their developer platform.
This is not the case anymore and hints about this may be misleading because people do not find a way to opt-in.
