### PR TITLE
Make auto and serve host handling consistent

### DIFF
--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -248,8 +248,11 @@ class CommandAuto(Command):
         self.logger.info("Serving on {0} ...".format(server_url))
 
         if browser:
+            # Some browsers fail to load 0.0.0.0 (Issue #2755)
+            if host == '0.0.0.0':
+                server_url = "http://127.0.0.1:{1}/".format(host, port)
             self.logger.info("Opening {0} in the default web browser...".format(server_url))
-            webbrowser.open('http://{0}:{1}'.format(host, port))
+            webbrowser.open(server_url)
 
         # Run the event loop forever and handle shutdowns.
         try:

--- a/nikola/plugins/command/serve.py
+++ b/nikola/plugins/command/serve.py
@@ -132,13 +132,14 @@ class CommandServe(Command):
             sa = httpd.socket.getsockname()
             if ipv6:
                 server_url = "http://[{0}]:{1}/".format(*sa)
-            elif sa[0] == '0.0.0.0':
-                server_url = "http://127.0.0.1:{1}/".format(*sa)
             else:
                 server_url = "http://{0}:{1}/".format(*sa)
             self.logger.info("Serving on {0} ...".format(server_url))
 
             if options['browser']:
+                # Some browsers fail to load 0.0.0.0 (Issue #2755)
+                if sa[0] == '0.0.0.0':
+                    server_url = "http://127.0.0.1:{1}/".format(*sa)
                 self.logger.info("Opening {0} in the default web browser...".format(server_url))
                 webbrowser.open(server_url)
             if options['detach']:


### PR DESCRIPTION
1. Show real address (including 0.0.0.0) in “serving” message
2. Change the address if needed for the browser
3. Ensure the correct formatting (brackets for IPv6) is used

Merging in ~24h if nobody complains.