### PR TITLE
Refactored imports

### DIFF
--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -47,7 +47,7 @@ from .utils import req_missing, LOGGER, slugify
 try:
     import typogrify.filters as typo
 except ImportError:
-    typo = None  # NOQA
+    typo = None
 
 
 class _ConfigurableFilter(object):

--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -33,6 +33,7 @@ from functools import wraps
 import os
 import io
 import json
+import re
 import shutil
 import subprocess
 import tempfile
@@ -329,7 +330,6 @@ def typogrify_sans_widont(data):
 @apply_to_text_file
 def php_template_injection(data):
     """Insert PHP code into Nikola templates."""
-    import re
     template = re.search(r'<\!-- __NIKOLA_PHP_TEMPLATE_INJECTION source\:(.*) checksum\:(.*)__ -->', data)
     if template:
         source = template.group(1)

--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -29,24 +29,25 @@
 All filters defined in this module are registered in Nikola.__init__.
 """
 
-from functools import wraps
-import os
 import io
 import json
+import os
 import re
 import shutil
+import shlex
 import subprocess
 import tempfile
-import shlex
+from functools import wraps
 
 import lxml
+import requests
+
+from .utils import req_missing, LOGGER, slugify
+
 try:
     import typogrify.filters as typo
 except ImportError:
     typo = None  # NOQA
-import requests
-
-from .utils import req_missing, LOGGER, slugify
 
 
 class _ConfigurableFilter(object):

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -33,17 +33,9 @@ import re
 
 import lxml
 import piexif
+from PIL import ExifTags, Image
 
 from nikola import utils
-
-try:
-    from PIL import ExifTags, Image  # NOQA
-except ImportError:
-    try:
-        import ExifTags
-        import Image
-    except ImportError:
-        Image = None
 
 EXIF_TAG_NAMES = {}
 
@@ -91,9 +83,10 @@ class ImageProcessor(object):
 
     def resize_image(self, src, dst, max_size, bigger_panoramas=True, preserve_exif_data=False, exif_whitelist={}, preserve_icc_profiles=False):
         """Make a copy of the image in the requested size."""
-        if not Image or os.path.splitext(src)[1] in ['.svg', '.svgz']:
+        if os.path.splitext(src)[1] in ['.svg', '.svgz']:
             self.resize_svg(src, dst, max_size, bigger_panoramas)
             return
+
         im = Image.open(src)
 
         if hasattr(im, 'n_frames') and im.n_frames > 1:

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -36,16 +36,14 @@ import piexif
 
 from nikola import utils
 
-Image = None
 try:
     from PIL import ExifTags, Image  # NOQA
 except ImportError:
     try:
         import ExifTags
-        import Image as _Image
-        Image = _Image
+        import Image
     except ImportError:
-        pass
+        Image = None
 
 EXIF_TAG_NAMES = {}
 

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -27,11 +27,11 @@
 """Process images."""
 
 import datetime
-import os
-import lxml
-import re
 import gzip
+import os
+import re
 
+import lxml
 import piexif
 
 from nikola import utils

--- a/nikola/metadata_extractors.py
+++ b/nikola/metadata_extractors.py
@@ -27,10 +27,11 @@
 """Default metadata extractors and helper functions."""
 
 import re
-import natsort
-
 from enum import Enum
 from io import StringIO
+
+import natsort
+
 from nikola.plugin_categories import MetadataExtractor
 from nikola.utils import unslugify
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -37,7 +37,7 @@ import sys
 import mimetypes
 from collections import defaultdict
 from copy import copy
-from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote, parse_qs  # NOQA
+from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote, parse_qs
 
 import dateutil.tz
 import lxml.etree

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -26,37 +26,32 @@
 
 """The main Nikola site object."""
 
-import io
-from collections import defaultdict
-from copy import copy
-from pkg_resources import resource_filename
 import datetime
+import io
+import json
 import functools
+import logging
 import operator
 import os
-import json
 import sys
-import natsort
 import mimetypes
+from collections import defaultdict
+from copy import copy
 from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote, parse_qs  # NOQA
 
-try:
-    import pyphen
-except ImportError:
-    pyphen = None
-
 import dateutil.tz
-import logging
-import PyRSS2Gen as rss
 import lxml.etree
 import lxml.html
-from yapsy.PluginManager import PluginManager
+import natsort
+import PyRSS2Gen as rss
+from pkg_resources import resource_filename
 from blinker import signal
+from yapsy.PluginManager import PluginManager
 
-
-from .post import Post  # NOQA
-from .state import Persistor
 from . import DEBUG, SHOW_TRACEBACKS, filters, utils, hierarchy_utils, shortcodes
+from . import metadata_extractors
+from .metadata_extractors import default_metadata_extractors_by
+from .post import Post  # NOQA
 from .plugin_categories import (
     Command,
     LateTask,
@@ -74,8 +69,12 @@ from .plugin_categories import (
     PostScanner,
     Taxonomy,
 )
-from . import metadata_extractors
-from .metadata_extractors import default_metadata_extractors_by
+from .state import Persistor
+
+try:
+    import pyphen
+except ImportError:
+    pyphen = None
 
 if DEBUG:
     logging.basicConfig(level=logging.DEBUG)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -38,10 +38,7 @@ import json
 import sys
 import natsort
 import mimetypes
-try:
-    from urlparse import urlparse, urlsplit, urlunsplit, urljoin, unquote, parse_qs
-except ImportError:
-    from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote, parse_qs  # NOQA
+from urllib.parse import urlparse, urlsplit, urlunsplit, urljoin, unquote, parse_qs  # NOQA
 
 try:
     import pyphen

--- a/nikola/packages/datecond/__init__.py
+++ b/nikola/packages/datecond/__init__.py
@@ -34,7 +34,6 @@
 
 """Date range parser."""
 
-from __future__ import print_function, unicode_literals
 import datetime
 import dateutil.parser
 import re

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -38,12 +38,9 @@ from yapsy.IPlugin import IPlugin
 
 from .utils import LOGGER, first_line, get_logger, req_missing
 
-try:
-    if typing.TYPE_CHECKING:  # NOQA
-        import nikola  # NOQA
-        import nikola.post  # NOQA
-except ImportError:
-    pass
+if typing.TYPE_CHECKING:  # NOQA
+    import nikola  # NOQA
+    import nikola.post  # NOQA
 
 __all__ = (
     'Command',

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -29,6 +29,7 @@
 import io
 import os
 import sys
+import typing
 
 import doit
 import logbook
@@ -38,7 +39,6 @@ from yapsy.IPlugin import IPlugin
 from .utils import LOGGER, first_line, get_logger, req_missing
 
 try:
-    import typing  # NOQA
     if typing.TYPE_CHECKING:  # NOQA
         import nikola  # NOQA
         import nikola.post  # NOQA

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -38,9 +38,9 @@ from yapsy.IPlugin import IPlugin
 
 from .utils import LOGGER, first_line, get_logger, req_missing
 
-if typing.TYPE_CHECKING:  # NOQA
-    import nikola  # NOQA
-    import nikola.post  # NOQA
+if typing.TYPE_CHECKING:
+    import nikola
+    import nikola.post
 
 __all__ = (
     'Command',

--- a/nikola/plugins/basic_import.py
+++ b/nikola/plugins/basic_import.py
@@ -30,11 +30,11 @@ import io
 import csv
 import datetime
 import os
-from pkg_resources import resource_filename
 from urllib.parse import urlparse
 
 from lxml import etree, html
 from mako.template import Template
+from pkg_resources import resource_filename
 
 from nikola import utils
 

--- a/nikola/plugins/basic_import.py
+++ b/nikola/plugins/basic_import.py
@@ -31,11 +31,7 @@ import csv
 import datetime
 import os
 from pkg_resources import resource_filename
-
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse  # NOQA
+from urllib.parse import urlparse
 
 from lxml import etree, html
 from mako.template import Template

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -26,14 +26,21 @@
 
 """Automatic rebuilds for Nikola."""
 
-import mimetypes
-import datetime
-import re
-import os
-import stat
-import sys
-import subprocess
 import asyncio
+import datetime
+import mimetypes
+import os
+import re
+import stat
+import subprocess
+import sys
+
+import webbrowser
+import pkg_resources
+
+from nikola.plugin_categories import Command
+from nikola.utils import dns_sd, req_missing, get_theme_path
+
 try:
     import aiohttp
     from aiohttp import web
@@ -50,11 +57,6 @@ try:
 except ImportError:
     Observer = None
 
-import webbrowser
-import pkg_resources
-
-from nikola.plugin_categories import Command
-from nikola.utils import dns_sd, req_missing, get_theme_path
 LRJS_PATH = os.path.join(os.path.dirname(__file__), 'livereload.js')
 
 if sys.platform == 'win32':

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -32,11 +32,7 @@ import re
 import sys
 import time
 import logbook
-try:
-    from urllib import unquote
-    from urlparse import urlparse, urljoin, urldefrag
-except ImportError:
-    from urllib.parse import unquote, urlparse, urljoin, urldefrag  # NOQA
+from urllib.parse import unquote, urlparse, urljoin, urldefrag
 
 from doit.loader import generate_tasks
 import lxml.html

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -26,17 +26,17 @@
 
 """Check the generated site."""
 
-from collections import defaultdict
 import os
 import re
 import sys
 import time
-import logbook
+from collections import defaultdict
 from urllib.parse import unquote, urlparse, urljoin, urldefrag
 
-from doit.loader import generate_tasks
+import logbook
 import lxml.html
 import requests
+from doit.loader import generate_tasks
 
 from nikola.plugin_categories import Command
 

--- a/nikola/plugins/command/default_config.py
+++ b/nikola/plugins/command/default_config.py
@@ -26,10 +26,11 @@
 
 """Show the default configuration."""
 
+import sys
+
+import nikola.plugins.command.init
 from nikola.plugin_categories import Command
 from nikola.utils import get_logger
-import nikola.plugins.command.init
-import sys
 
 
 LOGGER = get_logger('default_config')

--- a/nikola/plugins/command/deploy.py
+++ b/nikola/plugins/command/deploy.py
@@ -27,14 +27,14 @@
 """Deploy site."""
 
 import io
-from datetime import datetime
-from dateutil.tz import gettz
-import dateutil
 import os
 import subprocess
 import time
+from datetime import datetime
 
+import dateutil
 from blinker import signal
+from dateutil.tz import gettz
 
 from nikola.plugin_categories import Command
 from nikola.utils import clean_before_deployment

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -35,17 +35,12 @@ import json
 import requests
 from lxml import etree
 from collections import defaultdict
+from urllib.parse import urlparse, unquote
 
 try:
     import html2text
 except ImportError:
     html2text = None
-
-try:
-    from urlparse import urlparse
-    from urllib import unquote
-except ImportError:
-    from urllib.parse import urlparse, unquote  # NOQA
 
 try:
     import phpserialize

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -57,7 +57,7 @@ except ImportError:
 try:
     import phpserialize
 except ImportError:
-    phpserialize = None  # NOQA
+    phpserialize = None
 
 LOGGER = utils.get_logger('import_wordpress')
 

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -26,26 +26,17 @@
 
 """Import a WordPress dump."""
 
-import os
-import re
-import sys
 import datetime
 import io
 import json
-import requests
-from lxml import etree
+import os
+import re
+import sys
 from collections import defaultdict
 from urllib.parse import urlparse, unquote
 
-try:
-    import html2text
-except ImportError:
-    html2text = None
-
-try:
-    import phpserialize
-except ImportError:
-    phpserialize = None  # NOQA
+import requests
+from lxml import etree
 
 from nikola.plugin_categories import Command
 from nikola import utils, hierarchy_utils
@@ -57,6 +48,16 @@ from nikola.plugins.command.init import (
     format_default_translations_config,
     get_default_translations_dict
 )
+
+try:
+    import html2text
+except ImportError:
+    html2text = None
+
+try:
+    import phpserialize
+except ImportError:
+    phpserialize = None  # NOQA
 
 LOGGER = utils.get_logger('import_wordpress')
 

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -26,12 +26,12 @@
 
 """Create a new site."""
 
-import os
-import shutil
+import datetime
 import io
 import json
+import os
+import shutil
 import textwrap
-import datetime
 import unidecode
 from urllib.parse import urlsplit, urlunsplit
 

--- a/nikola/plugins/command/init.py
+++ b/nikola/plugins/command/init.py
@@ -33,13 +33,15 @@ import json
 import textwrap
 import datetime
 import unidecode
+from urllib.parse import urlsplit, urlunsplit
+
 import dateutil.tz
 import dateutil.zoneinfo
 from mako.template import Template
 from pkg_resources import resource_filename
 
 import nikola
-from nikola.nikola import DEFAULT_INDEX_READ_MORE_LINK, DEFAULT_FEED_READ_MORE_LINK, LEGAL_VALUES, urlsplit, urlunsplit
+from nikola.nikola import DEFAULT_INDEX_READ_MORE_LINK, DEFAULT_FEED_READ_MORE_LINK, LEGAL_VALUES
 from nikola.plugin_categories import Command
 from nikola.utils import ask, ask_yesno, get_logger, makedirs, load_messages
 from nikola.packages.tzlocal import get_localzone

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -34,8 +34,8 @@ import shutil
 import subprocess
 import sys
 
-from blinker import signal
 import dateutil.tz
+from blinker import signal
 
 from nikola.plugin_categories import Command
 from nikola import utils

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -89,7 +89,7 @@ def get_date(schedule=False, rule=None, last_date=None, tz=None, iso8601=False):
         except ImportError:
             LOGGER.error('To use the --schedule switch of new_post, '
                          'you have to install the "dateutil" package.')
-            rrule = None  # NOQA
+            rrule = None
     if schedule and rrule and rule:
         try:
             rule_ = rrule.rrulestr(rule, dtstart=last_date or date)

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -32,18 +32,9 @@ import re
 import signal
 import socket
 import webbrowser
-try:
-    from BaseHTTPServer import HTTPServer
-    from SimpleHTTPServer import SimpleHTTPRequestHandler
-except ImportError:
-    from http.server import HTTPServer  # NOQA
-    from http.server import SimpleHTTPRequestHandler  # NOQA
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import BytesIO as StringIO  # NOQA
-
+from http.server import HTTPServer
+from http.server import SimpleHTTPRequestHandler
+from io import BytesIO as StringIO
 
 from nikola.plugin_categories import Command
 from nikola.utils import dns_sd

--- a/nikola/plugins/command/theme.py
+++ b/nikola/plugins/command/theme.py
@@ -26,15 +26,15 @@
 
 """Manage themes."""
 
+import configparser
 import io
 import json.decoder
 import os
-import sys
 import shutil
+import sys
 import time
-import requests
-import configparser
 
+import requests
 import pygments
 from pygments.lexers import PythonLexer
 from pygments.formatters import TerminalFormatter

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -39,9 +39,6 @@ try:
     from markdown import Markdown
 except ImportError:
     Markdown = None
-    nikola_extension = None
-    gist_extension = None
-    podcast_extension = None
 
 
 class ThreadLocalMarkdown(threading.local):

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -26,11 +26,14 @@
 
 """Page compiler plugin for Markdown."""
 
-
 import io
+import json
 import os
 import threading
-import json
+
+from nikola import shortcodes as sc
+from nikola.plugin_categories import PageCompiler
+from nikola.utils import makedirs, req_missing, write_metadata, LocaleBorg, map_metadata
 
 try:
     from markdown import Markdown
@@ -39,10 +42,6 @@ except ImportError:
     nikola_extension = None
     gist_extension = None
     podcast_extension = None
-
-from nikola import shortcodes as sc
-from nikola.plugin_categories import PageCompiler
-from nikola.utils import makedirs, req_missing, write_metadata, LocaleBorg, map_metadata
 
 
 class ThreadLocalMarkdown(threading.local):

--- a/nikola/plugins/compile/markdown/__init__.py
+++ b/nikola/plugins/compile/markdown/__init__.py
@@ -38,7 +38,7 @@ from nikola.utils import makedirs, req_missing, write_metadata, LocaleBorg, map_
 try:
     from markdown import Markdown
 except ImportError:
-    Markdown = None  # NOQA
+    Markdown = None
     nikola_extension = None
     gist_extension = None
     podcast_extension = None

--- a/nikola/plugins/compile/markdown/mdx_gist.py
+++ b/nikola/plugins/compile/markdown/mdx_gist.py
@@ -75,6 +75,10 @@ Error Case: non-existent file:
     [:gist: 4747847 doesntexist.py]
 """
 
