### PR TITLE
Fix #3362

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,8 @@ Bugfixes
   broken symlinks or incorrect ``TRANSLATIONS_PATTERN`` values
 * Avoid installing ``tests`` package to site-packages, remove it from
   your environment if it was inadvertently added (Issue #3348)
+* Sometimes hyphenation added hyphens at the beginning of words
+  (Issue #3362)
 
 New in v8.0.4
 =============

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1115,8 +1115,14 @@ def insert_hyphens(node, hyphenator):
         text = getattr(node, attr)
         if not text:
             continue
-        new_data = ' '.join([hyphenator.inserted(w, hyphen='\u00AD')
-                             for w in text.split(' ')])
+
+        lines = text.splitlines()
+        new_data = "\n".join(
+            [
+                " ".join([hyphenator.inserted(w, hyphen="\u00AD") for w in line.split(" ")])
+                for line in lines
+            ]
+        )
         # Spaces are trimmed, we have to add them manually back
         if text[0].isspace():
             new_data = ' ' + new_data


### PR DESCRIPTION
Because we were only splitting words on spaces, sometimes a hyphen was inserted on a newline because pyphen tried to hyphenate something like "foo\nbar" and decided it was "foo\n-bar"