### PR TITLE
Fix #3248 — order multilingual feed links based on current language

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ New in master
 Features
 --------
 
+* Make RSS links show the current language feed first so readers
+  prefer it (Issue #3248)
+
 Bugfixes
 --------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ New in master
 Features
 --------
 
-* Make RSS links show the current language feed first so readers
+* Put the current language’s feed links first so that feed readers
   prefer it (Issue #3248)
 
 Bugfixes

--- a/nikola/data/themes/base-jinja/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/feeds_translations_helper.tmpl
@@ -42,7 +42,7 @@
                 <link rel="alternate" type="application/rss+xml" title="RSS for {{ kind }} {{ name|e }} ({{ language }})" hreflang="{{ language }}" href="{{ _link(kind + "_rss", classification, language) }}">
             {% endfor %}
         {% else %}
-            {% for language in translations|sort %}
+            {% for language in translations_feedorder %}
                 {% if (classification or classification == '') and kind != 'index' %}
                     {{ _head_feed_link('application/rss+xml', 'RSS for ' + kind + ' ' + classification, 'rss', classification, kind, language) }}
                 {% else %}
@@ -60,7 +60,7 @@
                 <link rel="alternate" type="application/atom+xml" title="Atom for {{ kind }} {{ name|e }} ({{ language }})" hreflang="{{ language }}" href="{{ _link(kind + "_atom", classification, language) }}">
             {% endfor %}
         {% else %}
-            {% for language in translations|sort %}
+            {% for language in translations_feedorder %}
                 {% if (classification or classification == '') and kind != 'index' %}
                     {{ _head_feed_link('application/atom+xml', 'Atom for ' + kind + ' ' + classification, 'atom', classification, kind, language) }}
                 {% else %}
@@ -98,7 +98,7 @@
                 </p>
             {% endfor %}
         {% else %}
-            {% for language in translations|sort %}
+            {% for language in translations_feedorder %}
                 <p class="feedlink">
                     {% if generate_atom %}
                         {{ _html_feed_link('application/atom+xml', 'Atom feed', 'atom', classification, kind, language) }}

--- a/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
+++ b/nikola/data/themes/base/templates/feeds_translations_helper.tmpl
@@ -42,7 +42,7 @@
                 <link rel="alternate" type="application/rss+xml" title="RSS for ${kind} ${name|h} (${language})" hreflang="${language}" href="${_link(kind + "_rss", classification, language)}">
             % endfor
         % else:
-            % for language in sorted(translations):
+            % for language in translations_feedorder:
                 % if (classification or classification == '') and kind != 'index':
                     ${_head_feed_link('application/rss+xml', 'RSS for ' + kind + ' ' + classification, 'rss', classification, kind, language)}
                 % else:
@@ -60,7 +60,7 @@
                 <link rel="alternate" type="application/atom+xml" title="Atom for ${kind} ${name|h} (${language})" hreflang="${language}" href="${_link(kind + "_atom", classification, language)}">
             % endfor
         % else:
-            % for language in sorted(translations):
+            % for language in translations_feedorder:
                 % if (classification or classification == '') and kind != 'index':
                     ${_head_feed_link('application/atom+xml', 'Atom for ' + kind + ' ' + classification, 'atom', classification, kind, language)}
                 % else:
@@ -98,7 +98,7 @@
                 </p>
             % endfor
         % else:
-            % for language in sorted(translations):
+            % for language in translations_feedorder:
                 <p class="feedlink">
                     % if generate_atom:
                         ${_html_feed_link('application/atom+xml', 'Atom feed', 'atom', classification, kind, language)}

--- a/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
@@ -1,4 +1,5 @@
 {#  -*- coding: utf-8 -*- #}
+{% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
 
 {% macro html_headstart() %}
 <!DOCTYPE html>
@@ -154,26 +155,7 @@ lang="{{ lang }}">
 
 
 {% macro html_feedlinks() %}
-    {% if rss_link %}
-        {{ rss_link }}
-    {% elif generate_rss %}
-        {% if translations|length > 1 %}
-            {% for language in translations|sort %}
-                <link rel="alternate" type="application/rss+xml" title="RSS ({{ language }})" href="{{ _link('rss', None, language) }}">
-            {% endfor %}
-        {% else %}
-            <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ _link('rss', None) }}">
-        {% endif %}
-    {% endif %}
-    {% if generate_atom %}
-        {% if translations|length > 1 %}
-            {% for language in translations|sort %}
-                <link rel="alternate" type="application/atom+xml" title="Atom ({{ language }})" href="{{ _link('index_atom', None, language) }}">
-            {% endfor %}
-        {% else %}
-            <link rel="alternate" type="application/atom+xml" title="Atom" href="{{ _link('index_atom', None) }}">
-        {% endif %}
-    {% endif %}
+    {{ feeds_translations.head(classification=None, kind='index', other=False) }}
 {% endmacro %}
 
 {% macro html_translations() %}

--- a/nikola/data/themes/bootblog4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4/templates/base_helper.tmpl
@@ -1,4 +1,5 @@
 ## -*- coding: utf-8 -*-
+<%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
 
 <%def name="html_headstart()">
 <!DOCTYPE html>
@@ -154,26 +155,7 @@ lang="${lang}">
 
 
 <%def name="html_feedlinks()">
-    %if rss_link:
-        ${rss_link}
-    %elif generate_rss:
-        %if len(translations_feedorder) > 1:
-            %for language in translations_feedorder:
-                <link rel="alternate" type="application/rss+xml" title="RSS (${language})" href="${_link('rss', None, language)}">
-            %endfor
-        %else:
-            <link rel="alternate" type="application/rss+xml" title="RSS" href="${_link('rss', None)}">
-        %endif
-    %endif
-    %if generate_atom:
-        %if len(translations_feedorder) > 1:
-            %for language in translations_feedorder:
-                <link rel="alternate" type="application/atom+xml" title="Atom (${language})" href="${_link('index_atom', None, language)}">
-            %endfor
-        %else:
-            <link rel="alternate" type="application/atom+xml" title="Atom" href="${_link('index_atom', None)}">
-        %endif
-    %endif
+    ${feeds_translations.head(classification=None, kind='index', other=False)}
 </%def>
 
 <%def name="html_translations()">

--- a/nikola/data/themes/bootblog4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4/templates/base_helper.tmpl
@@ -157,8 +157,8 @@ lang="${lang}">
     %if rss_link:
         ${rss_link}
     %elif generate_rss:
-        %if len(translations) > 1:
-            %for language in sorted(translations):
+        %if len(translations_feedorder) > 1:
+            %for language in translations_feedorder:
                 <link rel="alternate" type="application/rss+xml" title="RSS (${language})" href="${_link('rss', None, language)}">
             %endfor
         %else:
@@ -166,8 +166,8 @@ lang="${lang}">
         %endif
     %endif
     %if generate_atom:
-        %if len(translations) > 1:
-            %for language in sorted(translations):
+        %if len(translations_feedorder) > 1:
+            %for language in translations_feedorder:
                 <link rel="alternate" type="application/atom+xml" title="Atom (${language})" href="${_link('index_atom', None, language)}">
             %endfor
         %else:

--- a/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
@@ -1,4 +1,6 @@
 {#  -*- coding: utf-8 -*- #}
+{% import 'feeds_translations_helper.tmpl' as feeds_translations with context %}
+
 {% macro html_headstart() %}
 <!DOCTYPE html>
 <html
@@ -149,26 +151,7 @@ lang="{{ lang }}">
 {% endmacro %}
 
 {% macro html_feedlinks() %}
-    {% if rss_link %}
-        {{ rss_link }}
-    {% elif generate_rss %}
-        {% if translations|length > 1 %}
-            {% for language in translations|sort %}
-                <link rel="alternate" type="application/rss+xml" title="RSS ({{ language }})" href="{{ _link('rss', None, language) }}">
-            {% endfor %}
-        {% else %}
-            <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ _link('rss', None) }}">
-        {% endif %}
-    {% endif %}
-    {% if generate_atom %}
-        {% if translations|length > 1 %}
-            {% for language in translations|sort %}
-                <link rel="alternate" type="application/atom+xml" title="Atom ({{ language }})" href="{{ _link('index_atom', None, language) }}">
-            {% endfor %}
-        {% else %}
-            <link rel="alternate" type="application/atom+xml" title="Atom" href="{{ _link('index_atom', None) }}">
-        {% endif %}
-    {% endif %}
+    {{ feeds_translations.head(classification=None, kind='index', other=False) }}
 {% endmacro %}
 
 {% macro html_translations() %}

--- a/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
@@ -1,4 +1,6 @@
 ## -*- coding: utf-8 -*-
+<%namespace name="feeds_translations" file="feeds_translations_helper.tmpl" import="*"/>
+
 <%def name="html_headstart()">
 <!DOCTYPE html>
 <html
@@ -149,26 +151,7 @@ lang="${lang}">
 </%def>
 
 <%def name="html_feedlinks()">
-    %if rss_link:
-        ${rss_link}
-    %elif generate_rss:
-        %if len(translations_feedorder) > 1:
-            %for language in translations_feedorder:
-                <link rel="alternate" type="application/rss+xml" title="RSS (${language})" href="${_link('rss', None, language)}">
-            %endfor
-        %else:
-            <link rel="alternate" type="application/rss+xml" title="RSS" href="${_link('rss', None)}">
-        %endif
-    %endif
-    %if generate_atom:
-        %if len(translations_feedorder) > 1:
-            %for language in translations_feedorder:
-                <link rel="alternate" type="application/atom+xml" title="Atom (${language})" href="${_link('index_atom', None, language)}">
-            %endfor
-        %else:
-            <link rel="alternate" type="application/atom+xml" title="Atom" href="${_link('index_atom', None)}">
-        %endif
-    %endif
+    ${feeds_translations.head(classification=None, kind='index', other=False)}
 </%def>
 
 <%def name="html_translations()">

--- a/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
@@ -152,8 +152,8 @@ lang="${lang}">
     %if rss_link:
         ${rss_link}
     %elif generate_rss:
-        %if len(translations) > 1:
-            %for language in sorted(translations):
+        %if len(translations_feedorder) > 1:
+            %for language in translations_feedorder:
                 <link rel="alternate" type="application/rss+xml" title="RSS (${language})" href="${_link('rss', None, language)}">
             %endfor
         %else:
@@ -161,8 +161,8 @@ lang="${lang}">
         %endif
     %endif
     %if generate_atom:
-        %if len(translations) > 1:
-            %for language in sorted(translations):
+        %if len(translations_feedorder) > 1:
+            %for language in translations_feedorder:
                 <link rel="alternate" type="application/atom+xml" title="Atom (${language})" href="${_link('index_atom', None, language)}">
             %endfor
         %else:

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1361,6 +1361,10 @@ class Nikola(object):
             local_context[k] = local_context[k](local_context['lang'])
         local_context['is_rtl'] = local_context['lang'] in LEGAL_VALUES['RTL_LANGUAGES']
         local_context['url_type'] = self.config['URL_TYPE'] if url_type is None else url_type
+        local_context["translations_feedorder"] = sorted(
+            local_context["translations"],
+            key=lambda x: (int(x != local_context['lang']), x)
+        )
         # string, arguments
         local_context["formatmsg"] = lambda s, *a: s % a
         for h in local_context['template_hooks'].values():

--- a/nikola/plugins/task/taxonomies.py
+++ b/nikola/plugins/task/taxonomies.py
@@ -51,11 +51,12 @@ class RenderTaxonomies(Task):
         context = copy(context)
         context["kind"] = "{}_index".format(taxonomy.classification_name)
         sorted_links = []
-        sorted_links_all = []
         for other_lang in sorted(self.site.config['TRANSLATIONS'].keys()):
-            sorted_links_all.append((other_lang, None, None))
             if other_lang != lang:
                 sorted_links.append((other_lang, None, None))
+        # Put the current language in front, so that it appears first in links
+        # (Issue #3248)
+        sorted_links_all = [(lang, None, None)] + sorted_links
         context['has_other_languages'] = True
         context['other_languages'] = sorted_links
         context['all_languages'] = sorted_links_all


### PR DESCRIPTION
This is #3248. 

```html
<!-- output/index.html -->
<link rel="alternate" type="application/rss+xml" title="RSS (en)" hreflang="en" href="rss.xml">
<link rel="alternate" type="application/rss+xml" title="RSS (es)" hreflang="es" href="es/rss.xml">
<link rel="alternate" type="application/rss+xml" title="RSS (pl)" hreflang="pl" href="pl/rss.xml">

<!-- output/es/index.html -->
<link rel="alternate" type="application/rss+xml" title="RSS (es)" hreflang="es" href="rss.xml">
<link rel="alternate" type="application/rss+xml" title="RSS (en)" hreflang="en" href="../rss.xml">
<link rel="alternate" type="application/rss+xml" title="RSS (pl)" hreflang="pl" href="../pl/rss.xml">

<!-- output/pl/index.html -->
<link rel="alternate" type="application/rss+xml" title="RSS (pl)" hreflang="pl" href="rss.xml">
<link rel="alternate" type="application/rss+xml" title="RSS (en)" hreflang="en" href="../rss.xml">
<link rel="alternate" type="application/rss+xml" title="RSS (es)" hreflang="es" href="../es/rss.xml">
```

This also switches the bootstrap4 themes to use `feeds_translations_helper.tmpl` for the main RSS links. Third-party themes will get the new order if they use the helper, and will not be affected otherwise.

cc @friedelwolff (original requester)