### PR TITLE
Fix possibly undefined exit function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ Bugfixes
 * Show tracebacks when ``conf.py`` cannot be imported
 * Fix loading complex config files that import modules (Issue #3314)
 * Fix behavior of header demotion for negative values
+* Fix reference to possibly undefined function ``exit`` in ``nikola.py``
 
 New in v8.0.3
 =============

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1321,21 +1321,23 @@ class Nikola(object):
                      len([ext_ for ext_ in exts if source_name.endswith(ext_)]) > 0]
             if len(langs) != 1:
                 if len(set(langs)) > 1:
-                    exit("Your file extension->compiler definition is "
-                         "ambiguous.\nPlease remove one of the file extensions "
-                         "from 'COMPILERS' in conf.py\n(The error is in "
-                         "one of {0})".format(', '.join(langs)))
+                    sys.exit("Your file extension->compiler definition is "
+                             "ambiguous.\nPlease remove one of the file "
+                             "extensions from 'COMPILERS' in conf.py\n(The "
+                             "error is in one of {0})".format(', '.join(langs)))
                 elif len(langs) > 1:
                     langs = langs[:1]
                 else:
-                    exit("COMPILERS in conf.py does not tell me how to "
-                         "handle '{0}' extensions.".format(ext))
+                    sys.exit("COMPILERS in conf.py does not tell me how to "
+                             "handle '{0}' extensions.".format(ext))
 
             lang = langs[0]
             try:
                 compiler = self.compilers[lang]
             except KeyError:
-                exit("Cannot find '{0}' compiler; it might require an extra plugin -- do you have it installed?".format(lang))
+                sys.exit("Cannot find '{0}' compiler; "
+                         "it might require an extra plugin -- "
+                         "do you have it installed?".format(lang))
             self.inverse_compilers[ext] = compiler
 
         return compiler


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

We have been using a function that might be undefined. This use is actually recommended against by Python - https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module

We use the function from sys instead that works the same.