### PR TITLE
Fix #3210 -- Correctly handle separators for "ignored_assets"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Bugfixes
 --------
 
+* Correctly handle separators in the relative path given to
+  "ignored_assets" key in theme meta files (Issue #3210)
 * Fix error when ``nikola new_post`` receives directory name as
   path (Issue #3207)
 * Read listings files as UTF-8

--- a/nikola/plugins/task/copy_assets.py
+++ b/nikola/plugins/task/copy_assets.py
@@ -67,7 +67,7 @@ class CopyAssets(Task):
         theme_ini = utils.parse_theme_meta(main_theme)
         if theme_ini:
             ignored_assets = theme_ini.get("Nikola", "ignored_assets", fallback='').split(',')
-            ignored_assets = [asset_name.strip() for asset_name in ignored_assets]
+            ignored_assets = [os.path.normpath(asset_name).strip() for asset_name in ignored_assets]
         else:
             ignored_assets = []
 

--- a/nikola/plugins/task/copy_assets.py
+++ b/nikola/plugins/task/copy_assets.py
@@ -67,7 +67,7 @@ class CopyAssets(Task):
         theme_ini = utils.parse_theme_meta(main_theme)
         if theme_ini:
             ignored_assets = theme_ini.get("Nikola", "ignored_assets", fallback='').split(',')
-            ignored_assets = [os.path.normpath(asset_name).strip() for asset_name in ignored_assets]
+            ignored_assets = [os.path.normpath(asset_name.strip()) for asset_name in ignored_assets]
         else:
             ignored_assets = []
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Fix Issue https://github.com/getnikola/nikola/issues/3210 by normalizing the relative path to the convention of the operating system when parsing the theme meta file.