### PR TITLE
Fix #3349 — fix multi-level Mako inherit/import nesting

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ Features
 Bugfixes
 --------
 
+* Handle multiple level of inherit/import nesting in Mako templates
+  correctly (Issue #3349)
 * Output a more informative error when files are missing due to
   broken symlinks or incorrect ``TRANSLATIONS_PATTERN`` values
 * Avoid installing ``tests`` package to site-packages, remove it from

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -131,9 +131,10 @@ class MakoTemplates(TemplateSystem):
             dep_filenames = self.get_deps(template.filename)
             deps = [template.filename]
             for fname in dep_filenames:
-                deps += [fname] + self.get_deps(fname)
-            self.cache[template_name] = deps
-        return list(self.cache[template_name])
+                # yes, it uses forward slashes on Windows
+                deps += self.template_deps(fname.split('/')[-1])
+            self.cache[template_name] = list(set(deps))
+        return self.cache[template_name]
 
     def get_template_path(self, template_name):
         """Get the path to a template or return None."""


### PR DESCRIPTION
This fixes #3349. Turns out we’ve had a ton of missing dependencies with Mako. Tested on Windows and Linux.
