### PR TITLE
Fix #3342 — improve command help appearance

### DIFF
--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -30,12 +30,14 @@ import importlib.util
 import os
 import shutil
 import sys
+import textwrap
 import traceback
+import doit.cmd_base
 from collections import defaultdict
 
 from blinker import signal
+from doit.cmd_base import TaskLoader, _wrap
 from doit.cmd_auto import Auto as DoitAuto
-from doit.cmd_base import TaskLoader
 from doit.cmd_clean import Clean as DoitClean
 from doit.cmd_completion import TabCompletion
 from doit.cmd_help import Help as DoitHelp
@@ -378,6 +380,53 @@ class DoitNikola(DoitMain):
     def print_version():
         """Print Nikola version."""
         print("Nikola v" + __version__)
+
+
+# Override Command.help() to make it more readable and to remove
+# some doit-specific stuff. Based on doit's implementation.
+# (see Issue #3342)
+def _command_help(self: Command):
+    """Return help text for a command."""
+    text = []
+
+    usage = "{} {} {}".format(self.bin_name, self.name, self.doc_usage)
+    text.extend(textwrap.wrap(usage, subsequent_indent='  '))
+    text.extend(_wrap(self.doc_purpose, 4))
+
+    text.append("\nOptions:")
+    options = defaultdict(list)
+    for opt in self.cmdparser.options:
+        options[opt.section].append(opt)
+    for section, opts in sorted(options.items()):
+        if section:
+            section_name = '\n{}'.format(section)
+            text.extend(_wrap(section_name, 2))
+        for opt in opts:
+            # ignore option that cant be modified on cmd line
+            if not (opt.short or opt.long):
+                continue
+            text.extend(_wrap(opt.help_param(), 4))
+            opt_help = opt.help
+            if '%(default)s' in opt_help:
+                opt_help = opt.help % {'default': opt.default}
+            elif opt.default != '' and opt.default is not False and opt.default is not None:
+                opt_help += ' [default: {}]'.format(opt.default)
+            opt_choices = opt.help_choices()
+            desc = '{} {}'.format(opt_help, opt_choices)
+            text.extend(_wrap(desc, 8))
+
+            # print bool inverse option
+            if opt.inverse:
+                text.extend(_wrap('--{}'.format(opt.inverse), 4))
+                text.extend(_wrap('opposite of --{}'.format(opt.long), 8))
+
+    if self.doc_description is not None:
+        text.append("\n\nDescription:")
+        text.extend(_wrap(self.doc_description, 4))
+    return "\n".join(text)
+
+
+doit.cmd_base.Command.help = _command_help
 
 
 def levenshtein(s1, s2):

--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -36,8 +36,8 @@ import doit.cmd_base
 from collections import defaultdict
 
 from blinker import signal
-from doit.cmd_base import TaskLoader, _wrap
 from doit.cmd_auto import Auto as DoitAuto
+from doit.cmd_base import TaskLoader, _wrap
 from doit.cmd_clean import Clean as DoitClean
 from doit.cmd_completion import TabCompletion
 from doit.cmd_help import Help as DoitHelp

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -79,7 +79,7 @@ class CommandAuto(Command):
             'long': 'port',
             'default': 8000,
             'type': int,
-            'help': 'Port number (default: 8000)',
+            'help': 'Port number)',
         },
         {
             'name': 'address',
@@ -87,7 +87,7 @@ class CommandAuto(Command):
             'long': 'address',
             'type': str,
             'default': '127.0.0.1',
-            'help': 'Address to bind (default: 127.0.0.1 -- localhost)',
+            'help': 'Address to bind',
         },
         {
             'name': 'browser',

--- a/nikola/plugins/command/github_deploy.py
+++ b/nikola/plugins/command/github_deploy.py
@@ -73,7 +73,7 @@ class CommandGitHubDeploy(Command):
             'long': 'message',
             'default': 'Nikola auto commit.',
             'type': str,
-            'help': 'Commit message (default: Nikola auto commit.)',
+            'help': 'Commit message',
         },
     ]
 

--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -84,8 +84,7 @@ class CommandPlugin(Command):
             'short': 'u',
             'long': 'url',
             'type': str,
-            'help': "URL for the plugin repository (default: "
-                    "https://plugins.getnikola.com/v8/plugins.json)",
+            'help': "URL for the plugin repository",
             'default': 'https://plugins.getnikola.com/v8/plugins.json'
         },
         {

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -61,7 +61,7 @@ class CommandServe(Command):
             'long': 'port',
             'default': 8000,
             'type': int,
-            'help': 'Port number (default: 8000)',
+            'help': 'Port number',
         },
         {
             'name': 'address',
@@ -69,7 +69,7 @@ class CommandServe(Command):
             'long': 'address',
             'type': str,
             'default': '',
-            'help': 'Address to bind (default: 0.0.0.0 -- all local IPv4 interfaces)',
+            'help': 'Address to bind, defaults to all local IPv4 interfaces',
         },
         {
             'name': 'detach',

--- a/nikola/plugins/command/subtheme.py
+++ b/nikola/plugins/command/subtheme.py
@@ -58,7 +58,7 @@ class CommandSubTheme(Command):
             'long': 'name',
             'default': 'custom',
             'type': str,
-            'help': 'New theme name (default: custom)',
+            'help': 'New theme name',
         },
         {
             'name': 'swatch',
@@ -72,7 +72,7 @@ class CommandSubTheme(Command):
             'short': 'p',
             'long': 'parent',
             'default': 'bootstrap4',
-            'help': 'Parent theme name (default: bootstrap4)',
+            'help': 'Parent theme name',
         },
     ]
 

--- a/nikola/plugins/command/theme.py
+++ b/nikola/plugins/command/theme.py
@@ -91,8 +91,7 @@ class CommandTheme(Command):
             'short': 'u',
             'long': 'url',
             'type': str,
-            'help': "URL for the theme repository (default: "
-                    "https://themes.getnikola.com/v8/themes.json)",
+            'help': "URL for the theme repository",
             'default': 'https://themes.getnikola.com/v8/themes.json'
         },
         {
@@ -124,14 +123,14 @@ class CommandTheme(Command):
             'long': 'engine',
             'type': str,
             'default': 'mako',
-            'help': 'Engine to use for new theme (mako or jinja -- default: mako)',
+            'help': 'Engine to use for new theme (mako or jinja)',
         },
         {
             'name': 'new_parent',
             'long': 'parent',
             'type': str,
             'default': 'base',
-            'help': 'Parent to use for new theme (default: base)',
+            'help': 'Parent to use for new theme',
         },
         {
             'name': 'new_legacy_meta',


### PR DESCRIPTION
This is #3342.

```
$ nikola help auto
nikola auto
    builds and serves a site; automatically detects site changes,
    rebuilds, and optionally refreshes a browser

Options:
    -p ARG, --port=ARG
        Port number) [default: 8000]
    -a ARG, --address=ARG
        Address to bind [default: 127.0.0.1]
    -b, --browser
        Start a web browser
    -6, --ipv6
        Use IPv6
    --no-server
        Disable the server, automate rebuilds only
```