### PR TITLE
Drop logbook

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,14 @@ Bugfixes
 * Fix loading complex config files that import modules (Issue #3314)
 * Fix behavior of header demotion for negative values
 
+Other compatibility information
+-------------------------------
+
+1. Nikola no longer requires logbook.  You may need to upgrade plugins.
+2. If you receive an error stating that *sitemap is not a package*,
+   you need to remove a leftover ``nikola/plugins/task/sitemap``
+   directory (the full path is in the error message).
+
 New in v8.0.3
 =============
 

--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -43,14 +43,12 @@ from doit.cmd_run import Run as DoitRun
 from doit.doit_cmd import DoitMain
 from doit.loader import generate_tasks
 from doit.reporter import ExecutedOnlyReporter
-from logbook import NullHandler
 
 from . import __version__
 from .nikola import Nikola
 from .plugin_categories import Command
-from .utils import (LOGGER, STDERR_HANDLER, STRICT_HANDLER,
-                    ColorfulStderrHandler, get_root_dir, req_missing,
-                    sys_decode)
+from .log import configure_logging, LOGGER, ColorfulFormatter, LoggingMode
+from .utils import get_root_dir, req_missing, sys_decode
 
 try:
     import readline  # NOQA
@@ -70,7 +68,7 @@ def main(args=None):
     if sys.stderr.isatty() and os.name != 'nt' and os.getenv('NIKOLA_MONO') is None and os.getenv('TERM') != 'dumb':
         colorful = True
 
-    ColorfulStderrHandler._colorful = colorful
+    ColorfulFormatter._colorful = colorful
 
     if args is None:
         args = sys.argv[1:]
@@ -91,15 +89,14 @@ def main(args=None):
     quiet = False
     strict = False
     if len(args) > 0 and args[0] == 'build' and '--strict' in args:
-        LOGGER.notice('Running in strict mode')
-        STRICT_HANDLER.push_application()
+        LOGGER.info('Running in strict mode')
+        configure_logging(LoggingMode.STRICT)
         strict = True
-    if len(args) > 0 and args[0] == 'build' and '-q' in args or '--quiet' in args:
-        NullHandler().push_application()
+    elif len(args) > 0 and args[0] == 'build' and '-q' in args or '--quiet' in args:
+        configure_logging(LoggingMode.QUIET)
         quiet = True
-    if not quiet and not strict:
-        NullHandler().push_application()
-        STDERR_HANDLER[0].push_application()
+    else:
+        configure_logging()
 
     global config
 
@@ -417,7 +414,7 @@ def _print_exception():
     """Print an exception in a friendlier, shorter style."""
     etype, evalue, _ = sys.exc_info()
     LOGGER.error(''.join(traceback.format_exception(etype, evalue, None, limit=0, chain=False)).strip())
-    LOGGER.notice("To see more details, run Nikola in debug mode (set environment variable NIKOLA_DEBUG=1) or use NIKOLA_SHOW_TRACEBACKS=1")
+    LOGGER.warning("To see more details, run Nikola in debug mode (set environment variable NIKOLA_DEBUG=1) or use NIKOLA_SHOW_TRACEBACKS=1")
 
 
 if __name__ == "__main__":

--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -87,11 +87,9 @@ def main(args=None):
             break
 
     quiet = False
-    strict = False
     if len(args) > 0 and args[0] == 'build' and '--strict' in args:
         LOGGER.info('Running in strict mode')
         configure_logging(LoggingMode.STRICT)
-        strict = True
     elif len(args) > 0 and args[0] == 'build' and '-q' in args or '--quiet' in args:
         configure_logging(LoggingMode.QUIET)
         quiet = True

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -139,7 +139,7 @@ class ImageProcessor(object):
             else:
                 im.save(dst, icc_profile=icc_profile)
         except Exception as e:
-            self.logger.warn("Can't process {0}, using original "
+            self.logger.warning("Can't process {0}, using original "
                              "image! ({1})".format(src, e))
             utils.copy_file(src, dst)
 
@@ -182,7 +182,7 @@ class ImageProcessor(object):
             op.write(lxml.etree.tostring(tree))
             op.close()
         except (KeyError, AttributeError) as e:
-            self.logger.warn("No width/height in %s. Original exception: %s" % (src, e))
+            self.logger.warning("No width/height in %s. Original exception: %s" % (src, e))
             utils.copy_file(src, dst)
 
     def image_date(self, src):

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -140,7 +140,7 @@ class ImageProcessor(object):
                 im.save(dst, icc_profile=icc_profile)
         except Exception as e:
             self.logger.warning("Can't process {0}, using original "
-                             "image! ({1})".format(src, e))
+                                "image! ({1})".format(src, e))
             utils.copy_file(src, dst)
 
     def resize_svg(self, src, dst, max_size, bigger_panoramas):

--- a/nikola/log.py
+++ b/nikola/log.py
@@ -78,16 +78,16 @@ class ColorfulFormatter(logging.Formatter):
 
 def get_logger(name: str, handlers=None) -> logging.Logger:
     """Get a logger with handlers attached."""
-    l = logging.getLogger(name)
+    logger = logging.getLogger(name)
     if handlers is not None:
         for h in handlers:
-            l.addHandler(h)
-    return l
+            logger.addHandler(h)
+    return patch_notice_level(logger)
 
 
 # For compatibility with old code written with Logbook in mind
 # TODO remove in v8
-def patch_notice_level(logger: logging.Logger):
+def patch_notice_level(logger: logging.Logger) -> logging.Logger:
     """Patch logger to issue WARNINGs with logger.notice."""
     logger.notice = logger.warning
     return logger

--- a/nikola/log.py
+++ b/nikola/log.py
@@ -64,13 +64,15 @@ class ColorfulFormatter(logging.Formatter):
         return self.get_wrap_string(record).format(message)
 
     def get_wrap_string(self, record: logging.LogRecord) -> str:
-        """Returns the colorized string for this record."""
+        """Return the colorized string for this record."""
         if not self._colorful:
             return "{}"
         if record.levelno >= logging.ERROR:
             return "\033[1;31m{}\033[0m"
         elif record.levelno >= logging.WARNING:
             return "\033[1;33m{}\033[0m"
+        elif record.levelno >= logging.INFO:
+            return "\033[1m{}\033[0m"
         return "\033[37m{}\033[0m"
 
 

--- a/nikola/log.py
+++ b/nikola/log.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+
+# Copyright © 2012-2019 Roberto Alsina and others.
+
+# Permission is hereby granted, free of charge, to any
+# person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the
+# Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the
+# Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice
+# shall be included in all copies or substantial portions of
+# the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+# KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+# PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+# OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Logging support."""
+
+import enum
+import logging
+import warnings
+
+from nikola import DEBUG
+
+__all__ = (
+    "get_logger",
+    "LOGGER",
+)
+
+
+class ApplicationWarning(Exception):
+    """An application warning, raised in strict mode."""
+
+    pass
+
+
+class StrictModeExceptionHandler(logging.StreamHandler):
+    """A logging handler that raises an exception on warnings."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Emit a logging record."""
+        if record.levelno >= logging.WARNING:
+            raise ApplicationWarning(self.format(record))
+
+
+class ColorfulFormatter(logging.Formatter):
+    """Stream handler with colors."""
+
+    _colorful = False
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format a message and add colors to it."""
+        message = super().format(record)
+        return self.get_wrap_string(record).format(message)
+
+    def get_wrap_string(self, record: logging.LogRecord) -> str:
+        """Returns the colorized string for this record."""
+        if not self._colorful:
+            return "{}"
+        if record.levelno >= logging.ERROR:
+            return "\033[1;31m{}\033[0m"
+        elif record.levelno >= logging.WARNING:
+            return "\033[1;33m{}\033[0m"
+        return "\033[37m{}\033[0m"
+
+
+def get_logger(name: str, handlers=None) -> logging.Logger:
+    """Get a logger with handlers attached."""
+    l = logging.getLogger(name)
+    if handlers is not None:
+        for h in handlers:
+            l.addHandler(h)
+    return l
+
+
+# For compatibility with old code written with Logbook in mind
+# TODO remove in v8
+def patch_notice_level(logger: logging.Logger):
+    """Patch logger to issue WARNINGs with logger.notice."""
+    logger.notice = logger.warning
+    return logger
+
+
+LOGGER = get_logger("Nikola")
+
+
+class LoggingMode(enum.Enum):
+    """Logging mode options."""
+
+    NORMAL = 0
+    STRICT = 1
+    QUIET = 2
+
+
+def configure_logging(logging_mode: LoggingMode = LoggingMode.NORMAL) -> None:
+    """Configure logging for Nikola."""
+    if DEBUG:
+        logging.root.level = logging.DEBUG
+    else:
+        logging.root.level = logging.INFO
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        ColorfulFormatter(
+            fmt="[%(asctime)s] %(levelname)s: %(name)s: %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%SZ",
+        )
+    )
+    if logging_mode == LoggingMode.QUIET:
+        logging.root.handlers = []
+        return
+
+    handlers = [handler]
+    if logging_mode == LoggingMode.STRICT:
+        handlers.append(StrictModeExceptionHandler())
+
+    logging.root.handlers = handlers
+
+
+configure_logging()
+
+
+def showwarning(message, category, filename, lineno, file=None, line=None):
+    """Show a warning (from the warnings module) to the user."""
+    try:
+        n = category.__name__
+    except AttributeError:
+        n = str(category)
+    get_logger(n).warning("{0}:{1}: {2}".format(filename, lineno, message))
+
+
+warnings.showwarning = showwarning

--- a/nikola/log.py
+++ b/nikola/log.py
@@ -119,7 +119,7 @@ configure_logging()
 
 
 # For compatibility with old code written with Logbook in mind
-# TODO remove in v8
+# TODO remove in v9
 def patch_notice_level(logger: logging.Logger) -> logging.Logger:
     """Patch logger to issue WARNINGs with logger.notice."""
     logger.notice = logger.warning

--- a/nikola/log.py
+++ b/nikola/log.py
@@ -37,6 +37,7 @@ __all__ = (
     "LOGGER",
 )
 
+
 # Handlers/formatters
 class ApplicationWarning(Exception):
     """An application warning, raised in strict mode."""
@@ -115,15 +116,6 @@ def configure_logging(logging_mode: LoggingMode = LoggingMode.NORMAL) -> None:
 
 configure_logging()
 
-# Loggers for use
-def get_logger(name: str, handlers=None) -> logging.Logger:
-    """Get a logger with handlers attached."""
-    logger = logging.getLogger(name)
-    if handlers is not None:
-        for h in handlers:
-            logger.addHandler(h)
-    return patch_notice_level(logger)
-
 
 # For compatibility with old code written with Logbook in mind
 # TODO remove in v8
@@ -133,7 +125,18 @@ def patch_notice_level(logger: logging.Logger) -> logging.Logger:
     return logger
 
 
+# User-facing loggers
+def get_logger(name: str, handlers=None) -> logging.Logger:
+    """Get a logger with handlers attached."""
+    logger = logging.getLogger(name)
+    if handlers is not None:
+        for h in handlers:
+            logger.addHandler(h)
+    return patch_notice_level(logger)
+
+
 LOGGER = get_logger("Nikola")
+
 
 # Push warnings to logging
 def showwarning(message, category, filename, lineno, file=None, line=None):

--- a/nikola/log.py
+++ b/nikola/log.py
@@ -37,7 +37,7 @@ __all__ = (
     "LOGGER",
 )
 
-
+# Handlers/formatters
 class ApplicationWarning(Exception):
     """An application warning, raised in strict mode."""
 
@@ -76,26 +76,7 @@ class ColorfulFormatter(logging.Formatter):
         return "\033[37m{}\033[0m"
 
 
-def get_logger(name: str, handlers=None) -> logging.Logger:
-    """Get a logger with handlers attached."""
-    logger = logging.getLogger(name)
-    if handlers is not None:
-        for h in handlers:
-            logger.addHandler(h)
-    return patch_notice_level(logger)
-
-
-# For compatibility with old code written with Logbook in mind
-# TODO remove in v8
-def patch_notice_level(logger: logging.Logger) -> logging.Logger:
-    """Patch logger to issue WARNINGs with logger.notice."""
-    logger.notice = logger.warning
-    return logger
-
-
-LOGGER = get_logger("Nikola")
-
-
+# Initial configuration
 class LoggingMode(enum.Enum):
     """Logging mode options."""
 
@@ -105,7 +86,10 @@ class LoggingMode(enum.Enum):
 
 
 def configure_logging(logging_mode: LoggingMode = LoggingMode.NORMAL) -> None:
-    """Configure logging for Nikola."""
+    """Configure logging for Nikola.
+
+    This method can be called multiple times, previous configuration will be overridden.
+    """
     if DEBUG:
         logging.root.level = logging.DEBUG
     else:
@@ -131,7 +115,27 @@ def configure_logging(logging_mode: LoggingMode = LoggingMode.NORMAL) -> None:
 
 configure_logging()
 
+# Loggers for use
+def get_logger(name: str, handlers=None) -> logging.Logger:
+    """Get a logger with handlers attached."""
+    logger = logging.getLogger(name)
+    if handlers is not None:
+        for h in handlers:
+            logger.addHandler(h)
+    return patch_notice_level(logger)
 
+
+# For compatibility with old code written with Logbook in mind
+# TODO remove in v8
+def patch_notice_level(logger: logging.Logger) -> logging.Logger:
+    """Patch logger to issue WARNINGs with logger.notice."""
+    logger.notice = logger.warning
+    return logger
+
+
+LOGGER = get_logger("Nikola")
+
+# Push warnings to logging
 def showwarning(message, category, filename, lineno, file=None, line=None):
     """Show a warning (from the warnings module) to the user."""
     try:

--- a/nikola/log.py
+++ b/nikola/log.py
@@ -62,9 +62,9 @@ class ColorfulFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         """Format a message and add colors to it."""
         message = super().format(record)
-        return self.get_wrap_string(record).format(message)
+        return self.wrap_in_color(record).format(message)
 
-    def get_wrap_string(self, record: logging.LogRecord) -> str:
+    def wrap_in_color(self, record: logging.LogRecord) -> str:
         """Return the colorized string for this record."""
         if not self._colorful:
             return "{}"
@@ -96,6 +96,10 @@ def configure_logging(logging_mode: LoggingMode = LoggingMode.NORMAL) -> None:
     else:
         logging.root.level = logging.INFO
 
+    if logging_mode == LoggingMode.QUIET:
+        logging.root.handlers = []
+        return
+
     handler = logging.StreamHandler()
     handler.setFormatter(
         ColorfulFormatter(
@@ -103,9 +107,6 @@ def configure_logging(logging_mode: LoggingMode = LoggingMode.NORMAL) -> None:
             datefmt="%Y-%m-%dT%H:%M:%SZ",
         )
     )
-    if logging_mode == LoggingMode.QUIET:
-        logging.root.handlers = []
-        return
 
     handlers = [handler]
     if logging_mode == LoggingMode.STRICT:

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -716,9 +716,9 @@ class Nikola(object):
         for val in self.config['DATE_FORMAT'].values.values():
             if '%' in val:
                 utils.LOGGER.error('The DATE_FORMAT setting needs to be upgraded.')
-                utils.LOGGER.notice("Nikola now uses CLDR-style date strings. http://cldr.unicode.org/translation/date-time")
-                utils.LOGGER.notice("Example: %Y-%m-%d %H:%M ==> YYYY-MM-dd HH:mm")
-                utils.LOGGER.notice("(note it’s different to what moment.js uses!)")
+                utils.LOGGER.warning("Nikola now uses CLDR-style date strings. http://cldr.unicode.org/translation/date-time")
+                utils.LOGGER.warning("Example: %Y-%m-%d %H:%M ==> YYYY-MM-dd HH:mm")
+                utils.LOGGER.warning("(note it’s different to what moment.js uses!)")
                 sys.exit(1)
 
         # Silently upgrade LOCALES (remove encoding)

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -302,7 +302,7 @@ def _enclosure(post, lang):
         except KeyError:
             length = 0
         except ValueError:
-            utils.LOGGER.warn("Invalid enclosure length for post {0}".format(post.source_path))
+            utils.LOGGER.warning("Invalid enclosure length for post {0}".format(post.source_path))
             length = 0
         url = enclosure
         mime = mimetypes.guess_type(url)[0]
@@ -677,40 +677,40 @@ class Nikola(object):
 
         # A EXIF_WHITELIST implies you want to keep EXIF data
         if self.config['EXIF_WHITELIST'] and not self.config['PRESERVE_EXIF_DATA']:
-            utils.LOGGER.warn('Setting EXIF_WHITELIST implies PRESERVE_EXIF_DATA is set to True')
+            utils.LOGGER.warning('Setting EXIF_WHITELIST implies PRESERVE_EXIF_DATA is set to True')
             self.config['PRESERVE_EXIF_DATA'] = True
 
         # Setting PRESERVE_EXIF_DATA with an empty EXIF_WHITELIST implies 'keep everything'
         if self.config['PRESERVE_EXIF_DATA'] and not self.config['EXIF_WHITELIST']:
-            utils.LOGGER.warn('You are setting PRESERVE_EXIF_DATA and not EXIF_WHITELIST so EXIF data is not really kept.')
+            utils.LOGGER.warning('You are setting PRESERVE_EXIF_DATA and not EXIF_WHITELIST so EXIF data is not really kept.')
 
         if 'UNSLUGIFY_TITLES' in self.config:
-            utils.LOGGER.warn('The UNSLUGIFY_TITLES setting was renamed to FILE_METADATA_UNSLUGIFY_TITLES.')
+            utils.LOGGER.warning('The UNSLUGIFY_TITLES setting was renamed to FILE_METADATA_UNSLUGIFY_TITLES.')
             self.config['FILE_METADATA_UNSLUGIFY_TITLES'] = self.config['UNSLUGIFY_TITLES']
 
         if 'TAG_PAGES_TITLES' in self.config:
-            utils.LOGGER.warn('The TAG_PAGES_TITLES setting was renamed to TAG_TITLES.')
+            utils.LOGGER.warning('The TAG_PAGES_TITLES setting was renamed to TAG_TITLES.')
             self.config['TAG_TITLES'] = self.config['TAG_PAGES_TITLES']
 
         if 'TAG_PAGES_DESCRIPTIONS' in self.config:
-            utils.LOGGER.warn('The TAG_PAGES_DESCRIPTIONS setting was renamed to TAG_DESCRIPTIONS.')
+            utils.LOGGER.warning('The TAG_PAGES_DESCRIPTIONS setting was renamed to TAG_DESCRIPTIONS.')
             self.config['TAG_DESCRIPTIONS'] = self.config['TAG_PAGES_DESCRIPTIONS']
 
         if 'CATEGORY_PAGES_TITLES' in self.config:
-            utils.LOGGER.warn('The CATEGORY_PAGES_TITLES setting was renamed to CATEGORY_TITLES.')
+            utils.LOGGER.warning('The CATEGORY_PAGES_TITLES setting was renamed to CATEGORY_TITLES.')
             self.config['CATEGORY_TITLES'] = self.config['CATEGORY_PAGES_TITLES']
 
         if 'CATEGORY_PAGES_DESCRIPTIONS' in self.config:
-            utils.LOGGER.warn('The CATEGORY_PAGES_DESCRIPTIONS setting was renamed to CATEGORY_DESCRIPTIONS.')
+            utils.LOGGER.warning('The CATEGORY_PAGES_DESCRIPTIONS setting was renamed to CATEGORY_DESCRIPTIONS.')
             self.config['CATEGORY_DESCRIPTIONS'] = self.config['CATEGORY_PAGES_DESCRIPTIONS']
 
         if 'DISABLE_INDEXES_PLUGIN_INDEX_AND_ATOM_FEED' in self.config:
-            utils.LOGGER.warn('The DISABLE_INDEXES_PLUGIN_INDEX_AND_ATOM_FEED setting was renamed and split to DISABLE_INDEXES and DISABLE_MAIN_ATOM_FEED.')
+            utils.LOGGER.warning('The DISABLE_INDEXES_PLUGIN_INDEX_AND_ATOM_FEED setting was renamed and split to DISABLE_INDEXES and DISABLE_MAIN_ATOM_FEED.')
             self.config['DISABLE_INDEXES'] = self.config['DISABLE_INDEXES_PLUGIN_INDEX_AND_ATOM_FEED']
             self.config['DISABLE_MAIN_ATOM_FEED'] = self.config['DISABLE_INDEXES_PLUGIN_INDEX_AND_ATOM_FEED']
 
         if 'DISABLE_INDEXES_PLUGIN_RSS_FEED' in self.config:
-            utils.LOGGER.warn('The DISABLE_INDEXES_PLUGIN_RSS_FEED setting was renamed to DISABLE_MAIN_RSS_FEED.')
+            utils.LOGGER.warning('The DISABLE_INDEXES_PLUGIN_RSS_FEED setting was renamed to DISABLE_MAIN_RSS_FEED.')
             self.config['DISABLE_MAIN_RSS_FEED'] = self.config['DISABLE_INDEXES_PLUGIN_RSS_FEED']
 
         for val in self.config['DATE_FORMAT'].values.values():
@@ -730,8 +730,8 @@ class Nikola(object):
         self.config['LOCALES'] = locales
 
         if self.config.get('POSTS_SECTIONS'):
-            utils.LOGGER.warn("The sections feature has been removed and its functionality has been merged into categories.")
-            utils.LOGGER.warn("For more information on how to migrate, please read: https://getnikola.com/blog/upgrading-to-nikola-v8.html#sections-were-replaced-by-categories")
+            utils.LOGGER.warning("The sections feature has been removed and its functionality has been merged into categories.")
+            utils.LOGGER.warning("For more information on how to migrate, please read: https://getnikola.com/blog/upgrading-to-nikola-v8.html#sections-were-replaced-by-categories")
 
             for section_config_suffix, cat_config_suffix in (
                 ('DESCRIPTIONS', 'DESCRIPTIONS'),
@@ -766,9 +766,9 @@ class Nikola(object):
 
         # Make sure we have pyphen installed if we are using it
         if self.config.get('HYPHENATE') and pyphen is None:
-            utils.LOGGER.warn('To use the hyphenation, you have to install '
+            utils.LOGGER.warning('To use the hyphenation, you have to install '
                               'the "pyphen" package.')
-            utils.LOGGER.warn('Setting HYPHENATE to False.')
+            utils.LOGGER.warning('Setting HYPHENATE to False.')
             self.config['HYPHENATE'] = False
 
         # FIXME: Internally, we still use post_pages because it's a pain to change it
@@ -786,25 +786,25 @@ class Nikola(object):
                     if plugin_name not in self.config['DISABLED_PLUGINS']:
                         missing_plugins.append(plugin_name)
                 if missing_plugins:
-                    utils.LOGGER.warn('The "{}" plugin was replaced by several taxonomy plugins (see PR #2535): {}'.format(old_plugin_name, ', '.join(new_plugin_names)))
-                    utils.LOGGER.warn('You are currently disabling "{}", but not the following new taxonomy plugins: {}'.format(old_plugin_name, ', '.join(missing_plugins)))
-                    utils.LOGGER.warn('Please also disable these new plugins or remove "{}" from the DISABLED_PLUGINS list.'.format(old_plugin_name))
+                    utils.LOGGER.warning('The "{}" plugin was replaced by several taxonomy plugins (see PR #2535): {}'.format(old_plugin_name, ', '.join(new_plugin_names)))
+                    utils.LOGGER.warning('You are currently disabling "{}", but not the following new taxonomy plugins: {}'.format(old_plugin_name, ', '.join(missing_plugins)))
+                    utils.LOGGER.warning('Please also disable these new plugins or remove "{}" from the DISABLED_PLUGINS list.'.format(old_plugin_name))
                     self.config['DISABLED_PLUGINS'].extend(missing_plugins)
         # Special-case logic for "render_indexes" to fix #2591
         if 'render_indexes' in self.config['DISABLED_PLUGINS']:
             if 'generate_rss' in self.config['DISABLED_PLUGINS'] or self.config['GENERATE_RSS'] is False:
                 if 'classify_indexes' not in self.config['DISABLED_PLUGINS']:
-                    utils.LOGGER.warn('You are disabling the "render_indexes" plugin, as well as disabling the "generate_rss" plugin or setting GENERATE_RSS to False. To achieve the same effect, please disable the "classify_indexes" plugin in the future.')
+                    utils.LOGGER.warning('You are disabling the "render_indexes" plugin, as well as disabling the "generate_rss" plugin or setting GENERATE_RSS to False. To achieve the same effect, please disable the "classify_indexes" plugin in the future.')
                     self.config['DISABLED_PLUGINS'].append('classify_indexes')
             else:
                 if not self.config['DISABLE_INDEXES']:
-                    utils.LOGGER.warn('You are disabling the "render_indexes" plugin, but not the generation of RSS feeds. Please put "DISABLE_INDEXES = True" into your configuration instead.')
+                    utils.LOGGER.warning('You are disabling the "render_indexes" plugin, but not the generation of RSS feeds. Please put "DISABLE_INDEXES = True" into your configuration instead.')
                     self.config['DISABLE_INDEXES'] = True
 
         # Disable RSS.  For a successful disable, we must have both the option
         # false and the plugin disabled through the official means.
         if 'generate_rss' in self.config['DISABLED_PLUGINS'] and self.config['GENERATE_RSS'] is True:
-            utils.LOGGER.warn('Please use GENERATE_RSS to disable RSS feed generation, instead of mentioning generate_rss in DISABLED_PLUGINS.')
+            utils.LOGGER.warning('Please use GENERATE_RSS to disable RSS feed generation, instead of mentioning generate_rss in DISABLED_PLUGINS.')
             self.config['GENERATE_RSS'] = False
             self.config['DISABLE_MAIN_RSS_FEED'] = True
 
@@ -830,7 +830,7 @@ class Nikola(object):
             self.config['BASE_URL'] = self.config.get('SITE_URL')
         # BASE_URL should *always* end in /
         if self.config['BASE_URL'] and self.config['BASE_URL'][-1] != '/':
-            utils.LOGGER.warn("Your BASE_URL doesn't end in / -- adding it, but please fix it in your config file!")
+            utils.LOGGER.warning("Your BASE_URL doesn't end in / -- adding it, but please fix it in your config file!")
             self.config['BASE_URL'] += '/'
 
         try:
@@ -853,7 +853,7 @@ class Nikola(object):
         if config.get('METADATA_FORMAT', 'nikola').lower() == 'pelican':
             if 'markdown.extensions.meta' not in config.get('MARKDOWN_EXTENSIONS', []) \
                     and 'markdown' in self.config['COMPILERS']:
-                utils.LOGGER.warn(
+                utils.LOGGER.warning(
                     'To use the Pelican metadata format, you need to add '
                     '"markdown.extensions.meta" to your MARKDOWN_EXTENSIONS setting.')
 
@@ -861,7 +861,7 @@ class Nikola(object):
         try:
             self.tzinfo = dateutil.tz.gettz(self.config['TIMEZONE'])
         except Exception as exc:
-            utils.LOGGER.warn("Error getting TZ: {}", exc)
+            utils.LOGGER.warning("Error getting TZ: {}", exc)
             self.tzinfo = dateutil.tz.gettz()
         self.config['__tzinfo__'] = self.tzinfo
 
@@ -1230,7 +1230,7 @@ class Nikola(object):
                 self._THEMES = utils.get_theme_chain(self.config['THEME'], self.themes_dirs)
             except Exception:
                 if self.config['THEME'] != LEGAL_VALUES['DEFAULT_THEME']:
-                    utils.LOGGER.warn('''Cannot load theme "{0}", using '{1}' instead.'''.format(
+                    utils.LOGGER.warning('''Cannot load theme "{0}", using '{1}' instead.'''.format(
                         self.config['THEME'], LEGAL_VALUES['DEFAULT_THEME']))
                     self.config['THEME'] = LEGAL_VALUES['DEFAULT_THEME']
                     return self._get_themes()
@@ -1240,7 +1240,7 @@ class Nikola(object):
                 bootstrap_path = utils.get_asset_path(os.path.join(
                     'assets', 'css', 'bootstrap.min.css'), self._THEMES)
                 if bootstrap_path and bootstrap_path.split(os.sep)[-4] not in ['bootstrap', 'bootstrap3', 'bootstrap4']:
-                    utils.LOGGER.warn('The USE_CDN option may be incompatible with your theme, because it uses a hosted version of bootstrap.')
+                    utils.LOGGER.warning('The USE_CDN option may be incompatible with your theme, because it uses a hosted version of bootstrap.')
 
         return self._THEMES
 
@@ -1618,7 +1618,7 @@ class Nikola(object):
     def register_shortcode(self, name, f):
         """Register function f to handle shortcode "name"."""
         if name in self.shortcode_registry:
-            utils.LOGGER.warn('Shortcode name conflict: {}', name)
+            utils.LOGGER.warning('Shortcode name conflict: {}', name)
             return
         self.shortcode_registry[name] = f
 
@@ -1788,7 +1788,7 @@ class Nikola(object):
         try:
             path = self.path_handlers[kind](name, lang, **kwargs)
         except KeyError:
-            utils.LOGGER.warn("Unknown path request of kind: {0}".format(kind))
+            utils.LOGGER.warning("Unknown path request of kind: {0}".format(kind))
             return ""
 
         # If path handler returns a string we consider it to be an absolute URL not requiring any
@@ -1928,7 +1928,7 @@ class Nikola(object):
         one argument (the filename).
         """
         if filter_name in self.filters:
-            utils.LOGGER.warn('''The filter "{0}" is defined more than once.'''.format(filter_name))
+            utils.LOGGER.warning('''The filter "{0}" is defined more than once.'''.format(filter_name))
         self.filters[filter_name] = filter_definition
 
     def file_exists(self, path, not_empty=False):

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -767,7 +767,7 @@ class Nikola(object):
         # Make sure we have pyphen installed if we are using it
         if self.config.get('HYPHENATE') and pyphen is None:
             utils.LOGGER.warning('To use the hyphenation, you have to install '
-                              'the "pyphen" package.')
+                                 'the "pyphen" package.')
             utils.LOGGER.warning('Setting HYPHENATE to False.')
             self.config['HYPHENATE'] = False
 
