### PR TITLE
Introduce config option to disable reST file insertion.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,8 @@ Features
 --------
 
 * Add Friulian translation by aoanla
+* Add ``REST_FILE_INSERTION_ENABLED`` config option to enable or disable reST
+  external file inclusion directives. (Issue #3311)
 
 New in v8.0.2
 =============

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -223,6 +223,11 @@ TIMEZONE = ${TIMEZONE}
 # 'html' assumes the file is HTML and just copies it
 COMPILERS = ${COMPILERS}
 
+# Enable reST directives that insert the contents of external files such
+# as "include" and "raw." This maps directly to the docutils file_insertion_enabled
+# config. See: http://docutils.sourceforge.net/docs/user/config.html#file-insertion-enabled
+# REST_FILE_INSERTION_ENABLED = True
+
 # Create by default posts in one file format?
 # Set to False for two-file posts, with separate metadata.
 # ONE_FILE_POSTS = True

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -561,6 +561,7 @@ class Nikola(object):
             'GITHUB_REMOTE_NAME': 'origin',
             'GITHUB_COMMIT_SOURCE': False,  # WARNING: conf.py.in overrides this with True for backwards compatibility
             'META_GENERATOR_TAG': True,
+            'REST_FILE_INSERTION_ENABLED': True,
         }
 
         # set global_context for template rendering

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -126,6 +126,7 @@ class CompileRest(PageCompiler):
             'template': default_template_path,
             'language_code': LEGAL_VALUES['DOCUTILS_LOCALES'].get(LocaleBorg().current_lang, 'en'),
             'doctitle_xform': self.site.config.get('USE_REST_DOCINFO_METADATA'),
+            'file_insertion_enabled': self.site.config.get('REST_FILE_INSERTION_ENABLED'),
         }
 
         from nikola import shortcodes as sc


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

This PR resolves #3311 by introducing a new config option `REST_FILE_INSERTION_ENABLED`, which can be used to fully disable reST file insertion.