### PR TITLE
ISO Dates in YAML metadata break the build

### DIFF
--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -946,7 +946,7 @@ def extract_all(zipfile, path='themes'):
 def to_datetime(value, tzinfo=None):
     """Convert string to datetime."""
     try:
-        if not isinstance(value, datetime.date):
+        if isinstance(value, datetime.date):
             value = datetime.datetime.combine(value, datetime.datetime.min.time())
         if not isinstance(value, datetime.datetime):
             # dateutil does bad things with TZs like UTC-03:00.

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -946,6 +946,8 @@ def extract_all(zipfile, path='themes'):
 def to_datetime(value, tzinfo=None):
     """Convert string to datetime."""
     try:
+        if not isinstance(value, datetime.date):
+            value = datetime.datetime.combine(value, datetime.datetime.min.time())
         if not isinstance(value, datetime.datetime):
             # dateutil does bad things with TZs like UTC-03:00.
             dateregexp = re.compile(r' UTC([+-][0-9][0-9]:[0-9][0-9])')

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -947,7 +947,7 @@ def to_datetime(value, tzinfo=None):
     """Convert string to datetime."""
     try:
         if isinstance(value, datetime.date):
-            value = datetime.datetime.combine(value, datetime.datetime.min.time())
+            value = datetime.datetime.combine(value, datetime.time(0, 0))
         if not isinstance(value, datetime.datetime):
             # dateutil does bad things with TZs like UTC-03:00.
             dateregexp = re.compile(r' UTC([+-][0-9][0-9]:[0-9][0-9])')


### PR DESCRIPTION
PyYAML reads dates of the form `YYYY-MM-DD` as `datetime.date` objects
and when such objects end up in this function, it breaks. This is because
if the `value` is not a `datetime.datetime`, we assume that it's a `str`. We
have to check for `datetime.date` objects as well.

### Pull Request Checklist

- [Y] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [N] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable). **Trivial change, hence not updated.**
- [Y] I tested my changes.

### Description

At the top of my markdown post, I have the following YAML metadata:

```
---
title: Nice title
date: 2010-12-14
---

just some stuff here
```

Building the project with this post throws the following error:

    [2019-07-11T05:32:14Z] ERROR: Nikola: Invalid date '2010-12-14' in file posts\nice-title.md

The problem is because the metadata is parsed as YAML in the `nikola.metadata_extractors.YAMLMetadata` class and PyYAML creates a `datetime.date` object when it sees a value of the form `YYYY-MM-DD`.

This `datetime.date` object then turns up in the `nikola.utils.to_datetime` function called from the following line in `nikola.post` module:

    self.date = to_datetime(self.meta[self.default_lang]['date'], tzinfo)

However, in the `nikola.utils.to_datetime` function, if the `value` being passed is not an instance of `datetime.datetime`, we are assuming it is a `str` (by passing it over to `re.sub`).

The change in this PR will first check for `value` being a `datetime.date` object, and if it is, turn it into a `datetime.datetime` object with zero time and then proceed as usual. This way of solving it has the minimal overall impact.

Another possible solution this is within the `YAMLMetadata` class, after calling `yaml.load`, we could check for all values (recursively) that are objects of `datetime.date` and turn them into `datetime.datetime` instances. I personally don't like this solution especially because I think `to_datetime` should anyway be versatile enough to not choke on `datetime.date` objects.

Thank you.