### PR TITLE
Output <code> tag for double backticks in reST

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ New in master
 Bugfixes
 --------
 
+* Output ``<code>`` tag for double backticks in reST (Issue #3276)
+* Fully switch to HTML5 writer for reST (Issue #3276,
+  getnikola/plugins#294)
 * Make ipynb listings work again
 * Correctly link to listings with spaces in their names
 * import_wordpress plugin doesn't require anymore a translation and


### PR DESCRIPTION
This outputs `<code>` instead of an ugly `<span>` for \`\`double backticks\`\` in reST, with the reST HTML5 writer. This will also give us the standard Bootstrap pink styling for code.

cc @ralsina, @matclab