### PR TITLE
Replace PyYAML with ruamel.yaml.

### DIFF
--- a/nikola/metadata_extractors.py
+++ b/nikola/metadata_extractors.py
@@ -30,6 +30,7 @@ import re
 import natsort
 
 from enum import Enum
+from io import StringIO
 from nikola.plugin_categories import MetadataExtractor
 from nikola.utils import unslugify
 
@@ -185,7 +186,7 @@ class YAMLMetadata(MetadataExtractor):
     name = 'yaml'
     source = MetaSource.text
     conditions = ((MetaCondition.first_line, '---'),)
-    requirements = [('yaml', 'PyYAML', 'YAML')]
+    requirements = [('ruamel.yaml', 'ruamel.yaml', 'YAML')]
     supports_write = True
     split_metadata_re = re.compile('\n---\n')
     map_from = 'yaml'
@@ -193,8 +194,9 @@ class YAMLMetadata(MetadataExtractor):
 
     def _extract_metadata_from_text(self, source_text: str) -> dict:
         """Extract metadata from text."""
-        import yaml
-        meta = yaml.safe_load(source_text[4:])
+        from ruamel.yaml import YAML
+        yaml = YAML(typ='safe')
+        meta = yaml.load(source_text[4:])
         # We expect empty metadata to be '', not None
         for k in meta:
             if meta[k] is None:
@@ -203,8 +205,13 @@ class YAMLMetadata(MetadataExtractor):
 
     def write_metadata(self, metadata: dict, comment_wrap=False) -> str:
         """Write metadata in this extractor’s format."""
-        import yaml
-        return '\n'.join(('---', yaml.safe_dump(metadata, default_flow_style=False).strip(), '---', ''))
+        from ruamel.yaml import YAML
+        yaml = YAML(typ='safe')
+        yaml.default_flow_style = False
+        stream = StringIO()
+        yaml.dump(metadata, stream)
+        stream.seek(0)
+        return '\n'.join(('---', stream.read().strip(), '---', ''))
 
 
 @_register_default

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -34,9 +34,9 @@ import mimetypes
 import os
 
 try:
-    import yaml
+    from ruamel.yaml import YAML
 except ImportError:
-    yaml = None  # NOQA
+    YAML = None  # NOQA
 
 try:
     from urlparse import urljoin
@@ -441,7 +441,7 @@ class Galleries(Task, ImageProcessor):
         order:
         #
         If a numeric order value is specified, we use that directly, otherwise
-        we depend on how PyYAML returns the information - which may or may not
+        we depend on how the library returns the information - which may or may not
         be in the same order as in the file itself. Non-numeric ordering is not
         supported. If no caption is specified, then we return an empty string.
         Returns a string (l18n'd filename), list (ordering), dict (captions),
@@ -465,9 +465,10 @@ class Galleries(Task, ImageProcessor):
         self.logger.debug("Using {0} for gallery {1}".format(
             used_path, gallery))
         with open(used_path, "r", encoding='utf-8-sig') as meta_file:
-            if yaml is None:
-                utils.req_missing(['PyYAML'], 'use metadata.yml files for galleries')
-            meta = yaml.safe_load_all(meta_file)
+            if YAML is None:
+                utils.req_missing(['ruamel.yaml'], 'use metadata.yml files for galleries')
+            yaml = YAML(typ='safe')
+            meta = yaml.load_all(meta_file)
             for img in meta:
                 # load_all and safe_load_all both return None as their
                 # final element, so skip it

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -49,14 +49,6 @@ try:
     import pyphen
 except ImportError:
     pyphen = None
-try:
-    import toml
-except ImportError:
-    toml = None
-try:
-    import yaml
-except ImportError:
-    yaml = None
 
 from math import ceil  # for reading time feature
 

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -59,9 +59,9 @@ try:
 except ImportError:
     toml = None
 try:
-    import yaml
+    from ruamel.yaml import YAML
 except ImportError:
-    yaml = None
+    YAML = None
 try:
     import husl
 except ImportError:
@@ -1908,10 +1908,10 @@ def load_data(path):
     loader = None
     function = 'load'
     if ext in {'.yml', '.yaml'}:
-        loader = yaml
-        function = 'safe_load'
-        if yaml is None:
-            req_missing(['yaml'], 'use YAML data files')
+        loader = YAML(typ='safe')
+        function = 'load'
+        if YAML is None:
+            req_missing(['ruamel.yaml'], 'use YAML data files')
             return {}
     elif ext in {'.json', '.js'}:
         loader = json

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -11,6 +11,6 @@ ipykernel>=4.0.0
 ghp-import2>=1.0.0
 aiohttp>=2.3.8
 watchdog>=0.8.3
-PyYAML>=3.12,<=3.13
+ruamel.yaml>=0.15
 toml>=0.9.2
 


### PR DESCRIPTION
PyYAML is effectively unmaintained. Many sources are considering PyYAML insecure, and even though this claim is debatable, they still want the unsafe API to be default. Ruamel’s fork is actively maintained and has a saner approach. In addition, if the YAML-config project eventually becomes a thing, we would need that library anyway.