### PR TITLE
Fixing «Comments» link not translatable

### DIFF
--- a/nikola/data/themes/base-jinja/templates/comments_helper_disqus.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper_disqus.tmpl
@@ -30,7 +30,7 @@
 
 {% macro comment_link(link, identifier) %}
     {% if comment_system_id %}
-    <a href="{{ link }}#disqus_thread" data-disqus-identifier="{{ identifier }}">${messages(Comments)}</a>
+	<a href="{{ link }}#disqus_thread" data-disqus-identifier="{{ identifier }}">{{ messages("Comments") }}</a>
     {% endif %}
 {% endmacro %}
 

--- a/nikola/data/themes/base-jinja/templates/comments_helper_disqus.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper_disqus.tmpl
@@ -30,7 +30,7 @@
 
 {% macro comment_link(link, identifier) %}
     {% if comment_system_id %}
-    <a href="{{ link }}#disqus_thread" data-disqus-identifier="{{ identifier }}">Comments</a>
+    <a href="{{ link }}#disqus_thread" data-disqus-identifier="{{ identifier }}">${messages(Comments)}</a>
     {% endif %}
 {% endmacro %}
 

--- a/nikola/data/themes/base-jinja/templates/comments_helper_isso.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper_isso.tmpl
@@ -14,7 +14,7 @@
 
 {% macro comment_link(link, identifier) %}
     {% if comment_system_id %}
-        <a href="{{ link }}#isso-thread">Comments</a>
+        <a href="{{ link }}#isso-thread">${messages(Comments)}</a>
     {% endif %}
 {% endmacro %}
 

--- a/nikola/data/themes/base-jinja/templates/comments_helper_isso.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper_isso.tmpl
@@ -14,7 +14,7 @@
 
 {% macro comment_link(link, identifier) %}
     {% if comment_system_id %}
-        <a href="{{ link }}#isso-thread">${messages(Comments)}</a>
+        <a href="{{ link }}#isso-thread">{{ messages("Comments") }}</a>
     {% endif %}
 {% endmacro %}
 

--- a/nikola/data/themes/base/templates/comments_helper_disqus.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper_disqus.tmpl
@@ -32,7 +32,7 @@
 
 <%def name="comment_link(link, identifier)">
     %if comment_system_id:
-    <a href="${link}#disqus_thread" data-disqus-identifier="${identifier}">${messages(Comments)}</a>
+    <a href="${link}#disqus_thread" data-disqus-identifier="${identifier}">${messages("Comments")}</a>
     %endif
 </%def>
 

--- a/nikola/data/themes/base/templates/comments_helper_disqus.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper_disqus.tmpl
@@ -32,7 +32,7 @@
 
 <%def name="comment_link(link, identifier)">
     %if comment_system_id:
-    <a href="${link}#disqus_thread" data-disqus-identifier="${identifier}">Comments</a>
+    <a href="${link}#disqus_thread" data-disqus-identifier="${identifier}">${messages(Comments)}</a>
     %endif
 </%def>
 

--- a/nikola/data/themes/base/templates/comments_helper_isso.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper_isso.tmpl
@@ -14,7 +14,7 @@
 
 <%def name="comment_link(link, identifier)">
     %if comment_system_id:
-        <a href="${link}#isso-thread">Comments</a>
+        <a href="${link}#isso-thread">${messages(Comments)}</a>
     %endif
 </%def>
 

--- a/nikola/data/themes/base/templates/comments_helper_isso.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper_isso.tmpl
@@ -14,7 +14,7 @@
 
 <%def name="comment_link(link, identifier)">
     %if comment_system_id:
-        <a href="${link}#isso-thread">${messages(Comments)}</a>
+        <a href="${link}#isso-thread">${messages("Comments")}</a>
     %endif
 </%def>
 


### PR DESCRIPTION
### Description
Fixes a small bug where «Comments» link wasn't translatable no matter what language selected.