### PR TITLE
Use a separate template for archives

### DIFF
--- a/nikola/data/themes/base-jinja/templates/archive.tmpl
+++ b/nikola/data/themes/base-jinja/templates/archive.tmpl
@@ -1,0 +1,1 @@
+{% extends 'list_post.tmpl' %}

--- a/nikola/data/themes/base/templates/archive.tmpl
+++ b/nikola/data/themes/base/templates/archive.tmpl
@@ -1,0 +1,1 @@
+<%inherit file="list_post.tmpl"/>

--- a/nikola/plugins/task/archive.py
+++ b/nikola/plugins/task/archive.py
@@ -74,7 +74,7 @@ class Archive(Taxonomy):
         # Finish setup
         self.show_list_as_subcategories_list = not site.config['CREATE_FULL_ARCHIVES']
         self.show_list_as_index = site.config['ARCHIVES_ARE_INDEXES']
-        self.template_for_single_list = "archiveindex.tmpl" if site.config['ARCHIVES_ARE_INDEXES'] else "list_post.tmpl"
+        self.template_for_single_list = "archiveindex.tmpl" if site.config['ARCHIVES_ARE_INDEXES'] else "archive.tmpl"
         # Determine maximum hierarchy height
         if site.config['CREATE_DAILY_ARCHIVE'] or site.config['CREATE_FULL_ARCHIVES']:
             self.max_levels = 3


### PR DESCRIPTION
This does nothing in itself, but it lets users customize the archive template separately, which
then enables something like what Issue 2902 wants.

Here's an example of it working:

![image](https://user-images.githubusercontent.com/1579/78385229-e9c6c300-75b1-11ea-9a4e-a17cb6b5d5d4.png)
