### PR TITLE
bootstrap4, bootblog4: don't load moment.js when date_fanciness=0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,8 @@ Bugfixes
 * Remove mention of Twitter cards requiring an opt-in.
   This is not true anymore - anyone can use them.
 * fancydates now workwith listdate items (eg. archives)
+* bootstrap4 and bootblog4 themes no longer load moment.js when
+  fancydates are off. (Issue #3231)
 
 Features
 --------

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1632,6 +1632,7 @@ For Mako:
 
 .. code:: html
 
+    % if date_fanciness != 0:
     <!-- required scripts -- best handled with bundles -->
     <script src="/assets/js/moment-with-locales.min.js"></script>
     <script src="/assets/js/fancydates.js"></script>
@@ -1642,12 +1643,14 @@ For Mako:
     fancydates(${date_fanciness}, ${js_date_format});
     </script>
     <!-- end fancy dates code -->
+    %endif
 
 
 For Jinja2:
 
 .. code:: html
 
+    {% if date_fanciness != 0 %}
     <!-- required scripts -- best handled with bundles -->
     <script src="/assets/js/moment-with-locales.min.js"></script>
     <script src="/assets/js/fancydates.js"></script>
@@ -1658,6 +1661,7 @@ For Jinja2:
     fancydates({{ date_fanciness }}, {{ js_date_format }});
     </script>
     <!-- end fancy dates code -->
+    {% endif %}
 
 
 Adding Files

--- a/nikola/data/themes/base-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_helper.tmpl
@@ -66,9 +66,6 @@ lang="{{ lang }}">
     {% if use_bundles %}
         {% if use_cdn %}
             <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-            {% if date_fanciness != 0 %}
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
-            {% endif %}
             <script src="/assets/js/all.js"></script>
         {% else %}
             <script src="/assets/js/all-nocdn.js"></script>
@@ -76,16 +73,17 @@ lang="{{ lang }}">
     {% else %}
         {% if use_cdn %}
             <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-            {% if date_fanciness != 0 %}
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
-            {% endif %}
         {% else %}
             <script src="/assets/js/baguetteBox.min.js"></script>
-            {% if date_fanciness != 0 %}
-                <script src="/assets/js/moment-with-locales.min.js"></script>
-            {% endif %}
         {% endif %}
-        {% if date_fanciness != 0 %}
+    {% endif %}
+    {% if date_fanciness != 0 %}
+        {% if use_cdn %}
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js" crossorigin="anonymous"></script>
+        {% else %}
+            <script src="/assets/js/moment-with-locales.min.js"></script>
+        {% endif %}
+        {% if not use_bundles %}
             <script src="/assets/js/fancydates.js"></script>
         {% endif %}
     {% endif %}

--- a/nikola/data/themes/base/bundles
+++ b/nikola/data/themes/base/bundles
@@ -16,5 +16,4 @@ assets/js/all.js=
     fancydates.js,
 assets/js/all-nocdn.js=
     baguetteBox.min.js,
-    moment-with-locales.min.js,
     fancydates.js,

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -66,9 +66,6 @@ lang="${lang}">
     % if use_bundles:
         % if use_cdn:
             <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-            % if date_fanciness != 0:
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
-            % endif
             <script src="/assets/js/all.js"></script>
         % else:
             <script src="/assets/js/all-nocdn.js"></script>
@@ -76,16 +73,17 @@ lang="${lang}">
     % else:
         % if use_cdn:
             <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-            % if date_fanciness != 0:
-                <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
-            % endif
         % else:
             <script src="/assets/js/baguetteBox.min.js"></script>
-            % if date_fanciness != 0:
-                <script src="/assets/js/moment-with-locales.min.js"></script>
-            % endif
         % endif
-        % if date_fanciness != 0:
+    % endif
+    % if date_fanciness != 0:
+        % if use_cdn:
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
+        % else:
+            <script src="/assets/js/moment-with-locales.min.js"></script>
+        % endif
+        % if not use_bundles:
             <script src="/assets/js/fancydates.js"></script>
         % endif
     % endif

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -79,7 +79,7 @@ lang="${lang}">
     % endif
     % if date_fanciness != 0:
         % if use_cdn:
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js"></script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment-with-locales.min.js" crossorigin="anonymous"></script>
         % else:
             <script src="/assets/js/moment-with-locales.min.js"></script>
         % endif

--- a/nikola/data/themes/bootblog4-jinja/templates/base.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/base.tmpl
@@ -82,12 +82,14 @@
 </div>
 
 {{ base.late_load_js() }}
-    <!-- fancy dates -->
-    <script>
-    moment.locale("{{ momentjs_locales[lang] }}");
-    fancydates({{ date_fanciness }}, {{ js_date_format }});
-    </script>
-    <!-- end fancy dates -->
+    {% if date_fanciness != 0 %}
+        <!-- fancy dates -->
+        <script>
+        moment.locale("{{ momentjs_locales[lang] }}");
+        fancydates({{ date_fanciness }}, {{ js_date_format }});
+        </script>
+        <!-- end fancy dates -->
+    {% endif %}
     {% block extra_js %}{% endblock %}
     <script>
     baguetteBox.run('div#content', {

--- a/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
@@ -68,9 +68,6 @@ lang="{{ lang }}">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha256-ZvOgfh+ptkpoa2Y4HkRY28ir89u/+VRyDE7sB7hEEcI=" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-        {% if date_fanciness != 0 %}
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
-        {% endif %}
     {% endif %}
     {% if use_bundles and use_cdn %}
         <script src="/assets/js/all.js"></script>
@@ -82,11 +79,15 @@ lang="{{ lang }}">
             <script src="/assets/js/popper.min.js"></script>
             <script src="/assets/js/bootstrap.min.js"></script>
             <script src="/assets/js/baguetteBox.min.js"></script>
-            {% if date_fanciness != 0 %}
-                <script src="/assets/js/moment-with-locales.min.js"></script>
-            {% endif %}
         {% endif %}
-        {% if date_fanciness != 0 %}
+    {% endif %}
+    {% if date_fanciness != 0 %}
+        {% if use_cdn %}
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        {% else %}
+            <script src="/assets/js/moment-with-locales.min.js"></script>
+        {% endif %}
+        {% if not use_bundles %}
             <script src="/assets/js/fancydates.min.js"></script>
         {% endif %}
     {% endif %}

--- a/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
@@ -68,7 +68,9 @@ lang="{{ lang }}">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha256-ZvOgfh+ptkpoa2Y4HkRY28ir89u/+VRyDE7sB7hEEcI=" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        {% if date_fanciness != 0 %}
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        {% endif %}
     {% endif %}
     {% if use_bundles and use_cdn %}
         <script src="/assets/js/all.js"></script>
@@ -80,9 +82,13 @@ lang="{{ lang }}">
             <script src="/assets/js/popper.min.js"></script>
             <script src="/assets/js/bootstrap.min.js"></script>
             <script src="/assets/js/baguetteBox.min.js"></script>
-            <script src="/assets/js/moment-with-locales.min.js"></script>
+            {% if date_fanciness != 0 %}
+                <script src="/assets/js/moment-with-locales.min.js"></script>
+            {% endif %}
         {% endif %}
-        <script src="/assets/js/fancydates.min.js"></script>
+        {% if date_fanciness != 0 %}
+            <script src="/assets/js/fancydates.min.js"></script>
+        {% endif %}
     {% endif %}
     {{ social_buttons_code }}
 {% endmacro %}

--- a/nikola/data/themes/bootblog4/bundles
+++ b/nikola/data/themes/bootblog4/bundles
@@ -23,7 +23,6 @@ assets/js/all-nocdn.js=
     popper.min.js,
     bootstrap.min.js,
     baguetteBox.min.js,
-    moment-with-locales.min.js,
     fancydates.min.js,
 assets/js/all.js=
     fancydates.min.js,

--- a/nikola/data/themes/bootblog4/templates/base.tmpl
+++ b/nikola/data/themes/bootblog4/templates/base.tmpl
@@ -82,12 +82,14 @@ ${template_hooks['extra_head']()}
 </div>
 
 ${base.late_load_js()}
-    <!-- fancy dates -->
-    <script>
-    moment.locale("${momentjs_locales[lang]}");
-    fancydates(${date_fanciness}, ${js_date_format});
-    </script>
-    <!-- end fancy dates -->
+    %if date_fanciness != 0:
+        <!-- fancy dates -->
+        <script>
+        moment.locale("${momentjs_locales[lang]}");
+        fancydates(${date_fanciness}, ${js_date_format});
+        </script>
+        <!-- end fancy dates -->
+    %endif
     <%block name="extra_js"></%block>
     <script>
     baguetteBox.run('div#content', {

--- a/nikola/data/themes/bootblog4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4/templates/base_helper.tmpl
@@ -68,7 +68,9 @@ lang="${lang}">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha256-ZvOgfh+ptkpoa2Y4HkRY28ir89u/+VRyDE7sB7hEEcI=" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        %if date_fanciness != 0:
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        %endif
     % endif
     %if use_bundles and use_cdn:
         <script src="/assets/js/all.js"></script>
@@ -80,9 +82,13 @@ lang="${lang}">
             <script src="/assets/js/popper.min.js"></script>
             <script src="/assets/js/bootstrap.min.js"></script>
             <script src="/assets/js/baguetteBox.min.js"></script>
-            <script src="/assets/js/moment-with-locales.min.js"></script>
+            %if date_fanciness != 0:
+                <script src="/assets/js/moment-with-locales.min.js"></script>
+            %endif
         %endif
-        <script src="/assets/js/fancydates.min.js"></script>
+        %if date_fanciness != 0:
+            <script src="/assets/js/fancydates.min.js"></script>
+        %endif
     %endif
     ${social_buttons_code}
 </%def>

--- a/nikola/data/themes/bootblog4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4/templates/base_helper.tmpl
@@ -68,9 +68,6 @@ lang="${lang}">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha256-ZvOgfh+ptkpoa2Y4HkRY28ir89u/+VRyDE7sB7hEEcI=" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-        %if date_fanciness != 0:
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
-        %endif
     % endif
     %if use_bundles and use_cdn:
         <script src="/assets/js/all.js"></script>
@@ -82,11 +79,15 @@ lang="${lang}">
             <script src="/assets/js/popper.min.js"></script>
             <script src="/assets/js/bootstrap.min.js"></script>
             <script src="/assets/js/baguetteBox.min.js"></script>
-            %if date_fanciness != 0:
-                <script src="/assets/js/moment-with-locales.min.js"></script>
-            %endif
         %endif
-        %if date_fanciness != 0:
+    %endif
+    %if date_fanciness != 0:
+        %if use_cdn:
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        %else:
+            <script src="/assets/js/moment-with-locales.min.js"></script>
+        %endif
+        %if not use_bundles:
             <script src="/assets/js/fancydates.min.js"></script>
         %endif
     %endif

--- a/nikola/data/themes/bootstrap4-jinja/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base.tmpl
@@ -76,12 +76,14 @@ navbar-dark bg-dark
 </div>
 
 {{ base.late_load_js() }}
-    <!-- fancy dates -->
-    <script>
-    moment.locale("{{ momentjs_locales[lang] }}");
-    fancydates({{ date_fanciness }}, {{ js_date_format }});
-    </script>
-    <!-- end fancy dates -->
+    {% if date_fanciness != 0 %}
+        <!-- fancy dates -->
+        <script>
+        moment.locale("{{ momentjs_locales[lang] }}");
+        fancydates({{ date_fanciness }}, {{ js_date_format }});
+        </script>
+        <!-- end fancy dates -->
+    {% endif %}
     {% block extra_js %}{% endblock %}
     <script>
     baguetteBox.run('div#content', {

--- a/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
@@ -67,7 +67,9 @@ lang="{{ lang }}">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha256-ZvOgfh+ptkpoa2Y4HkRY28ir89u/+VRyDE7sB7hEEcI=" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        {% if date_fanciness != 0 %}
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        {% endif %}
     {% endif %}
     {% if use_bundles and use_cdn %}
         <script src="/assets/js/all.js"></script>
@@ -79,7 +81,11 @@ lang="{{ lang }}">
             <script src="/assets/js/popper.min.js"></script>
             <script src="/assets/js/bootstrap.min.js"></script>
             <script src="/assets/js/baguetteBox.min.js"></script>
-            <script src="/assets/js/moment-with-locales.min.js"></script>
+            {% if date_fanciness != 0 %}
+                <script src="/assets/js/moment-with-locales.min.js"></script>
+            {% endif %}
+        {% endif %}
+        {% if date_fanciness != 0 %}
             <script src="/assets/js/fancydates.min.js"></script>
         {% endif %}
     {% endif %}

--- a/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
@@ -67,9 +67,6 @@ lang="{{ lang }}">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha256-ZvOgfh+ptkpoa2Y4HkRY28ir89u/+VRyDE7sB7hEEcI=" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-        {% if date_fanciness != 0 %}
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
-        {% endif %}
     {% endif %}
     {% if use_bundles and use_cdn %}
         <script src="/assets/js/all.js"></script>
@@ -81,11 +78,15 @@ lang="{{ lang }}">
             <script src="/assets/js/popper.min.js"></script>
             <script src="/assets/js/bootstrap.min.js"></script>
             <script src="/assets/js/baguetteBox.min.js"></script>
-            {% if date_fanciness != 0 %}
-                <script src="/assets/js/moment-with-locales.min.js"></script>
-            {% endif %}
         {% endif %}
-        {% if date_fanciness != 0 %}
+    {% endif %}
+    {% if date_fanciness != 0 %}
+        {% if use_cdn %}
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        {% else %}
+            <script src="/assets/js/moment-with-locales.min.js"></script>
+        {% endif %}
+        {% if not use_bundles %}
             <script src="/assets/js/fancydates.min.js"></script>
         {% endif %}
     {% endif %}

--- a/nikola/data/themes/bootstrap4/bundles
+++ b/nikola/data/themes/bootstrap4/bundles
@@ -21,7 +21,6 @@ assets/js/all-nocdn.js=
     popper.min.js,
     bootstrap.min.js,
     baguetteBox.min.js,
-    moment-with-locales.min.js,
     fancydates.min.js,
 assets/js/all.js=
     fancydates.min.js

--- a/nikola/data/themes/bootstrap4/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base.tmpl
@@ -76,12 +76,14 @@ navbar-dark bg-dark
 </div>
 
 ${base.late_load_js()}
-    <!-- fancy dates -->
-    <script>
-    moment.locale("${momentjs_locales[lang]}");
-    fancydates(${date_fanciness}, ${js_date_format});
-    </script>
-    <!-- end fancy dates -->
+    %if date_fanciness != 0:
+        <!-- fancy dates -->
+        <script>
+        moment.locale("${momentjs_locales[lang]}");
+        fancydates(${date_fanciness}, ${js_date_format});
+        </script>
+        <!-- end fancy dates -->
+    %endif
     <%block name="extra_js"></%block>
     <script>
     baguetteBox.run('div#content', {

--- a/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
@@ -83,8 +83,10 @@ lang="${lang}">
             <script src="/assets/js/baguetteBox.min.js"></script>
             %if date_fanciness != 0:
                 <script src="/assets/js/moment-with-locales.min.js"></script>
-                <script src="/assets/js/fancydates.min.js"></script>
             %endif
+        %endif
+        %if date_fanciness != 0:
+            <script src="/assets/js/fancydates.min.js"></script>
         %endif
     %endif
     ${social_buttons_code}

--- a/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
@@ -67,7 +67,9 @@ lang="${lang}">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha256-ZvOgfh+ptkpoa2Y4HkRY28ir89u/+VRyDE7sB7hEEcI=" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        %if date_fanciness != 0:
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        %endif
     % endif
     %if use_bundles and use_cdn:
         <script src="/assets/js/all.js"></script>
@@ -79,8 +81,10 @@ lang="${lang}">
             <script src="/assets/js/popper.min.js"></script>
             <script src="/assets/js/bootstrap.min.js"></script>
             <script src="/assets/js/baguetteBox.min.js"></script>
-            <script src="/assets/js/moment-with-locales.min.js"></script>
-            <script src="/assets/js/fancydates.min.js"></script>
+            %if date_fanciness != 0:
+                <script src="/assets/js/moment-with-locales.min.js"></script>
+                <script src="/assets/js/fancydates.min.js"></script>
+            %endif
         %endif
     %endif
     ${social_buttons_code}

--- a/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
@@ -67,9 +67,6 @@ lang="${lang}">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha256-ZvOgfh+ptkpoa2Y4HkRY28ir89u/+VRyDE7sB7hEEcI=" crossorigin="anonymous"></script>
         <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/baguettebox.js/1.11.0/baguetteBox.min.js" integrity="sha256-yQGjQhFs3LtyiN5hhr3k9s9TWZOh/RzCkD3gwwCKlkg=" crossorigin="anonymous"></script>
-        %if date_fanciness != 0:
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
-        %endif
     % endif
     %if use_bundles and use_cdn:
         <script src="/assets/js/all.js"></script>
@@ -81,11 +78,15 @@ lang="${lang}">
             <script src="/assets/js/popper.min.js"></script>
             <script src="/assets/js/bootstrap.min.js"></script>
             <script src="/assets/js/baguetteBox.min.js"></script>
-            %if date_fanciness != 0:
-                <script src="/assets/js/moment-with-locales.min.js"></script>
-            %endif
         %endif
-        %if date_fanciness != 0:
+    %endif
+    %if date_fanciness != 0:
+        %if use_cdn:
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js" integrity="sha256-AdQN98MVZs44Eq2yTwtoKufhnU+uZ7v2kXnD5vqzZVo=" crossorigin="anonymous"></script>
+        %else:
+            <script src="/assets/js/moment-with-locales.min.js"></script>
+        %endif
+        %if not use_bundles:
             <script src="/assets/js/fancydates.min.js"></script>
         %endif
     %endif


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Fixes #3231, prevents bootstrap-based themes from loading moment.js when fancy dates are not in use.