+import requests
+
+from nikola.plugin_categories import MarkdownExtension
+from nikola.utils import get_logger
 
 try:
     from markdown.extensions import Extension
@@ -86,10 +90,6 @@ except ImportError:
     # the markdown compiler will fail first
     Extension = Pattern = object
 
-from nikola.plugin_categories import MarkdownExtension
-from nikola.utils import get_logger
-
-import requests
 
 LOGGER = get_logger('compile_markdown.mdx_gist')
 

--- a/nikola/plugins/compile/markdown/mdx_nikola.py
+++ b/nikola/plugins/compile/markdown/mdx_nikola.py
@@ -31,6 +31,9 @@
 """
 
 import re
+
+from nikola.plugin_categories import MarkdownExtension
+
 try:
     from markdown.postprocessors import Postprocessor
     from markdown.inlinepatterns import SimpleTagPattern
@@ -39,8 +42,6 @@ except ImportError:
     # No need to catch this, if you try to use this without Markdown,
     # the markdown compiler will fail first
     Postprocessor = SimpleTagPattern = Extension = object
-
-from nikola.plugin_categories import MarkdownExtension
 
 
 CODERE = re.compile('<div class="codehilite"><pre>(.*?)</pre></div>', flags=re.MULTILINE | re.DOTALL)

--- a/nikola/plugins/compile/php.py
+++ b/nikola/plugins/compile/php.py
@@ -26,13 +26,12 @@
 
 """Page compiler plugin for PHP."""
 
-
-import os
 import io
+import os
+from hashlib import md5
 
 from nikola.plugin_categories import PageCompiler
 from nikola.utils import makedirs, write_metadata
-from hashlib import md5
 
 
 class CompilePhp(PageCompiler):

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -28,8 +28,6 @@
 
 import io
 import os
-import logbook
-import logbook.base
 
 import docutils.core
 import docutils.nodes
@@ -40,6 +38,9 @@ import docutils.readers.standalone
 import docutils.writers.html5_polyglot
 import docutils.parsers.rst.directives
 from docutils.parsers.rst import roles
+
+import logbook
+import logbook.base
 
 from nikola.nikola import LEGAL_VALUES
 from nikola.metadata_extractors import MetaCondition

--- a/nikola/plugins/compile/rest/chart.py
+++ b/nikola/plugins/compile/rest/chart.py
@@ -33,7 +33,7 @@ from nikola.plugin_categories import RestExtension
 try:
     import pygal
 except ImportError:
-    pygal = None  # NOQA
+    pygal = None
 
 _site = None
 

--- a/nikola/plugins/compile/rest/chart.py
+++ b/nikola/plugins/compile/rest/chart.py
@@ -28,12 +28,12 @@
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 
+from nikola.plugin_categories import RestExtension
+
 try:
     import pygal
 except ImportError:
     pygal = None  # NOQA
-
-from nikola.plugin_categories import RestExtension
 
 _site = None
 

--- a/nikola/plugins/compile/rest/listing.py
+++ b/nikola/plugins/compile/rest/listing.py
@@ -35,15 +35,14 @@ from urllib.parse import urlunsplit
 
 import docutils.parsers.rst.directives.body
 import docutils.parsers.rst.directives.misc
+import pygments
+import pygments.util
 from docutils import core
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 from docutils.parsers.rst.roles import set_classes
 from docutils.parsers.rst.directives.misc import Include
-
 from pygments.lexers import get_lexer_by_name
-import pygments
-import pygments.util
 
 from nikola import utils
 from nikola.plugin_categories import RestExtension

--- a/nikola/plugins/compile/rest/listing.py
+++ b/nikola/plugins/compile/rest/listing.py
@@ -31,10 +31,7 @@
 import io
 import os
 import uuid
-try:
-    from urlparse import urlunsplit
-except ImportError:
-    from urllib.parse import urlunsplit  # NOQA
+from urllib.parse import urlunsplit
 
 import docutils.parsers.rst.directives.body
 import docutils.parsers.rst.directives.misc

--- a/nikola/plugins/compile/rest/media.py
+++ b/nikola/plugins/compile/rest/media.py
@@ -29,14 +29,13 @@
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
 
+from nikola.plugin_categories import RestExtension
+from nikola.utils import req_missing
+
 try:
     import micawber
 except ImportError:
     micawber = None  # NOQA
-
-
-from nikola.plugin_categories import RestExtension
-from nikola.utils import req_missing
 
 
 class Plugin(RestExtension):

--- a/nikola/plugins/compile/rest/media.py
+++ b/nikola/plugins/compile/rest/media.py
@@ -35,7 +35,7 @@ from nikola.utils import req_missing
 try:
     import micawber
 except ImportError:
-    micawber = None  # NOQA
+    micawber = None
 
 
 class Plugin(RestExtension):

--- a/nikola/plugins/compile/rest/post_list.py
+++ b/nikola/plugins/compile/rest/post_list.py
@@ -31,8 +31,6 @@ from docutils.parsers.rst import Directive, directives
 from nikola import utils
 from nikola.plugin_categories import RestExtension
 
-# from nikola.plugins.shortcode.post_list import _do_post_list
-
 # WARNING: the directive name is post-list
 #          (with a DASH instead of an UNDERSCORE)
 

--- a/nikola/plugins/compile/rest/vimeo.py
+++ b/nikola/plugins/compile/rest/vimeo.py
@@ -26,15 +26,14 @@
 
 """Vimeo directive for reStructuredText."""
 
-from docutils import nodes
-from docutils.parsers.rst import Directive, directives
-from nikola.plugins.compile.rest import _align_choice, _align_options_base
-
-import requests
 import json
 
+import requests
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
 
 from nikola.plugin_categories import RestExtension
+from nikola.plugins.compile.rest import _align_choice, _align_options_base
 
 
 class Plugin(RestExtension):

--- a/nikola/plugins/compile/rest/youtube.py
+++ b/nikola/plugins/compile/rest/youtube.py
@@ -28,8 +28,8 @@
 
 from docutils import nodes
 from docutils.parsers.rst import Directive, directives
-from nikola.plugins.compile.rest import _align_choice, _align_options_base
 
+from nikola.plugins.compile.rest import _align_choice, _align_options_base
 from nikola.plugin_categories import RestExtension
 
 

--- a/nikola/plugins/misc/taxonomies_classifier.py
+++ b/nikola/plugins/misc/taxonomies_classifier.py
@@ -26,13 +26,13 @@
 
 """Render the taxonomy overviews, classification pages and feeds."""
 
-import blinker
 import functools
-import natsort
 import os
 import sys
-
 from collections import defaultdict
+
+import blinker
+import natsort
 
 from nikola.plugin_categories import SignalHandler
 from nikola import utils, hierarchy_utils

--- a/nikola/plugins/shortcode/chart.py
+++ b/nikola/plugins/shortcode/chart.py
@@ -33,7 +33,7 @@ from nikola.utils import req_missing, load_data
 try:
     import pygal
 except ImportError:
-    pygal = None  # NOQA
+    pygal = None
 
 _site = None
 

--- a/nikola/plugins/shortcode/chart.py
+++ b/nikola/plugins/shortcode/chart.py
@@ -27,13 +27,13 @@
 
 from ast import literal_eval
 
+from nikola.plugin_categories import ShortcodePlugin
+from nikola.utils import req_missing, load_data
+
 try:
     import pygal
 except ImportError:
     pygal = None  # NOQA
-
-from nikola.plugin_categories import ShortcodePlugin
-from nikola.utils import req_missing, load_data
 
 _site = None
 

--- a/nikola/plugins/shortcode/listing.py
+++ b/nikola/plugins/shortcode/listing.py
@@ -27,15 +27,11 @@
 """Listing shortcode (equivalent to reST’s listing directive)."""
 
 import os
+from urllib.parse import urlunsplit
 
 import pygments
 
 from nikola.plugin_categories import ShortcodePlugin
-
-try:
-    from urlparse import urlunsplit
-except ImportError:
-    from urllib.parse import urlunsplit  # NOQA
 
 
 class Plugin(ShortcodePlugin):

--- a/nikola/plugins/shortcode/thumbnail.py
+++ b/nikola/plugins/shortcode/thumbnail.py
@@ -26,9 +26,9 @@
 
 """Thumbnail shortcode (equivalent to reST’s thumbnail directive)."""
 
-from nikola.plugin_categories import ShortcodePlugin
-
 import os.path
+
+from nikola.plugin_categories import ShortcodePlugin
 
 
 class ThumbnailShortcode(ShortcodePlugin):

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -27,9 +27,11 @@
 """Classify the posts in archives."""
 
 import datetime
-import natsort
-import nikola.utils
 from collections import defaultdict
+
+import natsort
+
+import nikola.utils
 from nikola.plugin_categories import Taxonomy
 
 

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -26,8 +26,8 @@
 
 """Render the category pages and feeds."""
 
-
 import os
+
 from nikola.plugin_categories import Taxonomy
 from nikola import utils, hierarchy_utils
 

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -37,16 +37,12 @@ from urllib.parse import urljoin
 
 import natsort
 import PyRSS2Gen as rss
+from PIL import Image
 
 from nikola.plugin_categories import Task
 from nikola import utils
 from nikola.image_processing import ImageProcessor
 from nikola.post import Post
-
-try:
-    from PIL import Image  # NOQA
-except ImportError:
-    import Image
 
 try:
     from ruamel.yaml import YAML

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -33,27 +33,25 @@ import json
 import mimetypes
 import os
 from collections import OrderedDict
-
-try:
-    from ruamel.yaml import YAML
-except ImportError:
-    YAML = None  # NOQA
-
 from urllib.parse import urljoin
 
 import natsort
-try:
-    from PIL import Image  # NOQA
-except ImportError:
-    import Image as _Image
-    Image = _Image
-
 import PyRSS2Gen as rss
 
 from nikola.plugin_categories import Task
 from nikola import utils
 from nikola.image_processing import ImageProcessor
 from nikola.post import Post
+
+try:
+    from PIL import Image  # NOQA
+except ImportError:
+    import Image
+
+try:
+    from ruamel.yaml import YAML
+except ImportError:
+    YAML = None  # NOQA
 
 _image_size_cache = {}
 

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -39,10 +39,7 @@ try:
 except ImportError:
     YAML = None  # NOQA
 
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin  # NOQA
+from urllib.parse import urljoin
 
 import natsort
 try:

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -47,7 +47,7 @@ from nikola.post import Post
 try:
     from ruamel.yaml import YAML
 except ImportError:
-    YAML = None  # NOQA
+    YAML = None
 
 _image_size_cache = {}
 

--- a/nikola/plugins/task/listings.py
+++ b/nikola/plugins/task/listings.py
@@ -26,13 +26,12 @@
 
 """Render code listings."""
 
-
-from collections import defaultdict
 import os
+from collections import defaultdict
 
+import natsort
 from pygments import highlight
 from pygments.lexers import get_lexer_for_filename, guess_lexer, TextLexer
-import natsort
 
 from nikola.plugin_categories import Task
 from nikola import utils

--- a/nikola/plugins/task/posts.py
+++ b/nikola/plugins/task/posts.py
@@ -26,8 +26,8 @@
 
 """Build HTML fragments from metadata and text."""
 
-from copy import copy
 import os
+from copy import copy
 
 from nikola.plugin_categories import Task
 from nikola import utils

--- a/nikola/plugins/task/robots.py
+++ b/nikola/plugins/task/robots.py
@@ -28,10 +28,7 @@
 
 import io
 import os
-try:
-    from urlparse import urljoin, urlparse
-except ImportError:
-    from urllib.parse import urljoin, urlparse  # NOQA
+from urllib.parse import urljoin, urlparse
 
 from nikola.plugin_categories import LateTask
 from nikola import utils

--- a/nikola/plugins/task/sitemap.py
+++ b/nikola/plugins/task/sitemap.py
@@ -30,12 +30,8 @@ import io
 import datetime
 import dateutil.tz
 import os
-try:
-    from urlparse import urljoin, urlparse
-    import robotparser as robotparser
-except ImportError:
-    from urllib.parse import urljoin, urlparse  # NOQA
-    import urllib.robotparser as robotparser  # NOQA
+import urllib.robotparser as robotparser
+from urllib.parse import urljoin, urlparse
 
 from nikola.plugin_categories import LateTask
 from nikola.utils import apply_filters, config_changed, encodelink

--- a/nikola/plugins/task/sitemap.py
+++ b/nikola/plugins/task/sitemap.py
@@ -26,12 +26,13 @@
 
 """Generate a sitemap."""
 
-import io
 import datetime
-import dateutil.tz
+import io
 import os
 import urllib.robotparser as robotparser
 from urllib.parse import urljoin, urlparse
+
+import dateutil.tz
 
 from nikola.plugin_categories import LateTask
 from nikola.utils import apply_filters, config_changed, encodelink

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -26,16 +26,17 @@
 
 """Render the taxonomy overviews, classification pages and feeds."""
 
-import blinker
 import os
-import natsort
 from collections import defaultdict
 from copy import copy
 from urllib.parse import urljoin
 
-from nikola.plugin_categories import Task
+import blinker
+import natsort
+
 from nikola import utils, hierarchy_utils
 from nikola.nikola import _enclosure
+from nikola.plugin_categories import Task
 
 
 class RenderTaxonomies(Task):

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -31,10 +31,7 @@ import os
 import natsort
 from collections import defaultdict
 from copy import copy
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin  # NOQA
+from urllib.parse import urljoin
 
 from nikola.plugin_categories import Task
 from nikola import utils, hierarchy_utils

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -24,20 +24,20 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
 """Jinja template handler."""
 
-import os
 import io
 import json
+import os
+
+from nikola.plugin_categories import TemplateSystem
+from nikola.utils import makedirs, req_missing, sort_posts, _smartjoin_filter
+
 try:
     import jinja2
     from jinja2 import meta
 except ImportError:
     jinja2 = None  # NOQA
-
-from nikola.plugin_categories import TemplateSystem
-from nikola.utils import makedirs, req_missing, sort_posts, _smartjoin_filter
 
 
 class JinjaTemplates(TemplateSystem):

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -37,7 +37,7 @@ try:
     import jinja2
     from jinja2 import meta
 except ImportError:
-    jinja2 = None  # NOQA
+    jinja2 = None
 
 
 class JinjaTemplates(TemplateSystem):

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -34,10 +34,7 @@ import hashlib
 import json
 import os
 import re
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin  # NOQA
+from urllib.parse import urljoin
 
 from . import utils
 

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -425,7 +425,7 @@ class Post(object):
             rv = rv._prev_post
         return rv
 
-    @prev_post.setter  # NOQA
+    @prev_post.setter
     def prev_post(self, v):
         """Set previous post."""
         self._prev_post = v
@@ -443,7 +443,7 @@ class Post(object):
             rv = rv._next_post
         return rv
 
-    @next_post.setter  # NOQA
+    @next_post.setter
     def next_post(self, v):
         """Set next post."""
         self._next_post = v

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -26,31 +26,25 @@
 
 """The Post class."""
 
-
 import io
-from collections import defaultdict
 import datetime
 import hashlib
 import json
 import os
 import re
+from collections import defaultdict
+from math import ceil  # for reading time feature
 from urllib.parse import urljoin
 
-from . import utils
-
-from blinker import signal
 import dateutil.tz
 import lxml.html
 import natsort
-try:
-    import pyphen
-except ImportError:
-    pyphen = None
-
-from math import ceil  # for reading time feature
+from blinker import signal
 
 # for tearDown with _reload we cannot use 'from import' to get forLocaleBorg
 import nikola.utils
+from . import metadata_extractors
+from . import utils
 from .utils import (
     current_time,
     Functionary,
@@ -63,7 +57,12 @@ from .utils import (
     get_translation_candidate,
     map_metadata
 )
-from nikola import metadata_extractors
+
+try:
+    import pyphen
+except ImportError:
+    pyphen = None
+
 
 __all__ = ('Post',)
 

--- a/nikola/shortcodes.py
+++ b/nikola/shortcodes.py
@@ -26,11 +26,10 @@
 
 """Support for Hugo-style shortcodes."""
 
-
+import sys
 import uuid
 
 from .utils import LOGGER
-import sys
 
 
 class ParsingError(Exception):

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -42,6 +42,7 @@ import socket
 import subprocess
 import sys
 import threading
+import typing
 from urllib.parse import quote as urlquote
 from urllib.parse import unquote as urlunquote
 from urllib.parse import urlparse, urlunparse
@@ -64,11 +65,6 @@ try:
 except ImportError:
     husl = None
 
-try:
-    import typing  # NOQA
-    import typing.re  # NOQA
-except ImportError:
-    pass
 
 from blinker import signal
 from collections import defaultdict, OrderedDict
@@ -1290,7 +1286,7 @@ class LocaleBorg(object):
             lang = self.current_lang
         locale = self.locales.get(lang, lang)
 
-        def date_formatter(match: 'typing.re.Match') -> str:
+        def date_formatter(match: typing.Match) -> str:
             """Format a date as requested."""
             mode, custom_format = match.groups()
             if LocaleBorg.in_string_formatter is not None:

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -41,17 +41,13 @@ import shutil
 import socket
 import subprocess
 import sys
+from urllib.parse import quote as urlquote
+from urllib.parse import unquote as urlunquote
+from urllib.parse import urlparse, urlunparse
+
 import dateutil.parser
 import dateutil.tz
 import logbook
-try:
-    from urllib import quote as urlquote
-    from urllib import unquote as urlunquote
-    from urlparse import urlparse, urlunparse
-except ImportError:
-    from urllib.parse import quote as urlquote  # NOQA
-    from urllib.parse import unquote as urlunquote  # NOQA
-    from urllib.parse import urlparse, urlunparse  # NOQA
 import warnings
 import PyRSS2Gen as rss
 try:

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -41,6 +41,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import threading
 from urllib.parse import quote as urlquote
 from urllib.parse import unquote as urlunquote
 from urllib.parse import urlparse, urlunparse
@@ -1227,7 +1228,6 @@ class LocaleBorg(object):
 
         Used in testing to prevent leaking state between tests.
         """
