### PR TITLE
Fix #3229 — don’t use absolute links for brand/languages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,7 @@ Features
 Bugfixes
 --------
 
+* Don’t force absolute links for brand/languages (Issue #3229)
 * Fix RTL mirroring in base theme (``:dir()`` pseudo-class is Firefox only)
   (Issue #3353)
 * Work around Bootstrap 4 alignment bug for RTL languages

--- a/nikola/data/themes/base-jinja/templates/base_header.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_header.tmpl
@@ -16,7 +16,7 @@
 {% endmacro %}
 
 {% macro html_site_title() %}
-    <h1 id="brand"><a href="{{ abs_link(_link("root", None, lang)) }}" title="{{ blog_title|e }}" rel="home">
+    <h1 id="brand"><a href="{{ _link("root", None, lang) }}" title="{{ blog_title|e }}" rel="home">
     {% if logo_url %}
         <img src="{{ logo_url }}" alt="{{ blog_title|e }}" id="logo">
     {% endif %}

--- a/nikola/data/themes/base-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_helper.tmpl
@@ -123,7 +123,7 @@ lang="{{ lang }}">
     <ul class="translations">
     {% for langname in translations|sort %}
         {% if langname != lang %}
-            <li><a href="{{ abs_link(_link("root", None, langname)) }}" rel="alternate" hreflang="{{ langname }}">{{ messages("LANGUAGE", langname) }}</a></li>
+            <li><a href="{{ _link("root", None, langname) }}" rel="alternate" hreflang="{{ langname }}">{{ messages("LANGUAGE", langname) }}</a></li>
         {% endif %}
     {% endfor %}
     </ul>

--- a/nikola/data/themes/base/templates/base_header.tmpl
+++ b/nikola/data/themes/base/templates/base_header.tmpl
@@ -16,7 +16,7 @@
 </%def>
 
 <%def name="html_site_title()">
-    <h1 id="brand"><a href="${abs_link(_link("root", None, lang))}" title="${blog_title|h}" rel="home">
+    <h1 id="brand"><a href="${_link("root", None, lang)}" title="${blog_title|h}" rel="home">
     %if logo_url:
         <img src="${logo_url}" alt="${blog_title|h}" id="logo">
     %endif

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -123,7 +123,7 @@ lang="${lang}">
     <ul class="translations">
     %for langname in sorted(translations):
         %if langname != lang:
-            <li><a href="${abs_link(_link("root", None, langname))}" rel="alternate" hreflang="${langname}">${messages("LANGUAGE", langname)}</a></li>
+            <li><a href="${_link("root", None, langname)}" rel="alternate" hreflang="${langname}">${messages("LANGUAGE", langname)}</a></li>
         %endif
     %endfor
     </ul>

--- a/nikola/data/themes/bootblog4-jinja/templates/base.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/base.tmpl
@@ -24,7 +24,7 @@
             </div>
         </div>
           <div class="col-md-6 col-xs-10 col-sm-10 bootblog4-brand" style="width: auto;">
-            <a class="navbar-brand blog-header-logo text-dark" href="{{ abs_link(_link("root", None, lang)) }}">
+            <a class="navbar-brand blog-header-logo text-dark" href="{{ _link("root", None, lang) }}">
         {% if logo_url %}
             <img src="{{ logo_url }}" alt="{{ blog_title|e }}" id="logo" class="d-inline-block align-top">
         {% endif %}

--- a/nikola/data/themes/bootblog4/templates/base.tmpl
+++ b/nikola/data/themes/bootblog4/templates/base.tmpl
@@ -24,7 +24,7 @@ ${template_hooks['extra_head']()}
             </div>
         </div>
           <div class="col-md-6 col-xs-10 col-sm-10 bootblog4-brand" style="width: auto;">
-            <a class="navbar-brand blog-header-logo text-dark" href="${abs_link(_link("root", None, lang))}">
+            <a class="navbar-brand blog-header-logo text-dark" href="${_link("root", None, lang)}">
         %if logo_url:
             <img src="${logo_url}" alt="${blog_title|h}" id="logo" class="d-inline-block align-top">
         %endif

--- a/nikola/data/themes/bootstrap4-jinja/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base.tmpl
@@ -21,7 +21,7 @@ navbar-dark bg-dark
 {% endif %}
 ">
     <div class="container"><!-- This keeps the margins nice -->
-        <a class="navbar-brand" href="{{ abs_link(_link("root", None, lang)) }}">
+        <a class="navbar-brand" href="{{ _link("root", None, lang) }}">
         {% if logo_url %}
             <img src="{{ logo_url }}" alt="{{ blog_title|e }}" id="logo" class="d-inline-block align-top">
         {% endif %}

--- a/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
@@ -157,7 +157,7 @@ lang="{{ lang }}">
 {% macro html_translations() %}
     {% for langname in translations|sort %}
         {% if langname != lang %}
-            <li class="nav-item"><a href="{{ abs_link(_link("root", None, langname)) }}" rel="alternate" hreflang="{{ langname }}" class="nav-link">{{ messages("LANGUAGE", langname) }}</a></li>
+            <li class="nav-item"><a href="{{ _link("root", None, langname) }}" rel="alternate" hreflang="{{ langname }}" class="nav-link">{{ messages("LANGUAGE", langname) }}</a></li>
         {% endif %}
     {% endfor %}
 {% endmacro %}

--- a/nikola/data/themes/bootstrap4/templates/base.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base.tmpl
@@ -21,7 +21,7 @@ navbar-dark bg-dark
 % endif
 ">
     <div class="container"><!-- This keeps the margins nice -->
-        <a class="navbar-brand" href="${abs_link(_link("root", None, lang))}">
+        <a class="navbar-brand" href="${_link("root", None, lang)}">
         %if logo_url:
             <img src="${logo_url}" alt="${blog_title|h}" id="logo" class="d-inline-block align-top">
         %endif

--- a/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
@@ -157,7 +157,7 @@ lang="${lang}">
 <%def name="html_translations()">
     %for langname in sorted(translations):
         %if langname != lang:
-            <li class="nav-item"><a href="${abs_link(_link("root", None, langname))}" rel="alternate" hreflang="${langname}" class="nav-link">${messages("LANGUAGE", langname)}</a></li>
+            <li class="nav-item"><a href="${_link("root", None, langname)}" rel="alternate" hreflang="${langname}" class="nav-link">${messages("LANGUAGE", langname)}</a></li>
         %endif
     %endfor
 </%def>


### PR DESCRIPTION
This is #3229.  

The absolute links don’t bring in much benefit, and they require extra steps when using `serve` or opening HTML pages from the filesystem. So, let‘s get rid of them.

Will merge in ~24 hours if nobody complains.

cc @mardy