@@ -2413,8 +2413,8 @@ class Nikola(object):
             entry_author_name = lxml.etree.SubElement(entry_author, "name")
             entry_author_name.text = post.author(lang)
             entry_root.append(atom_link("alternate", "text/html",
-                              post.permalink(lang, absolute=True,
-                                             query=feed_append_query)))
+                                        post.permalink(lang, absolute=True,
+                                                       query=feed_append_query)))
             entry_summary = lxml.etree.SubElement(entry_root, "summary")
             if not self.config["FEED_PLAIN"]:
                 entry_summary.set("type", "html")
@@ -2645,11 +2645,11 @@ class Nikola(object):
             "task_dep": ['render_posts'],
             "targets": [output_name],
             "actions": [(self.atom_feed_renderer,
-                        (lang,
-                         post_list,
-                         output_name,
-                         kw['filters'],
-                         context,))],
+                         (lang,
+                          post_list,
+                          output_name,
+                          kw['filters'],
+                          context,))],
             "clean": True,
             "uptodate": [utils.config_changed(kw, 'nikola.nikola.Nikola.atom_feed_renderer')] + additional_dependencies
         }

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -27,12 +27,12 @@
 """Nikola plugin categories."""
 
 import io
+import logging
 import os
 import sys
 import typing
 
 import doit
