### PR TITLE
"Use consistent html writer (plugin#294)

### DIFF
--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -304,7 +304,7 @@ def add_node(node, visit_function=None, depart_function=None):
 def rst2html(source, source_path=None, source_class=docutils.io.StringInput,
              destination_path=None, reader=None,
              parser=None, parser_name='restructuredtext', writer=None,
-             writer_name='html', settings=None, settings_spec=None,
+             writer_name='html5_polyglot', settings=None, settings_spec=None,
              settings_overrides=None, config_section='nikola',
              enable_exit_status=None, logger=None, l_add_ln=0, transforms=None):
     """Set up & run a ``Publisher``, and return a dictionary of document parts.


### PR DESCRIPTION
Writer html5_polyglot is used in plugins/compile/rest/__init__.py whereas the
rst2hmtml is initialized with `writer_name='html'` which according to
docutils doc http://docutils.sourceforge.net/docs/user/html.html defaults
to `html4css1`. This discrepency prevent plugins adding role to work

Closes https://github.com/getnikola/plugins/issues/294

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
