### PR TITLE
Add Slideshare reST directive

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -116,6 +116,7 @@
 * `Sukil Etxenike <https://github.com/sukiletxe>`_
 * `Ted Timmons <https://github.com/tedder>`_
 * `Thibauld Nion <https://github.com/tibonihoo>`_
+* `Thomas Aglassinger <https://github.com/roskakori>`_
 * `Thomas Burette <https://github.com/tburette>`_
 * `Tim Chase <https://github.com/Gumnos>`_
 * `Timo Kankare <https://github.com/tikank>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,11 @@
+New in master
+=============
+
+Features
+--------
+
+* Add slideshare directive by Thomas Aglassinger
+
 New in v8.0.2
 =============
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2586,6 +2586,32 @@ You can also embed playlists, via the `soundcloud_playlist` directive which work
 Supported options: ``height``, ``width``, ``align`` (one of ``left``,
 ``center``, ``right``) — all are optional.
 
+SlideShare
+~~~~~~~~~~
+
+To link to SlideShare slides, you need the key of the slides. Click on "Share" and examine the :guilabel:`Embed` field.
+It should show something like:
+
+.. code:: html
+
+    <iframe src="//www.slideshare.net/slideshow/embed_code/key/Je1cVvMV6PA63S" ...>
+
+In this case they key is **Je1cVvMV6PA63S**.
+
+Now all you need to do is:
+
+.. code:: restructuredtext
+
+    .. slideshare:: Je1cVvMV6PA63S
+
+Supported options are ``height`` and ``width``. Example:
+
+.. code:: restructuredtext
+
+    .. slideshare:: Je1cVvMV6PA63S
+       :width: 298
+       :height: 242
+
 Code
 ~~~~
 

--- a/nikola/plugins/compile/rest/slideshare.plugin
+++ b/nikola/plugins/compile/rest/slideshare.plugin
@@ -1,0 +1,12 @@
+[Core]
+name = rest_slideshare
+module = slideshare
+
+[Nikola]
+compiler = rest
+PluginCategory = CompilerExtension
+
+[Documentation]
+version = 1.0
+description = SlideShare directive
+

--- a/nikola/plugins/compile/rest/slideshare.py
+++ b/nikola/plugins/compile/rest/slideshare.py
@@ -28,7 +28,6 @@
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from nikola.plugins.compile.rest import _align_choice, _align_options_base
 
 from nikola.plugin_categories import RestExtension
 

--- a/nikola/plugins/compile/rest/slideshare.py
+++ b/nikola/plugins/compile/rest/slideshare.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2012-2019 Roberto Alsina and others.
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""SlideShare directive for reStructuredText."""
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from nikola.plugins.compile.rest import _align_choice, _align_options_base
+
+from nikola.plugin_categories import RestExtension
+
+
+class Plugin(RestExtension):
+    """Plugin for the ``slideshare`` directive."""
+
+    name = "rest_slideshare"
+
+    def set_site(self, site):
+        """Set Nikola site."""
+        self.site = site
+        directives.register_directive('slideshare', SlideShare)
+        return super(Plugin, self).set_site(site)
+
+
+CODE = '<iframe src="https://www.slideshare.net/slideshow/embed_code/key/{key}" width="{width}" height="{height}" ' \
+       'frameborder="0" marginwidth="0" marginheight="0" scrolling="no" ' \
+       'style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" ' \
+       'allowfullscreen></iframe>'
+
+
+class SlideShare(Directive):
+    """reST extension for inserting SlideShare embedded slides.
+
+    Usage:
+        .. slideshare:: hIdRKXzzqZsgyR
+           :height: 595
+           :width: 485
+
+    """
+
+    has_content = True
+    required_arguments = 1
+    option_spec = {
+        "width": directives.unchanged,
+        "height": directives.unchanged,
+    }
+
+    _DEFAULT_HEIGHT = 485
+    _DEFAULT_WIDTH = 595
+
+    def run(self):
+        """Run the slideshare directive."""
+        self.check_content()
+        options = {
+            'key': self.arguments[0],
+            'width': SlideShare._DEFAULT_WIDTH,
+            'height': SlideShare._DEFAULT_HEIGHT,
+        }
+        options.update({k: v for k, v in self.options.items() if v})
+        return [nodes.raw('', CODE.format(**options), format='html')]
+
+    def check_content(self):
+        """Check if content exists."""
+        if self.content:  # pragma: no cover
+            raise self.warning("This directive does not accept content. The "
+                               "'key=value' format for options is deprecated, "
+                               "use ':key: value' instead")

--- a/tests/test_rst_compiler.py
+++ b/tests/test_rst_compiler.py
@@ -189,7 +189,7 @@ class SlideShareTestCase(ReSTExtensionTestCase):
         """ Test Youtube iframe tag generation """
         self.basic_test()
         self.assertHTMLContains("iframe",
-                                attributes={"src": "xxxhttps://www.slideshare.net/slideshow/embed_code/key/KEY",
+                                attributes={"src": "https://www.slideshare.net/slideshow/embed_code/key/KEY",
                                             "height": "123", "width": "456", "frameborder": "0", "marginwidth": "0",
                                             "marginheight": "0", "scrolling": "no",
                                             "style": ("border:1px solid #CCC; border-width:1px; margin-bottom:5px; "

--- a/tests/test_rst_compiler.py
+++ b/tests/test_rst_compiler.py
@@ -178,6 +178,23 @@ class YoutubeTestCase(ReSTExtensionTestCase):
                                             "allow": "encrypted-media"})
 
 
+class SlideShareTestCase(ReSTExtensionTestCase):
+    """ SlideShare test case """
+
+    sample = '.. slideshare:: KEY\n   :height: 123\n   :width: 456'
+
+    def test_youtube(self):
+        """ Test Youtube iframe tag generation """
+        self.basic_test()
+        self.assertHTMLContains("iframe",
+                                attributes={"src": "https:www.slideshare.net/slideshow/embed_code/key/KEY",
+                                            "height": "123", "width": "456",
+                                            "frameborder": "0", "marginwidth": 0, "marginheight": 0, "scrolling": "no",
+                                            "style": ("border:1px solid #CCC; border-width:1px; margin-bottom:5px; "
+                                                      "max-width: 100%;"),
+                                            "allowfullscreen": ""})
+
+
 class ListingTestCase(ReSTExtensionTestCase):
     """ Listing test case and CodeBlock alias tests """
 

--- a/tests/test_rst_compiler.py
+++ b/tests/test_rst_compiler.py
@@ -95,7 +95,9 @@ class ReSTExtensionTestCase(BaseTestCase):
             if attributes:
                 arg_attrs = set(attributes.items())
                 tag_attrs = set(tag.items())
-                self.assertTrue(arg_attrs.issubset(tag_attrs))
+                if not arg_attrs.issubset(tag_attrs):
+                    self.fail('for tag %s actual attributes must be subset of %s but are %s' % (
+                        tag, tag_attrs, arg_attrs))
             if text:
                 self.assertIn(text, tag.text)
 
@@ -187,9 +189,9 @@ class SlideShareTestCase(ReSTExtensionTestCase):
         """ Test Youtube iframe tag generation """
         self.basic_test()
         self.assertHTMLContains("iframe",
-                                attributes={"src": "https:www.slideshare.net/slideshow/embed_code/key/KEY",
-                                            "height": "123", "width": "456",
-                                            "frameborder": "0", "marginwidth": 0, "marginheight": 0, "scrolling": "no",
+                                attributes={"src": "xxxhttps://www.slideshare.net/slideshow/embed_code/key/KEY",
+                                            "height": "123", "width": "456", "frameborder": "0", "marginwidth": "0",
+                                            "marginheight": "0", "scrolling": "no",
                                             "style": ("border:1px solid #CCC; border-width:1px; margin-bottom:5px; "
                                                       "max-width: 100%;"),
                                             "allowfullscreen": ""})


### PR DESCRIPTION
This adds a slideshare reST directive to inline slides stored on https://www.slideshare.net.