-        import threading
         cls.__thread_local = threading.local()
         cls.__thread_lock = threading.Lock()
 

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -43,6 +43,7 @@ import subprocess
 import sys
 import threading
 import typing
+from html import unescape as html_unescape
 from urllib.parse import quote as urlquote
 from urllib.parse import unquote as urlunquote
 from urllib.parse import urlparse, urlunparse
@@ -1961,19 +1962,6 @@ def load_data(path):
         return
     with io.open(path, 'r', encoding='utf8') as inf:
         return getattr(loader, function)(inf)
-
-
-# see http://stackoverflow.com/a/2087433
-try:
-    import html  # Python 3.4 and newer
-    html_unescape = html.unescape
-except (AttributeError, ImportError):
-    from html.parser import HTMLParser  # Python 3.4 and older
-
-    def html_unescape(s):
-        """Convert all named and numeric character references in the string s to the corresponding unicode characters."""
-        h = HTMLParser()
-        return h.unescape(s)
 
 
 def rss_writer(rss_obj, output_path):


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description

Removed imports that we made to be compatible with now unsupported versions of Python (< 3.5).

Moved some builtin module imports to the top of the module - there is no point in having them as a lazy import as these are always present.

The largest part is a reworked import order:
First come Python builtins.
After that outside depenendencies followed by our own modules.
Lastly there are the conditional / optional imports.

Imports have been grouped together to make it easy to see where an import belongs.

The imports are ordered to first have complete module imports followed by specific imports.
The order is then alphabetically.
