### PR TITLE
Fix #3225 -- make Isso configurable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,8 @@ Bugfixes
 Features
 --------
 
+* Support configuring Isso via ``GLOBAL_CONTEXT['isso_config']``
+  (Issue #3225)
 * Handle fragments in doc role (Issue #3212)
 * Slugify references in doc role.
 * Add Interlingua translation by Alberto Mardegan

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1845,12 +1845,12 @@ are probably expecting: comments.
 
 Nikola supports several third party comment systems:
 
-* `DISQUS <http://disqus.com>`_
-* `IntenseDebate <http://www.intensedebate.com/>`_
-* `LiveFyre <http://www.livefyre.com/>`_
-* `Muut (Formerly moot) <http://muut.com>`_
-* `Facebook <http://facebook.com/>`_
-* `Isso <http://posativ.org/isso/>`_
+* `DISQUS <https://disqus.com>`_
+* `IntenseDebate <https://www.intensedebate.com/>`_
+* `LiveFyre <https://www.livefyre.com/>`_
+* `Muut (Formerly moot) <https://muut.com/>`_
+* `Facebook <https://facebook.com/>`_
+* `Isso <httsp://posativ.org/isso/>`_
 * `Commento <https://github.com/adtac/commento>`_
 
 By default it will use DISQUS, but you can change by setting ``COMMENT_SYSTEM``

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1850,7 +1850,7 @@ Nikola supports several third party comment systems:
 * `LiveFyre <http://www.livefyre.com/>`_
 * `Muut (Formerly moot) <http://muut.com>`_
 * `Facebook <http://facebook.com/>`_
-* `isso <http://posativ.org/isso/>`_
+* `Isso <http://posativ.org/isso/>`_
 * `Commento <https://github.com/adtac/commento>`_
 
 By default it will use DISQUS, but you can change by setting ``COMMENT_SYSTEM``
@@ -1868,9 +1868,10 @@ to one of "disqus", "intensedebate", "livefyre", "moot", "facebook", "isso" or "
    * For Facebook, you need to `create an app
      <https://developers.facebook.com/apps>`_ (turn off sandbox mode!)
      and get an **App ID**
-   * For isso, it is the URL of isso (must be world-accessible, encoded with
+   * For Isso, it is the URL of your Isso instance (must be world-accessible, encoded with
      Punycode (if using Internationalized Domain Names) and **have a trailing slash**,
-     default ``http://localhost:8080/``)
+     default ``http://localhost:8080/``). You can add custom config options via
+     GLOBAL_CONTEXT, eg. ``GLOBAL_CONTEXT['isso_config'] = {"require-author": "true"}``
    * For commento it's the URL of the commento instance as required by the ``serverUrl``
      parameter in commento's documentation.
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1850,7 +1850,7 @@ Nikola supports several third party comment systems:
 * `LiveFyre <https://www.livefyre.com/>`_
 * `Muut (Formerly moot) <https://muut.com/>`_
 * `Facebook <https://facebook.com/>`_
-* `Isso <httsp://posativ.org/isso/>`_
+* `Isso <https://posativ.org/isso/>`_
 * `Commento <https://github.com/adtac/commento>`_
 
 By default it will use DISQUS, but you can change by setting ``COMMENT_SYSTEM``

--- a/nikola/data/themes/base-jinja/templates/comments_helper_isso.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper_isso.tmpl
@@ -2,7 +2,13 @@
 {% macro comment_form(url, title, identifier) %}
     {% if comment_system_id %}
         <div data-title="{{ title|urlencode }}" id="isso-thread"></div>
-        <script src="{{ comment_system_id }}js/embed.min.js" data-isso="{{ comment_system_id }}"></script>
+        <script src="{{ comment_system_id }}js/embed.min.js" data-isso="{{ comment_system_id }}" data-isso-lang="{{ lang }}"
+        {% if isso_config %}
+        {% for k, v in isso_config.items() %}
+        data-isso-{{ k }}="{{ v }}"
+        {% endfor %}
+        {% endif %}
+        ></script>
     {% endif %}
 {% endmacro %}
 
@@ -15,6 +21,6 @@
 
 {% macro comment_link_script() %}
     {% if comment_system_id and 'index' in pagekind %}
-        <script src="{{ comment_system_id }}js/count.min.js" data-isso="{{ comment_system_id }}"></script>
+        <script src="{{ comment_system_id }}js/count.min.js" data-isso="{{ comment_system_id }}" data-isso-lang="{{ lang }}"></script>
     {% endif %}
 {% endmacro %}

--- a/nikola/data/themes/base/templates/comments_helper_isso.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper_isso.tmpl
@@ -2,7 +2,13 @@
 <%def name="comment_form(url, title, identifier)">
     %if comment_system_id:
         <div data-title="${title|u}" id="isso-thread"></div>
-        <script src="${comment_system_id}js/embed.min.js" data-isso="${comment_system_id}"></script>
+        <script src="${comment_system_id}js/embed.min.js" data-isso="${comment_system_id}" data-isso-lang="${lang}"
+        % if isso_config:
+        % for k, v in isso_config.items():
+        data-isso-${k}="${v}"
+        % endfor
+        % endif
+        ></script>
     %endif
 </%def>
 
@@ -15,6 +21,6 @@
 
 <%def name="comment_link_script()">
     %if comment_system_id and 'index' in pagekind:
-        <script src="${comment_system_id}js/count.min.js" data-isso="${comment_system_id}"></script>
+        <script src="${comment_system_id}js/count.min.js" data-isso="${comment_system_id}" data-isso-lang="${lang}"></script>
     %endif
 </%def>


### PR DESCRIPTION
This is #3225. The configurability support lives in `GLOBAL_CONTEXT['isso_config']`.