### PR TITLE
Add classes to `body` based on pagekind, permalink and lang

### DIFF
--- a/nikola/data/themes/bootstrap4/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base.tmpl
@@ -8,7 +8,7 @@ ${base.html_headstart()}
 </%block>
 ${template_hooks['extra_head']()}
 </head>
-<body>
+<body class="${' '.join(pagekind)} ${permalink.replace('/', ' ')} lang_${lang} lang_${'rtl' if is_rtl else 'ltr'}">
 <a href="#content" class="sr-only sr-only-focusable">${messages("Skip to main content")}</a>
 
 <!-- Menubar -->


### PR DESCRIPTION
This allows styling on a per-pagekind, -page or -language basis,
without requiring template overrides.

For a Thai page in a Thai site, this results in body tags as follows:
`<body class="story_page page_page  2018 schedule  lang_th lang_ltr">`

For an English page in a Thai site:
`<body class="story_page page_page  en 2018 party  lang_en lang_ltr">`

We could filter out that "en", but I don't know if that's worthwhile.