### PR TITLE
Fix getnikola#3344: Load filename metadata first, and then the rest.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,8 @@ Bugfixes
 * Show tracebacks when ``conf.py`` cannot be imported
 * Fix loading complex config files that import modules (Issue #3314)
 * Fix behavior of header demotion for negative values
+* If ``FILE_METADATA_REGEXP`` is set, load metadata from the filename
+  first, then continue with the other sources (Issue #3344)
 
 Other compatibility information
 -------------------------------


### PR DESCRIPTION
We load metadata from the filename first, if `FILE_METADATA_REGEXP` is
set and then metadata from other sources overrides these by updating the
dictionary.

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Details and issue discussion at #3344.