-import logbook
 from doit.cmd_base import Command as DoitCommand
 from yapsy.IPlugin import IPlugin
 
@@ -70,7 +70,7 @@ class BasePlugin(IPlugin):
         self.inject_templates()
         self.logger = get_logger(self.name)
         if not site.debug:
-            self.logger.level = logbook.base.INFO
+            self.logger.level = logging.INFO
 
     def inject_templates(self):
         """Inject 'templates/<engine>' (if exists) very early in the theme chain."""

--- a/nikola/plugins/basic_import.py
+++ b/nikola/plugins/basic_import.py
@@ -95,8 +95,8 @@ class ImportMixin(object):
             os.system('nikola init -q ' + self.output_folder)
         else:
             self.import_into_existing_site = True
-            utils.LOGGER.notice('The folder {0} already exists - assuming that this is a '
-                                'already existing Nikola site.'.format(self.output_folder))
+            utils.LOGGER.warning('The folder {0} already exists - assuming that this is a '
+                                 'already existing Nikola site.'.format(self.output_folder))
 
         filename = resource_filename('nikola', 'conf.py.in')
         # The 'strict_undefined=True' will give the missing symbol name if any,

--- a/nikola/plugins/basic_import.py
+++ b/nikola/plugins/basic_import.py
@@ -84,7 +84,7 @@ class ImportMixin(object):
             src = (urlparse(k).path + 'index.html')[1:]
             dst = (urlparse(v).path)
             if src == index:
