### PR TITLE
Fix DeprecationWarning: invalid escape sequence in dodo.py

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -78,6 +78,7 @@
 * `Michael Joseph <https://github.com/michaeljoseph>`_
 * `Michael McNeil Forbes <https://github.com/mforbes>`_
 * `Michal Petrucha <https://github.com/koniiiik>`_
+* `Mickaël Schoentgen <https://github.com/BoboTiG>`_
 * `Miguel Ángel García <https://github.com/magmax>`_
 * `Mitch Chapman <https://github.com/mchapman87501>`_
 * `mrabbitt <https://github.com/mrabbitt>`_

--- a/dodo.py
+++ b/dodo.py
@@ -28,7 +28,7 @@ def task_pydocstyle():
     """pydocstyle -- static check for docstring style"""
     yield {
         'name': os.path.join(os.getcwd(), 'nikola'),
-        'actions': ["pydocstyle --count --match-dir='(?!^\.)(?!data).*' nikola/"],
+        'actions': ["pydocstyle --count --match-dir='(?!^\\.)(?!data).*' nikola/"],
     }
 
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

A little patch to fix `DeprecationWarning: invalid escape sequence` in `dodo.py`.