### PR TITLE
Fix #3319 - drop extra_header/extra_footer from base theme

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,9 @@ Features
 Bugfixes
 --------
 
+* Remove ``extra_header`` and ``extra_footer`` from ``base`` theme
+  due to incompatibility with Mako. The blocks are still available
+  in ``bootstrap4`` and ``bootblog4``. (Issue #3319 via #3291)
 * Show tracebacks when ``conf.py`` cannot be imported
 * Fix loading complex config files that import modules (Issue #3314)
 * Fix behavior of header demotion for negative values

--- a/nikola/data/themes/base-jinja/templates/base.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base.tmpl
@@ -13,11 +13,11 @@
 <body>
     <a href="#content" class="sr-only sr-only-focusable">{{ messages("Skip to main content") }}</a>
     <div id="container">
-         {{ header.html_header() }}
-         <main id="content">
+        {{ header.html_header() }}
+        <main id="content">
             {% block content %}{% endblock %}
-         </main>
-         {{ footer.html_footer() }}
+        </main>
+        {{ footer.html_footer() }}
     </div>
     {{ base.late_load_js() }}
     {% if date_fanciness != 0 %}

--- a/nikola/data/themes/base-jinja/templates/base_footer.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_footer.tmpl
@@ -5,7 +5,6 @@
         <footer id="footer">
             <p>{{ content_footer }}</p>
             {{ template_hooks['page_footer']() }}
-            {% block extra_footer %}{% endblock %}
         </footer>
     {% endif %}
 {% endmacro %}

--- a/nikola/data/themes/base-jinja/templates/base_header.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_header.tmpl
@@ -13,7 +13,6 @@
         {% endif %}
     </header>
     {{ template_hooks['page_header']() }}
-    {% block extra_header %}{% endblock %}
 {% endmacro %}
 
 {% macro html_site_title() %}

--- a/nikola/data/themes/base/templates/base.tmpl
+++ b/nikola/data/themes/base/templates/base.tmpl
@@ -13,11 +13,11 @@ ${template_hooks['extra_head']()}
 <body>
     <a href="#content" class="sr-only sr-only-focusable">${messages("Skip to main content")}</a>
     <div id="container">
-         ${header.html_header()}
-         <main id="content">
+        ${header.html_header()}
+        <main id="content">
             <%block name="content"></%block>
-         </main>
-         ${footer.html_footer()}
+        </main>
+        ${footer.html_footer()}
     </div>
     ${base.late_load_js()}
     % if date_fanciness != 0:

--- a/nikola/data/themes/base/templates/base_footer.tmpl
+++ b/nikola/data/themes/base/templates/base_footer.tmpl
@@ -5,7 +5,6 @@
         <footer id="footer">
             <p>${content_footer}</p>
             ${template_hooks['page_footer']()}
-            <%block name="extra_footer"></%block>
         </footer>
     %endif
 </%def>

--- a/nikola/data/themes/base/templates/base_header.tmpl
+++ b/nikola/data/themes/base/templates/base_header.tmpl
@@ -13,7 +13,6 @@
         %endif
     </header>
     ${template_hooks['page_header']()}
-    <%block name="extra_header"></%block>
 </%def>
 
 <%def name="html_site_title()">


### PR DESCRIPTION
Mako does not allow blocks inside functions. The blocks have to be removed from these themes. They are still available in bootstrap4/bootblog4.

cc @laodzu @tdimitrov