-                utils.LOGGER.warn("Can't do a redirect for: {0!r}".format(k))
+                utils.LOGGER.warning("Can't do a redirect for: {0!r}".format(k))
             else:
                 redirections.append((src, dst))
         return redirections

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -355,7 +355,7 @@ class CommandAuto(Command):
                     }
                     await ws.send_json(response)
                 elif message['command'] != 'info':
-                    self.logger.warn("Unknown command in message: {0}".format(message))
+                    self.logger.warning("Unknown command in message: {0}".format(message))
             elif msg.type == aiohttp.WSMsgType.CLOSED:
                 break
             elif msg.type == aiohttp.WSMsgType.CLOSE:
@@ -366,7 +366,7 @@ class CommandAuto(Command):
                 self.logger.error('WebSocket connection closed with exception {0}'.format(ws.exception()))
                 break
             else:
-                self.logger.warn("Received unknown message: {0}".format(msg))
+                self.logger.warning("Received unknown message: {0}".format(msg))
 
         self.sockets.remove(ws)
         self.logger.debug("WebSocket connection closed: {0}".format(ws))
@@ -385,7 +385,7 @@ class CommandAuto(Command):
                 await ws.send_json(message)
             except RuntimeError as e:
                 if 'closed' in e.args[0]:
-                    self.logger.warn("WebSocket {0} closed uncleanly".format(ws))
+                    self.logger.warning("WebSocket {0} closed uncleanly".format(ws))
                     to_delete.append(ws)
                 else:
                     raise

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -26,6 +26,7 @@
 
 """Check the generated site."""
 
+import logging
 import os
 import re
 import sys
@@ -33,7 +34,6 @@ import time
 from collections import defaultdict
 from urllib.parse import unquote, urlparse, urljoin, urldefrag
 
-import logbook
 import lxml.html
 import requests
 from doit.loader import generate_tasks
@@ -156,9 +156,9 @@ class CommandCheck(Command):
             print(self.help())
             return 1
         if options['verbose']:
-            self.logger.level = logbook.DEBUG
+            self.logger.level = logging.DEBUG
         else:
-            self.logger.level = logbook.NOTICE
+            self.logger.level = logging.warning
         failure = False
         if options['links']:
             failure |= self.scan_links(options['find_sources'], options['remote'])
@@ -197,7 +197,7 @@ class CommandCheck(Command):
                 # Do not look at links in the cache, which are not parsed by
                 # anyone and may result in false positives.  Problems arise
                 # with galleries, for example.  Full rationale: (Issue #1447)
-                self.logger.notice("Ignoring {0} (in cache, links may be incorrect)".format(filename))
+                self.logger.warning("Ignoring {0} (in cache, links may be incorrect)".format(filename))
                 return False
 
             if not os.path.exists(fname):

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -250,13 +250,13 @@ class CommandCheck(Command):
 
                 # Warn about links from https to http (mixed-security)
                 if base_url.netloc == parsed.netloc and base_url.scheme == "https" and parsed.scheme == "http":
-                    self.logger.warn("Mixed-content security for link in {0}: {1}".format(filename, target))
+                    self.logger.warning("Mixed-content security for link in {0}: {1}".format(filename, target))
 
                 # Link to an internal REDIRECTIONS page
                 if target in self.internal_redirects:
                     redir_status_code = 301
                     redir_target = [_dest for _target, _dest in self.site.config['REDIRECTIONS'] if urljoin('/', _target) == target][0]
-                    self.logger.warn("Remote link moved PERMANENTLY to \"{0}\" and should be updated in {1}: {2} [HTTP: 301]".format(redir_target, filename, target))
+                    self.logger.warning("Remote link moved PERMANENTLY to \"{0}\" and should be updated in {1}: {2} [HTTP: 301]".format(redir_target, filename, target))
 
                 # Absolute links to other domains, skip
                 # Absolute links when using only paths, skip.
@@ -266,7 +266,7 @@ class CommandCheck(Command):
                         continue
                     if target in self.checked_remote_targets:  # already checked this exact target
                         if self.checked_remote_targets[target] in [301, 308]:
-                            self.logger.warn("Remote link PERMANENTLY redirected in {0}: {1} [Error {2}]".format(filename, target, self.checked_remote_targets[target]))
+                            self.logger.warning("Remote link PERMANENTLY redirected in {0}: {1} [Error {2}]".format(filename, target, self.checked_remote_targets[target]))
                         elif self.checked_remote_targets[target] in [302, 307]:
                             self.logger.debug("Remote link temporarily redirected in {0}: {1} [HTTP: {2}]".format(filename, target, self.checked_remote_targets[target]))
                         elif self.checked_remote_targets[target] > 399:
@@ -294,7 +294,7 @@ class CommandCheck(Command):
                         resp = requests.get(target, headers=req_headers, allow_redirects=True)
                         # Permanent redirects should be updated
                         if redir_status_code in [301, 308]:
-                            self.logger.warn("Remote link moved PERMANENTLY to \"{0}\" and should be updated in {1}: {2} [HTTP: {3}]".format(resp.url, filename, target, redir_status_code))
+                            self.logger.warning("Remote link moved PERMANENTLY to \"{0}\" and should be updated in {1}: {2} [HTTP: {3}]".format(resp.url, filename, target, redir_status_code))
                         if redir_status_code in [302, 307]:
                             self.logger.debug("Remote link temporarily redirected to \"{0}\" in {1}: {2} [HTTP: {3}]".format(resp.url, filename, target, redir_status_code))
                         self.checked_remote_targets[resp.url] = resp.status_code
@@ -308,7 +308,7 @@ class CommandCheck(Command):
                     elif resp.status_code <= 399:  # The address leads *somewhere* that is not an error
                         self.logger.debug("Successfully checked remote link in {0}: {1} [HTTP: {2}]".format(filename, target, resp.status_code))
                         continue
-                    self.logger.warn("Could not check remote link in {0}: {1} [Unknown problem]".format(filename, target))
+                    self.logger.warning("Could not check remote link in {0}: {1} [Unknown problem]".format(filename, target))
                     continue
 
                 if url_type == 'rel_path':
@@ -357,11 +357,11 @@ class CommandCheck(Command):
                         self.existing_targets.add(target_filename)
                     else:
                         rv = True
-                        self.logger.warn("Broken link in {0}: {1}".format(filename, target))
+                        self.logger.warning("Broken link in {0}: {1}".format(filename, target))
                         if find_sources:
