### PR TITLE
Fix #3361

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@ Bugfixes
   (Issue #3362)
 * Mark gallery images as "dirty" if EXIF configuration changes (Issue
   #3357)
+* Make gallery indexes depend on destination images to avoid
+  multithreading race condition (Issue #3361)
 
 New in v8.0.4
 =============

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -308,7 +308,7 @@ class Galleries(Task, ImageProcessor):
                 yield utils.apply_filters({
                     'basename': self.name,
                     'name': dst,
-                    'file_dep': file_dep,
+                    'file_dep': file_dep + file_dep_dest,
                     'targets': [dst],
                     'actions': [
                         (self.render_gallery_index, (

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -308,7 +308,7 @@ class Galleries(Task, ImageProcessor):
                 yield utils.apply_filters({
                     'basename': self.name,
                     'name': dst,
-                    'file_dep': file_dep + file_dep_dest,
+                    'file_dep': file_dep + dest_img_list,
                     'targets': [dst],
                     'actions': [
                         (self.render_gallery_index, (


### PR DESCRIPTION
Building the gallery indexes requires reading sizes of **destination** images, so they should also depend on destination image files.
