### PR TITLE
Pass correct parameters to shortcodes in jupyter notebooks

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -65,6 +65,7 @@
 * `Luis Miguel Morillas <https://github.com/lmorillas>`_
 * `Manuel Kaufmann <https://github.com/humitos>`_
 * `Manuel Thalmann <https://github.com/manuth>`_
+* `Marcel Stimberg <https://github.com/mstimberg>`_
 * `Marcelo MD <https://github.com/marcelomd>`_
 * `Marcos Dione <https://github.com/StyXman>`_
 * `Mariano Guerra <https://github.com/marianoguerra>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Features
 Bugfixes
 --------
 
+* Pass the correct parameters to shortcodes in jupyter notebooks
 * Fix handling of conflicts between posts/pages and indexes generated
   by ``CATEGORY_PAGES_FOLLOW_DESTPATH``
 * Fix default date format to ``yyyy-MM-dd`` to avoid bug with ISO

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -85,7 +85,9 @@ class CompileIPynb(PageCompiler):
         with io.open(dest, "w+", encoding="utf8") as out_file:
             with io.open(source, "r", encoding="utf8") as in_file:
                 nb_str = in_file.read()
-            output, shortcode_deps = self.compile_string(nb_str, is_two_file, post, lang)
+            output, shortcode_deps = self.compile_string(nb_str, source,
+                                                         is_two_file, post,
+                                                         lang)
             out_file.write(output)
         if post is None:
             if shortcode_deps:


### PR DESCRIPTION
The wrong call passed a boolean as the filename and the language name instead of the `post` object.

I took the liberty to add my name to the authors list – the change is trivial, but it took me a while to figure out why I was getting these weird values in the shortcodes :)

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

