### PR TITLE
gallery was losing ordering

### DIFF
--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -32,6 +32,7 @@ import io
 import json
 import mimetypes
 import os
+from collections import OrderedDict
 
 try:
     from ruamel.yaml import YAML
@@ -664,7 +665,7 @@ class Galleries(Task, ImageProcessor):
         else:
             img_list, thumbs, img_titles = [], [], []
 
-        photo_info = {}
+        photo_info = OrderedDict()
         for img, thumb, title in zip(img_list, thumbs, img_titles):
             w, h = _image_size_cache.get(thumb, (None, None))
             if w is None:


### PR DESCRIPTION
sorry for the quick and dirty PR.
It seems that the sorting was actually getting lost in older python versions. IIRC, python 3.6 introduced `dict`s that retain the insertion order, but it shouldn't really be relied on. I'm on python 3.5 (with nikola and gallery_directive both installed today), and the dict implementation was jumbeling up the sort that happens a few lines before as it seems.

I don't have time to do the checklist below here, but it's a trivial fix and I thought I'd open this, if only as a reminder for my future self.

### Pull Request Checklist

- [ ] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [ ] I tested my changes.

### Description