-                            self.logger.warn("Possible sources:")
-                            self.logger.warn("\n".join(deps[filename]))
-                            self.logger.warn("===============================\n")
+                            self.logger.warning("Possible sources:")
+                            self.logger.warning("\n".join(deps[filename]))
+                            self.logger.warning("===============================\n")
         except Exception as exc:
             self.logger.error(u"Error with: {0} {1}".format(filename, exc))
         return rv
@@ -407,15 +407,15 @@ class CommandCheck(Command):
 
         if only_on_output:
             only_on_output.sort()
-            self.logger.warn("Files from unknown origins (orphans):")
+            self.logger.warning("Files from unknown origins (orphans):")
             for f in only_on_output:
-                self.logger.warn(f)
+                self.logger.warning(f)
             failure = True
         if only_on_input:
             only_on_input.sort()
-            self.logger.warn("Files not generated:")
+            self.logger.warning("Files not generated:")
             for f in only_on_input:
-                self.logger.warn(f)
+                self.logger.warning(f)
         if not failure:
             self.logger.debug("All files checked.")
         return failure
@@ -444,7 +444,7 @@ class CommandCheck(Command):
                 pass
 
         if warn_flag:
-            self.logger.warn('Some files or directories have been removed, your site may need rebuilding')
+            self.logger.warning('Some files or directories have been removed, your site may need rebuilding')
             return True
 
         return False

--- a/nikola/plugins/command/check.py
+++ b/nikola/plugins/command/check.py
@@ -158,7 +158,7 @@ class CommandCheck(Command):
         if options['verbose']:
             self.logger.level = logging.DEBUG
         else:
-            self.logger.level = logging.warning
+            self.logger.level = logging.WARNING
         failure = False
         if options['links']:
             failure |= self.scan_links(options['find_sources'], options['remote'])

--- a/nikola/plugins/command/deploy.py
+++ b/nikola/plugins/command/deploy.py
@@ -88,7 +88,7 @@ class CommandDeploy(Command):
         # Remove drafts and future posts if requested
         undeployed_posts = clean_before_deployment(self.site)
         if undeployed_posts:
-            self.logger.notice("Deleted {0} posts due to DEPLOY_* settings".format(len(undeployed_posts)))
+            self.logger.warning("Deleted {0} posts due to DEPLOY_* settings".format(len(undeployed_posts)))
 
         if args:
             presets = args

--- a/nikola/plugins/command/deploy.py
+++ b/nikola/plugins/command/deploy.py
@@ -77,7 +77,7 @@ class CommandDeploy(Command):
             clean = False
 
         if self.site.config['COMMENT_SYSTEM'] and self.site.config['COMMENT_SYSTEM_ID'] == 'nikolademo':
-            self.logger.warn("\nWARNING WARNING WARNING WARNING\n"
+            self.logger.warning("\nWARNING WARNING WARNING WARNING\n"
                              "You are deploying using the nikolademo Disqus account.\n"
                              "That means you will not be able to moderate the comments in your own site.\n"
                              "And is probably not what you want to do.\n"

--- a/nikola/plugins/command/deploy.py
+++ b/nikola/plugins/command/deploy.py
@@ -78,11 +78,11 @@ class CommandDeploy(Command):
 
         if self.site.config['COMMENT_SYSTEM'] and self.site.config['COMMENT_SYSTEM_ID'] == 'nikolademo':
             self.logger.warning("\nWARNING WARNING WARNING WARNING\n"
-                             "You are deploying using the nikolademo Disqus account.\n"
-                             "That means you will not be able to moderate the comments in your own site.\n"
-                             "And is probably not what you want to do.\n"
-                             "Think about it for 5 seconds, I'll wait :-)\n"
-                             "(press Ctrl+C to abort)\n")
+                                "You are deploying using the nikolademo Disqus account.\n"
+                                "That means you will not be able to moderate the comments in your own site.\n"
+                                "And is probably not what you want to do.\n"
+                                "Think about it for 5 seconds, I'll wait :-)\n"
+                                "(press Ctrl+C to abort)\n")
             time.sleep(5)
 
         # Remove drafts and future posts if requested

--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -96,7 +96,7 @@ class CommandGitHubDeploy(Command):
         # Remove drafts and future posts if requested (Issue #2406)
         undeployed_posts = clean_before_deployment(self.site)
         if undeployed_posts:
-            self.logger.notice("Deleted {0} posts due to DEPLOY_* settings".format(len(undeployed_posts)))
+            self.logger.warning("Deleted {0} posts due to DEPLOY_* settings".format(len(undeployed_posts)))
 
         # Commit and push
         self._commit_and_push(options['commit_message'])
@@ -139,7 +139,7 @@ class CommandGitHubDeploy(Command):
                 if e != 0:
                     self._run_command(['git', 'commit', '-am', commit_message])
                 else:
-                    self.logger.notice('Nothing to commit to source branch.')
+                    self.logger.info('Nothing to commit to source branch.')
 
             try:
                 source_commit = uni_check_output(['git', 'rev-parse', source])

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -64,7 +64,7 @@ LOGGER = utils.get_logger('import_wordpress')
 
 def install_plugin(site, plugin_name, output_dir=None, show_install_notes=False):
     """Install a Nikola plugin."""
-    LOGGER.notice("Installing plugin '{0}'".format(plugin_name))
+    LOGGER.info("Installing plugin '{0}'".format(plugin_name))
     # Get hold of the 'plugin' plugin
     plugin_installer_info = site.plugin_manager.getPluginByName('plugin', 'Command')
     if plugin_installer_info is None:
@@ -993,10 +993,10 @@ to
                 post_format = 'wp'
 
         if is_draft and self.exclude_drafts:
-            LOGGER.notice('Draft "{0}" will not be imported.'.format(title))
+            LOGGER.warning('Draft "{0}" will not be imported.'.format(title))
             return False
         elif is_private and self.exclude_privates:
-            LOGGER.notice('Private post "{0}" will not be imported.'.format(title))
+            LOGGER.warning('Private post "{0}" will not be imported.'.format(title))
             return False
         elif content.strip() or self.import_empty_items:
             # If no content is found, no files are written.

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -265,7 +265,7 @@ to
             options['output_folder'] = args.pop(0)
 
         if args:
-            LOGGER.warn('You specified additional arguments ({0}). Please consider '
+            LOGGER.warning('You specified additional arguments ({0}). Please consider '
                         'putting these arguments before the filename if you '
                         'are running into problems.'.format(args))
 
@@ -313,7 +313,7 @@ to
             LOGGER.error("You can use at most one of the options --html2text, --transform-to-html and --transform-to-markdown.")
             return False
         if (self.html2text or self.transform_to_html or self.transform_to_markdown) and self.use_wordpress_compiler:
-            LOGGER.warn("It does not make sense to combine --use-wordpress-compiler with any of --html2text, --transform-to-html and --transform-to-markdown, as the latter convert all posts to HTML and the first option then affects zero posts.")
+            LOGGER.warning("It does not make sense to combine --use-wordpress-compiler with any of --html2text, --transform-to-html and --transform-to-markdown, as the latter convert all posts to HTML and the first option then affects zero posts.")
 
         if (self.html2text or self.transform_to_markdown) and not html2text:
             LOGGER.error("You need to install html2text via 'pip install html2text' before you can use the --html2text and --transform-to-markdown options.")
@@ -421,9 +421,9 @@ to
                 if not install_plugin(self.site, 'wordpress_compiler', output_dir=os.path.join(self.output_folder, 'plugins')):
                     return False
             else:
-                LOGGER.warn("Make sure to install the WordPress page compiler via")
-                LOGGER.warn("    nikola plugin -i wordpress_compiler")
-                LOGGER.warn("in your imported blog's folder ({0}), if you haven't installed it system-wide or user-wide. Otherwise, your newly imported blog won't compile.".format(self.output_folder))
+                LOGGER.warning("Make sure to install the WordPress page compiler via")
+                LOGGER.warning("    nikola plugin -i wordpress_compiler")
+                LOGGER.warning("in your imported blog's folder ({0}), if you haven't installed it system-wide or user-wide. Otherwise, your newly imported blog won't compile.".format(self.output_folder))
 
     @classmethod
     def read_xml_file(cls, filename):
@@ -514,12 +514,12 @@ to
         try:
             request = requests.get(url, auth=self.auth)
             if request.status_code >= 400:
-                LOGGER.warn("Downloading {0} to {1} failed with HTTP status code {2}".format(url, dst_path, request.status_code))
+                LOGGER.warning("Downloading {0} to {1} failed with HTTP status code {2}".format(url, dst_path, request.status_code))
                 return
             with open(dst_path, 'wb+') as fd:
                 fd.write(request.content)
         except requests.exceptions.ConnectionError as err:
-            LOGGER.warn("Downloading {0} to {1} failed: {2}".format(url, dst_path, err))
+            LOGGER.warning("Downloading {0} to {1} failed: {2}".format(url, dst_path, err))
 
     def import_attachment(self, item, wordpress_namespace):
         """Import an attachment to the site."""
@@ -782,7 +782,7 @@ to
         elif approved == 'spam' or approved == 'trash':
             pass
         else:
-            LOGGER.warn("Unknown comment approved status: {0}".format(approved))
+            LOGGER.warning("Unknown comment approved status: {0}".format(approved))
         parent = int(get_text_tag(comment, "{{{0}}}comment_parent".format(wordpress_namespace), 0))
         if parent == 0:
             parent = None
@@ -846,7 +846,7 @@ to
             if len(cats) > 0:
                 other_meta['category'] = cats[0]
                 if len(cats) > 1:
-                    LOGGER.warn(('Post "{0}" has more than one category! ' +
+                    LOGGER.warning(('Post "{0}" has more than one category! ' +
                                  'Will only use the first one.').format(post_name))
             tags_cats = [utils.html_unescape(tag) for tag in tags]
         else:
@@ -864,7 +864,7 @@ to
         previous = self._tag_sanitize_map[is_category][tag.lower()]
         if self.tag_saniziting_strategy == 'first':
             if tag != previous[0]:
-                LOGGER.warn("Changing spelling of {0} name '{1}' to {2}.".format('category' if is_category else 'tag', tag, previous[0]))
+                LOGGER.warning("Changing spelling of {0} name '{1}' to {2}.".format('category' if is_category else 'tag', tag, previous[0]))
             return previous[0]
         else:
             LOGGER.error("Unknown tag sanitizing strategy '{0}'!".format(self.tag_saniziting_strategy))
@@ -945,7 +945,7 @@ to
         post_status = 'published'
         has_math = "no"
         if status == 'trash':
-            LOGGER.warn('Trashed post "{0}" will not be imported.'.format(title))
+            LOGGER.warning('Trashed post "{0}" will not be imported.'.format(title))
             return False
         elif status == 'private':
             is_draft = False
@@ -1076,7 +1076,7 @@ to
 
             return (out_folder, slug)
         else:
-            LOGGER.warn(('Not going to import "{0}" because it seems to contain'
+            LOGGER.warning(('Not going to import "{0}" because it seems to contain'
                          ' no content.').format(title))
             return False
 
@@ -1103,7 +1103,7 @@ to
             if parent_id is not None and int(parent_id) != 0:
                 self.attachments[int(parent_id)][post_id] = data
             else:
-                LOGGER.warn("Attachment #{0} ({1}) has no parent!".format(post_id, data['files']))
+                LOGGER.warning("Attachment #{0} ({1}) has no parent!".format(post_id, data['files']))
 
     def write_attachments_info(self, path, attachments):
         """Write attachments info file."""
@@ -1141,7 +1141,7 @@ to
             self.process_item_if_post_or_page(item)
         # Assign attachments to posts
         for post_id in self.attachments:
-            LOGGER.warn(("Found attachments for post or page #{0}, but didn't find post or page. " +
+            LOGGER.warning(("Found attachments for post or page #{0}, but didn't find post or page. " +
                          "(Attachments: {1})").format(post_id, [e['files'][0] for e in self.attachments[post_id].values()]))
 
 

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -266,8 +266,8 @@ to
 
         if args:
             LOGGER.warning('You specified additional arguments ({0}). Please consider '
-                        'putting these arguments before the filename if you '
-                        'are running into problems.'.format(args))
+                           'putting these arguments before the filename if you '
+                           'are running into problems.'.format(args))
 
         self.onefile = options.get('one_file', False)
 
@@ -847,7 +847,7 @@ to
                 other_meta['category'] = cats[0]
                 if len(cats) > 1:
                     LOGGER.warning(('Post "{0}" has more than one category! ' +
-                                 'Will only use the first one.').format(post_name))
+                                    'Will only use the first one.').format(post_name))
             tags_cats = [utils.html_unescape(tag) for tag in tags]
         else:
             tags_cats = [utils.html_unescape(tag) for tag in tags + categories]
@@ -1077,7 +1077,7 @@ to
             return (out_folder, slug)
         else:
             LOGGER.warning(('Not going to import "{0}" because it seems to contain'
-                         ' no content.').format(title))
+                            ' no content.').format(title))
             return False
 
     def _extract_item_info(self, item):
@@ -1142,7 +1142,7 @@ to
         # Assign attachments to posts
         for post_id in self.attachments:
             LOGGER.warning(("Found attachments for post or page #{0}, but didn't find post or page. " +
-                         "(Attachments: {1})").format(post_id, [e['files'][0] for e in self.attachments[post_id].values()]))
+                            "(Attachments: {1})").format(post_id, [e['files'][0] for e in self.attachments[post_id].values()]))
 
 
 def get_text_tag(tag, name, default):

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -377,7 +377,7 @@ class CommandNewPost(Command):
             meta_path = os.path.join(output_path, slug + ".meta")
         else:
             if date_path_opt:
-                LOGGER.warn("A path has been specified, ignoring -d")
+                LOGGER.warning("A path has been specified, ignoring -d")
             txt_path = os.path.join(self.site.original_cwd, path)
             meta_path = os.path.splitext(txt_path)[0] + ".meta"
 
@@ -412,7 +412,7 @@ class CommandNewPost(Command):
         # Override onefile if not really supported.
         if not compiler_plugin.supports_onefile and onefile:
             onefile = False
-            LOGGER.warn('This compiler does not support one-file posts.')
+            LOGGER.warning('This compiler does not support one-file posts.')
 
         if onefile and import_file:
             with io.open(import_file, 'r', encoding='utf-8') as fh:

--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -266,8 +266,8 @@ class CommandPlugin(Command):
         reqnpypath = os.path.join(dest_path, 'requirements-nonpy.txt')
         if os.path.exists(reqnpypath):
             LOGGER.warning('This plugin has third-party '
-                          'dependencies you need to install '
-                          'manually.')
+                           'dependencies you need to install '
+                           'manually.')
             print('Contents of the requirements-nonpy.txt file:\n')
             with io.open(reqnpypath, 'r', encoding='utf-8') as fh:
                 for l in fh.readlines():

