### PR TITLE
Correct behavior of ipynb compile config

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -283,7 +283,7 @@ COMPILERS = ${COMPILERS}
 # and displayed underneath the tag list or index page’s title.
 # TAG_DESCRIPTIONS = {
 #    DEFAULT_LANG: {
-#        "blogging": "Meta-blog posts about blogging about blogging.",
+#        "blogging": "Meta-blog posts about blogging.",
 #        "open source": "My contributions to my many, varied, ever-changing, and eternal libre software projects."
 #    },
 # }
@@ -356,7 +356,7 @@ CATEGORY_OUTPUT_FLAT_HIERARCHY = ${CATEGORY_OUTPUT_FLAT_HIERARCHY}
 # and displayed underneath the category list or index page’s title.
 # CATEGORY_DESCRIPTIONS = {
 #    DEFAULT_LANG: {
-#        "blogging": "Meta-blog posts about blogging about blogging.",
+#        "blogging": "Meta-blog posts about blogging.",
 #        "open source": "My contributions to my many, varied, ever-changing, and eternal libre software projects."
 #    },
 # }
@@ -963,7 +963,7 @@ PRETTY_URLS = ${PRETTY_URLS}
 # feature yet, it's faster and the output looks better.
 # USE_KATEX = False
 
-# KaTeX auto-render settings. If you want support for the $.$ syntax (wihch may
+# KaTeX auto-render settings. If you want support for the $.$ syntax (which may
 # conflict with running text!), just use this config:
 # KATEX_AUTO_RENDER = """
 # delimiters: [
@@ -979,7 +979,7 @@ PRETTY_URLS = ${PRETTY_URLS}
 # IPYNB_CONFIG = {}
 # With the following example configuration you can use a custom jinja template
 # called `toggle.tpl` which has to be located in your site/blog main folder:
-# IPYNB_CONFIG = {'Exporter':{'template_file': 'toggle'}}
+# IPYNB_CONFIG = {'Exporter': {'template_file': 'toggle'}}
 
 # What Markdown extensions to enable?
 # You will also get gist, nikola and podcast because those are

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -57,8 +57,8 @@ class CompileIPynb(PageCompiler):
     def _compile_string(self, nb_json):
         """Export notebooks as HTML strings."""
         self._req_missing_ipynb()
-        c = Config(self.site.config['IPYNB_CONFIG'])
-        c.update(get_default_jupyter_config())
+        c = Config(get_default_jupyter_config())
+        c.merge(Config(self.site.config['IPYNB_CONFIG']))
         if 'template_file' not in self.site.config['IPYNB_CONFIG'].get('Exporter', {}):
             c['Exporter']['template_file'] = 'basic.tpl'  # not a typo
         exportHtml = HTMLExporter(config=c)


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

We should use Traitlets config's [merge](https://github.com/ipython/traitlets/blob/master/traitlets/config/loader.py#L190) method to update default config from IPYNB_CONFIG, rather than relies on `dict`'s update. The `update` method erases the content of `Config(self.site.config['IPYNB_CONFIG'])` when both `get_default_jupyter_config()` and `self.site.config['IPYNB_CONFIG'])` have the same `Exporter` key.