### PR TITLE
Add a pointer to the default posting format

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -216,6 +216,8 @@ TIMEZONE = ${TIMEZONE}
 # Feel free to add or delete extensions to any list, but don't add any new
 # compilers unless you write the interface for it yourself.
 #
+# The default compiler for `new_post` is the first entry in the POSTS tuple.
+#
 # 'rest' is reStructuredText
 # 'markdown' is Markdown
 # 'html' assumes the file is HTML and just copies it


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [ ] I tested my changes.

### Description
I was trying to figure out how to create a new_post without needing to pass `-f markdown`. Apparently it is by setting the PAGES tuple order. I'd guessed CONTENT_FORMAT="Markdown" or METADATA_FORMAT="Pelican". I was wrong.

There's probably a better way to document this but it's the best I could easily figure out.