--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -137,7 +137,7 @@ class CommandPlugin(Command):
             self.output_dir = options.get('output_dir')
         else:
             if not self.site.configured and not user_mode and install:
-                LOGGER.notice('No site found, assuming --user')
+                LOGGER.warning('No site found, assuming --user')
                 user_mode = True
 
             if user_mode:
@@ -249,7 +249,7 @@ class CommandPlugin(Command):
 
         reqpath = os.path.join(dest_path, 'requirements.txt')
         if os.path.exists(reqpath):
-            LOGGER.notice('This plugin has Python dependencies.')
+            LOGGER.warning('This plugin has Python dependencies.')
             LOGGER.info('Installing dependencies with pip...')
             try:
                 subprocess.check_call((sys.executable, '-m', 'pip', 'install', '-r', reqpath))
@@ -265,7 +265,7 @@ class CommandPlugin(Command):
 
         reqnpypath = os.path.join(dest_path, 'requirements-nonpy.txt')
         if os.path.exists(reqnpypath):
-            LOGGER.notice('This plugin has third-party '
+            LOGGER.warning('This plugin has third-party '
                           'dependencies you need to install '
                           'manually.')
             print('Contents of the requirements-nonpy.txt file:\n')
@@ -281,7 +281,7 @@ class CommandPlugin(Command):
 
         req_plug_path = os.path.join(dest_path, 'requirements-plugins.txt')
         if os.path.exists(req_plug_path):
-            LOGGER.notice('This plugin requires other Nikola plugins.')
+            LOGGER.info('This plugin requires other Nikola plugins.')
             LOGGER.info('Installing plugins...')
             plugin_failure = False
             try:
@@ -301,7 +301,7 @@ class CommandPlugin(Command):
 
         confpypath = os.path.join(dest_path, 'conf.py.sample')
         if os.path.exists(confpypath) and show_install_notes:
-            LOGGER.notice('This plugin has a sample config file.  Integrate it with yours in order to make this plugin work!')
+            LOGGER.warning('This plugin has a sample config file.  Integrate it with yours in order to make this plugin work!')
             print('Contents of the conf.py.sample file:\n')
             with io.open(confpypath, 'r', encoding='utf-8') as fh:
                 if self.site.colorful:

--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -305,11 +305,9 @@ class CommandPlugin(Command):
             print('Contents of the conf.py.sample file:\n')
             with io.open(confpypath, 'r', encoding='utf-8') as fh:
                 if self.site.colorful:
-                    print(utils.indent(pygments.highlight(
-                        fh.read(), PythonLexer(), TerminalFormatter()),
-                        4 * ' '))
+                    print(pygments.highlight(fh.read(), PythonLexer(), TerminalFormatter()))
                 else:
-                    print(utils.indent(fh.read(), 4 * ' '))
+                    print(fh.read())
         return 0
 
     def do_uninstall(self, name):

--- a/nikola/plugins/command/subtheme.py
+++ b/nikola/plugins/command/subtheme.py
@@ -146,5 +146,5 @@ class CommandSubTheme(Command):
             cp['Family'] = {'family': cp['Family']['family']}
             cp.write(output)
 
-        LOGGER.notice(
+        LOGGER.info(
             'Theme created.  Change the THEME setting to "{0}" to use it.'.format(name))

--- a/nikola/plugins/command/subtheme.py
+++ b/nikola/plugins/command/subtheme.py
@@ -95,10 +95,10 @@ class CommandSubTheme(Command):
         elif _check_for_theme('bootstrap4', themes) or _check_for_theme('bootstrap4-jinja', themes):
             version = '4'
         elif not _check_for_theme('bootstrap4', themes) and not _check_for_theme('bootstrap4-jinja', themes):
-            LOGGER.warn(
+            LOGGER.warning(
                 '"subtheme" only makes sense for themes that use bootstrap')
         elif _check_for_theme('bootstrap3-gradients', themes) or _check_for_theme('bootstrap3-gradients-jinja', themes):
-            LOGGER.warn(
+            LOGGER.warning(
                 '"subtheme" doesn\'t work well with the bootstrap3-gradients family')
 
         LOGGER.info("Creating '{0}' theme from '{1}' and '{2}'".format(

--- a/nikola/plugins/command/theme.py
+++ b/nikola/plugins/command/theme.py
@@ -239,11 +239,9 @@ class CommandTheme(Command):
             print('Contents of the conf.py.sample file:\n')
             with io.open(confpypath, 'r', encoding='utf-8') as fh:
                 if self.site.colorful:
-                    print(utils.indent(pygments.highlight(
-                        fh.read(), PythonLexer(), TerminalFormatter()),
-                        4 * ' '))
+                    print(pygments.highlight(fh.read(), PythonLexer(), TerminalFormatter()))
                 else:
-                    print(utils.indent(fh.read(), 4 * ' '))
+                    print(fh.read())
         return True
 
     def do_uninstall(self, name):

--- a/nikola/plugins/command/theme.py
+++ b/nikola/plugins/command/theme.py
@@ -202,7 +202,7 @@ class CommandTheme(Command):
                 self.do_install(parent_name, data)
                 name = parent_name
         if installstatus:
-            LOGGER.notice('Remember to set THEME="{0}" in conf.py to use this theme.'.format(origname))
+            LOGGER.info('Remember to set THEME="{0}" in conf.py to use this theme.'.format(origname))
 
     def do_install(self, name, data):
         """Download and install a theme."""
@@ -235,7 +235,7 @@ class CommandTheme(Command):
 
         confpypath = os.path.join(dest_path, 'conf.py.sample')
         if os.path.exists(confpypath):
-            LOGGER.notice('This theme has a sample config file.  Integrate it with yours in order to make this theme work!')
+            LOGGER.warning('This theme has a sample config file.  Integrate it with yours in order to make this theme work!')
             print('Contents of the conf.py.sample file:\n')
             with io.open(confpypath, 'r', encoding='utf-8') as fh:
                 if self.site.colorful:
@@ -370,7 +370,7 @@ class CommandTheme(Command):
                 LOGGER.info("Created file {0}".format(os.path.join(themedir, 'engine')))
 
         LOGGER.info("Theme {0} created successfully.".format(themedir))
-        LOGGER.notice('Remember to set THEME="{0}" in conf.py to use this theme.'.format(name))
+        LOGGER.info('Remember to set THEME="{0}" in conf.py to use this theme.'.format(name))
 
     def get_json(self, url):
         """Download the JSON file with all plugins."""

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -135,7 +135,7 @@ class CompileIPynb(PageCompiler):
 
             if kernel is None:
                 kernel = self.default_kernel
-                self.logger.notice('No kernel specified, assuming "{0}".'.format(kernel))
+                self.logger.warning('No kernel specified, assuming "{0}".'.format(kernel))
 
             IPYNB_KERNELS = {}
             ksm = kernelspec.KernelSpecManager()

--- a/nikola/plugins/compile/markdown/mdx_gist.py
+++ b/nikola/plugins/compile/markdown/mdx_gist.py
@@ -166,7 +166,7 @@ class GistPattern(Pattern):
             pre_elem.text = AtomicString(raw_gist)
 
         except GistFetchException as e:
-            LOGGER.warn(e.message)
+            LOGGER.warning(e.message)
             warning_comment = etree.Comment(' WARNING: {0} '.format(e.message))
             noscript_elem.append(warning_comment)
 

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -26,8 +26,8 @@
 
 """reStructuredText compiler for Nikola."""
 
-import logging
 import io
+import logging
 import os
 
 import docutils.core

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -26,6 +26,7 @@
 
 """reStructuredText compiler for Nikola."""
 
+import logging
 import io
 import os
 
@@ -38,9 +39,6 @@ import docutils.readers.standalone
 import docutils.writers.html5_polyglot
 import docutils.parsers.rst.directives
 from docutils.parsers.rst import roles
-
-import logbook
-import logbook.base
 
 from nikola.nikola import LEGAL_VALUES
 from nikola.metadata_extractors import MetaCondition
@@ -72,8 +70,8 @@ class CompileRest(PageCompiler):
 
         # Silence reST errors, some of which are due to a different
         # environment. Real issues will be reported while compiling.
-        null_logger = logbook.Logger('NULL')
-        null_logger.handlers = [logbook.NullHandler()]
+        null_logger = logging.getLogger('NULL')
+        null_logger.setLevel(1000)
         with io.open(source_path, 'r', encoding='utf-8') as inf:
             data = inf.read()
             _, _, _, document = rst2html(data, logger=null_logger, source_path=source_path, transforms=self.site.rst_transforms)
@@ -192,7 +190,7 @@ class CompileRest(PageCompiler):
             plugin_info.plugin_object.short_help = plugin_info.description
 
         if not site.debug:
-            self.logger.level = logbook.base.WARNING
+            self.logger.level = logging.WARNING
 
 
 def get_observer(settings):
@@ -203,7 +201,7 @@ def get_observer(settings):
         Error code mapping:
 
         +----------+----------+
-        | docutils |  logbook |
+        | docutils |  logging |
         +----------+----------+
         |    DEBUG |    DEBUG |
         |     INFO |     INFO |
@@ -213,11 +211,11 @@ def get_observer(settings):
         +----------+----------+
         """
         errormap = {
-            docutils.utils.Reporter.DEBUG_LEVEL: logbook.base.DEBUG,
-            docutils.utils.Reporter.INFO_LEVEL: logbook.base.INFO,
-            docutils.utils.Reporter.WARNING_LEVEL: logbook.base.WARNING,
-            docutils.utils.Reporter.ERROR_LEVEL: logbook.base.ERROR,
-            docutils.utils.Reporter.SEVERE_LEVEL: logbook.base.CRITICAL
+            docutils.utils.Reporter.DEBUG_LEVEL: logging.DEBUG,
+            docutils.utils.Reporter.INFO_LEVEL: logging.INFO,
+            docutils.utils.Reporter.WARNING_LEVEL: logging.WARNING,
+            docutils.utils.Reporter.ERROR_LEVEL: logging.ERROR,
+            docutils.utils.Reporter.SEVERE_LEVEL: logging.CRITICAL
         }
         text = docutils.nodes.Element.astext(msg)
         line = msg['line'] + settings['add_ln'] if 'line' in msg else ''

--- a/nikola/plugins/compile/rest/doc.py
+++ b/nikola/plugins/compile/rest/doc.py
@@ -90,7 +90,7 @@ def doc_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
         if twin_slugs:
             inliner.reporter.warning(
                 'More than one post with the same slug. Using "{0}"'.format(permalink))
-            LOGGER.warn(
+            LOGGER.warning(
                 'More than one post with the same slug. Using "{0}" for doc role'.format(permalink))
         node = make_link_node(rawtext, title, permalink, options)
         return [node], []
@@ -108,7 +108,7 @@ def doc_shortcode(*args, **kwargs):
     success, twin_slugs, title, permalink, slug = _doc_link(text, text, LOGGER)
     if success:
         if twin_slugs:
-            LOGGER.warn(
+            LOGGER.warning(
                 'More than one post with the same slug. Using "{0}" for doc shortcode'.format(permalink))
         return '<a href="{0}">{1}</a>'.format(permalink, title)
     else:

--- a/nikola/plugins/task/listings.py
+++ b/nikola/plugins/task/listings.py
@@ -301,7 +301,7 @@ class Listings(Task):
                     utils.LOGGER.error("Using non-unique listing name '{0}', which maps to more than one listing name ({1})!".format(name, str(self.improper_input_file_mapping[name])))
                     return ["ERROR"]
                 if len(self.site.config['LISTINGS_FOLDERS']) > 1:
-                    utils.LOGGER.notice("Using listings names in site.link() without input directory prefix while configuration's LISTINGS_FOLDERS has more than one entry.")
+                    utils.LOGGER.warning("Using listings names in site.link() without input directory prefix while configuration's LISTINGS_FOLDERS has more than one entry.")
                 name = list(self.improper_input_file_mapping[name])[0]
                 break
         else:

--- a/nikola/plugins/task/robots.py
+++ b/nikola/plugins/task/robots.py
@@ -55,7 +55,7 @@ class RobotsFile(LateTask):
 
         def write_robots():
             if kw["site_url"] != urljoin(kw["site_url"], "/"):
-                utils.LOGGER.warn('robots.txt not ending up in server root, will be useless')
+                utils.LOGGER.warning('robots.txt not ending up in server root, will be useless')
                 utils.LOGGER.info('Add "robots" to DISABLED_PLUGINS to disable this warning and robots.txt generation.')
 
             with io.open(robots_path, 'w+', encoding='utf8') as outf:
@@ -79,6 +79,6 @@ class RobotsFile(LateTask):
                 "task_dep": ["sitemap"]
             }, kw["filters"])
         elif kw["robots_exclusions"]:
-            utils.LOGGER.warn('Did not generate robots.txt as one already exists in FILES_FOLDERS. ROBOTS_EXCLUSIONS will not have any affect on the copied file.')
+            utils.LOGGER.warning('Did not generate robots.txt as one already exists in FILES_FOLDERS. ROBOTS_EXCLUSIONS will not have any affect on the copied file.')
         else:
             utils.LOGGER.debug('Did not generate robots.txt as one already exists in FILES_FOLDERS.')

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -281,7 +281,7 @@ class Post(object):
                     self.is_draft = True
                 else:
                     LOGGER.warning(('The post "{0}" has the unknown status "{1}". '
-                                 'Valid values are "published", "featured", "private" and "draft".').format(self.source_path, status))
+                                    'Valid values are "published", "featured", "private" and "draft".').format(self.source_path, status))
 
             if self.config['WARN_ABOUT_TAG_METADATA']:
                 show_warning = False
@@ -296,10 +296,10 @@ class Post(object):
                     show_warning = True
                 if show_warning:
                     LOGGER.warning('It is suggested that you convert special tags to metadata and set '
-                                'USE_TAG_METADATA to False. You can use the upgrade_metadata_v8 '
-                                'command plugin for conversion (install with: nikola plugin -i '
-                                'upgrade_metadata_v8). Change the WARN_ABOUT_TAG_METADATA '
-                                'configuration to disable this warning.')
+                                   'USE_TAG_METADATA to False. You can use the upgrade_metadata_v8 '
+                                   'command plugin for conversion (install with: nikola plugin -i '
+                                   'upgrade_metadata_v8). Change the WARN_ABOUT_TAG_METADATA '
+                                   'configuration to disable this warning.')
             if self.config['USE_TAG_METADATA']:
                 if 'draft' in [_.lower() for _ in self._tags[lang]]:
                     self.is_draft = True

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -234,7 +234,7 @@ class Post(object):
                     LOGGER.warn("Post {0} has both 'category' and 'section' metadata. Section will be ignored.".format(source_path))
                 else:
                     meta['category'] = meta['section']
-                    LOGGER.notice("Post {0} uses 'section' metadata, setting its value to 'category'".format(source_path))
+                    LOGGER.info("Post {0} uses 'section' metadata, setting its value to 'category'".format(source_path))
 
             # Handle CATEGORY_DESTPATH_AS_DEFAULT
             if 'category' not in meta and self.config['CATEGORY_DESTPATH_AS_DEFAULT']:
@@ -649,7 +649,7 @@ class Post(object):
         })
 
         if self.publish_later:
-            LOGGER.notice('{0} is scheduled to be published in the future ({1})'.format(
+            LOGGER.info('{0} is scheduled to be published in the future ({1})'.format(
                 self.source_path, self.date))
 
     def fragment_deps(self, lang):

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -231,7 +231,7 @@ class Post(object):
             # TODO: remove in v9
             if 'section' in meta:
                 if 'category' in meta:
-                    LOGGER.warn("Post {0} has both 'category' and 'section' metadata. Section will be ignored.".format(source_path))
+                    LOGGER.warning("Post {0} has both 'category' and 'section' metadata. Section will be ignored.".format(source_path))
                 else:
                     meta['category'] = meta['section']
                     LOGGER.info("Post {0} uses 'section' metadata, setting its value to 'category'".format(source_path))
@@ -280,22 +280,22 @@ class Post(object):
                     self.post_status = status
                     self.is_draft = True
                 else:
-                    LOGGER.warn(('The post "{0}" has the unknown status "{1}". '
+                    LOGGER.warning(('The post "{0}" has the unknown status "{1}". '
                                  'Valid values are "published", "featured", "private" and "draft".').format(self.source_path, status))
 
             if self.config['WARN_ABOUT_TAG_METADATA']:
                 show_warning = False
                 if 'draft' in [_.lower() for _ in self._tags[lang]]:
-                    LOGGER.warn('The post "{0}" uses the "draft" tag.'.format(self.source_path))
+                    LOGGER.warning('The post "{0}" uses the "draft" tag.'.format(self.source_path))
                     show_warning = True
                 if 'private' in self._tags[lang]:
-                    LOGGER.warn('The post "{0}" uses the "private" tag.'.format(self.source_path))
+                    LOGGER.warning('The post "{0}" uses the "private" tag.'.format(self.source_path))
                     show_warning = True
                 if 'mathjax' in self._tags[lang]:
-                    LOGGER.warn('The post "{0}" uses the "mathjax" tag.'.format(self.source_path))
+                    LOGGER.warning('The post "{0}" uses the "mathjax" tag.'.format(self.source_path))
                     show_warning = True
                 if show_warning:
-                    LOGGER.warn('It is suggested that you convert special tags to metadata and set '
+                    LOGGER.warning('It is suggested that you convert special tags to metadata and set '
                                 'USE_TAG_METADATA to False. You can use the upgrade_metadata_v8 '
                                 'command plugin for conversion (install with: nikola plugin -i '
                                 'upgrade_metadata_v8). Change the WARN_ABOUT_TAG_METADATA '

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -30,7 +30,6 @@ import configparser
 import datetime
 import hashlib
 import io
-import logging
 import operator
 import os
 import re
@@ -41,7 +40,6 @@ import subprocess
 import sys
 import threading
 import typing
-import warnings
 from collections import defaultdict, OrderedDict
 from collections.abc import Callable, Iterable
 from html import unescape as html_unescape
@@ -55,19 +53,17 @@ from zipfile import ZipFile as zipf
 import babel.dates
 import dateutil.parser
 import dateutil.tz
-import logbook
 import PyRSS2Gen as rss
 from blinker import signal
 from doit import tools
 from doit.cmdparse import CmdParse
-from logbook.compat import redirect_logging
-from logbook.more import ExceptionHandler, ColorizedStderrHandler
 from pkg_resources import resource_filename
 from pygments.formatters import HtmlFormatter
 from unidecode import unidecode
 
-from nikola import DEBUG
-from .log import LOGGER, get_logger
+# Renames
+from nikola import DEBUG  # NOQA
+from .log import LOGGER, get_logger  # NOQA
 from .hierarchy_utils import TreeNode, clone_treenode, flatten_tree_structure, sort_classifications
 from .hierarchy_utils import join_hierarchical_category_path, parse_escaped_hierarchical_category_name
 

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -150,7 +150,7 @@ def req_missing(names, purpose, python=True, optional=False):
             purpose, pnames, whatarethey_p)
 
     if optional:
-        LOGGER.warn(msg)
+        LOGGER.warning(msg)
     else:
         LOGGER.error(msg)
         LOGGER.error('Exiting due to missing dependencies.')
@@ -710,7 +710,7 @@ def load_messages(themes, translations, default_lang, themes_dirs):
         raise LanguageNotFoundError(lang, last_exception)
     for lang, status in completion_status.items():
         if not status and lang not in INCOMPLETE_LANGUAGES_WARNED:
-            LOGGER.warn("Incomplete translation for language '{0}'.".format(lang))
+            LOGGER.warning("Incomplete translation for language '{0}'.".format(lang))
             INCOMPLETE_LANGUAGES_WARNED.add(lang)
 
     return messages
@@ -1457,9 +1457,9 @@ def write_metadata(data, metadata_format=None, comment_wrap=False, site=None, co
         extractor.check_requirements()
         return extractor.write_metadata(data, comment_wrap)
     elif extractor and metadata_format not in default_meta:
-        LOGGER.warn('Writing METADATA_FORMAT {} is not supported, using "nikola" format'.format(metadata_format))
+        LOGGER.warning('Writing METADATA_FORMAT {} is not supported, using "nikola" format'.format(metadata_format))
     elif metadata_format not in default_meta:
-        LOGGER.warn('Unknown METADATA_FORMAT {}, using "nikola" format'.format(metadata_format))
+        LOGGER.warning('Unknown METADATA_FORMAT {}, using "nikola" format'.format(metadata_format))
 
     if metadata_format == 'rest_docinfo':
         title = data['title']

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -109,6 +109,10 @@ bytes_str = bytes
 unicode_str = str
 unichr = chr
 
+# For compatibility with old logging setups.
+# TODO remove in v9?
+STDERR_HANDLER = None
+
 
 USE_SLUGIFY = True
 

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -67,6 +67,7 @@ from pygments.formatters import HtmlFormatter
 from unidecode import unidecode
 
 from nikola import DEBUG
+from .log import LOGGER, get_logger
 from .hierarchy_utils import TreeNode, clone_treenode, flatten_tree_structure, sort_classifications
 from .hierarchy_utils import join_hierarchical_category_path, parse_escaped_hierarchical_category_name
 
@@ -113,56 +114,7 @@ unicode_str = str
 unichr = chr
 
 
-class ApplicationWarning(Exception):
-    pass
-
-
-class ColorfulStderrHandler(ColorizedStderrHandler):
-    """Stream handler with colors."""
-
-    _colorful = False
-
-    def should_colorize(self, record):
-        """Inform about colorization using the value obtained from Nikola."""
-        return self._colorful
-
-
-def get_logger(name, handlers=None):
-    """Get a logger with handlers attached."""
-    l = logbook.Logger(name)
-    l.handlers += STDERR_HANDLER
-    return l
-
-
-STDERR_HANDLER = [ColorfulStderrHandler(
-    level=logbook.INFO if not DEBUG else logbook.DEBUG,
-    format_string=u'[{record.time:%Y-%m-%dT%H:%M:%SZ}] {record.level_name}: {record.channel}: {record.message}'
-)]
-
-
-LOGGER = get_logger('Nikola')
-STRICT_HANDLER = ExceptionHandler(ApplicationWarning, level='WARNING')
-
 USE_SLUGIFY = True
-
-redirect_logging()
-
-if DEBUG:
-    logging.basicConfig(level=logging.DEBUG)
-else:
-    logging.basicConfig(level=logging.INFO)
-
-
-def showwarning(message, category, filename, lineno, file=None, line=None):
-    """Show a warning (from the warnings module) to the user."""
-    try:
-        n = category.__name__
-    except AttributeError:
-        n = str(category)
-    get_logger(n).warn('{0}:{1}: {2}'.format(filename, lineno, message))
-
-
-warnings.showwarning = showwarning
 
 
 def req_missing(names, purpose, python=True, optional=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ unidecode>=0.04.16
 lxml>=3.3.5
 Yapsy>=1.11.223
 PyRSS2Gen>=1.1
-logbook>=1.3.0
 blinker>=1.3
 setuptools>=24.2.0
 natsort>=3.5.2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -40,7 +40,6 @@ parts:
             - lxml>=3.3.5
             - Yapsy>=1.11.223
             - PyRSS2Gen>=1.1
-            - logbook>=0.7.0
             - blinker>=1.3
             - setuptools>=5.4.1
             - natsort>=3.5.2

--- a/tests/base.py
+++ b/tests/base.py
@@ -135,7 +135,7 @@ class FakeSite(object):
     def register_shortcode(self, name, f):
         """Register function f to handle shortcode "name"."""
         if name in self.shortcode_registry:
-            nikola.utils.LOGGER.warn('Shortcode name conflict: %s', name)
+            nikola.utils.LOGGER.warning('Shortcode name conflict: %s', name)
             return
         self.shortcode_registry[name] = f
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -14,8 +14,6 @@ import os
 from contextlib import contextmanager
 import unittest
 
-import logbook
-
 import nikola.utils
 import nikola.shortcodes
 
@@ -31,7 +29,6 @@ from nikola.plugin_categories import (
     MarkdownExtension,
     RestExtension
 )
-nikola.utils.LOGGER.handlers.append(logbook.TestHandler())
 
 BaseTestCase = unittest.TestCase
 


### PR DESCRIPTION
Inspired by #3333, get rid of the `logbook` dependency. We don’t use any of its advanced features and with 70 SLOC, we can get rid of it.

Code that imports `logbook` might or might not work. Any such code has been eliminated from Nikola core, and from plugins (`drop-logbook` branch in `nikola-plugins`, PR getnikola/plugins#319).  Calling `logger.notice` will still work for the foreseeable future (it’s patched into our loggers).