### PR TITLE
Fail meaningfully for RSS_LINKS_APPEND_QUERY

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -113,6 +113,7 @@
 * `Stefan Näwe <https://github.com/snaewe>`_
 * `Stephan Fitzpatrick <https://github.com/knowsuchagency>`_
 * `Sukil Etxenike <https://github.com/sukiletxe>`_
+* `Ted Timmons <https://github.com/tedder>`_
 * `Thibauld Nion <https://github.com/tibonihoo>`_
 * `Thomas Burette <https://github.com/tburette>`_
 * `Tim Chase <https://github.com/Gumnos>`_

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1675,7 +1675,7 @@ class Nikola(object):
 
         feed_append_query = None
         if rss_links_append_query:
-            if isinstance(rss_links_append_query, bool):
+            if rss_links_append_query is True:
                 raise ValueError("RSS_LINKS_APPEND_QUERY (or FEED_LINKS_APPEND_QUERY) cannot be True. Valid values are False or a formattable string.")
             feed_append_query = rss_links_append_query.format(
                 feedRelUri='/' + feed_url[len(self.config['BASE_URL']):],

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1675,6 +1675,8 @@ class Nikola(object):
 
         feed_append_query = None
         if rss_links_append_query:
+            if isinstance(rss_links_append_query, bool):
+                raise ValueError("RSS_LINKS_APPEND_QUERY (or FEED_LINKS_APPEND_QUERY) cannot be True. Valid values are False or a formattable string.")
             feed_append_query = rss_links_append_query.format(
                 feedRelUri='/' + feed_url[len(self.config['BASE_URL']):],
                 feedFormat="rss")


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
Valid values for `FEED_LINKS_APPEND_QUERY` (or `RSS_LINKS_APPEND_QUERY`) are `None`, `False`, or a string. It's sort of devious, because presumably if False is allowed, True is also allowed. Further, the error is more buried since the config string is abstracted and passed down the stack, making it difficult to understand what is actually failing.

Perhaps there's a reasonable default that could be used in the truthy-true-but-not-string case, but having a descriptive failure is a step in that direction.

Tested locally with false/true/string.

Added myself to authors since this is about my fourth PR, I guess.