### PR TITLE
Fix #3360

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,8 @@ Bugfixes
   broken symlinks or incorrect ``TRANSLATIONS_PATTERN`` values
 * Avoid installing ``tests`` package to site-packages, remove it from
   your environment if it was inadvertently added (Issue #3348)
+* Sometimes hyphenation added hyphens at the beginning of words
+  (Issue #3362)
 * Mark gallery images as "dirty" if EXIF configuration changes (Issue
   #3357)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@ Bugfixes
   (Issue #3362)
 * Mark gallery images as "dirty" if EXIF configuration changes (Issue
   #3357)
+* Fix regression in gallery titles being "index" if there was a
+  index.txt and no title (Issue #3360)
 
 New in v8.0.4
 =============

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -504,7 +504,6 @@ class Galleries(Task, ImageProcessor):
             # (warning: galleries titled index and filenamed differently
             #  may break)
             if post.title() == 'index':
-                from doit.tools import set_trace; set_trace()
                 for lang in post.meta.keys():
                     post.meta[lang]['title'] = os.path.split(gallery)[1]
             # Register the post (via #2417)

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -503,8 +503,10 @@ class Galleries(Task, ImageProcessor):
             # index.txt file would be errorneously named `index`
             # (warning: galleries titled index and filenamed differently
             #  may break)
-            if post.title == 'index':
-                post.title = os.path.split(gallery)[1]
+            if post.title() == 'index':
+                from doit.tools import set_trace; set_trace()
+                for lang in post.meta.keys():
+                    post.meta[lang]['title'] = os.path.split(gallery)[1]
             # Register the post (via #2417)
             self.site.post_per_input_file[index_path] = post
         else:

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1115,8 +1115,14 @@ def insert_hyphens(node, hyphenator):
         text = getattr(node, attr)
         if not text:
             continue
-        new_data = ' '.join([hyphenator.inserted(w, hyphen='\u00AD')
-                             for w in text.split(' ')])
+
+        lines = text.splitlines()
+        new_data = "\n".join(
+            [
+                " ".join([hyphenator.inserted(w, hyphen="\u00AD") for w in line.split(" ")])
+                for line in lines
+            ]
+        )
         # Spaces are trimmed, we have to add them manually back
         if text[0].isspace():
             new_data = ' ' + new_data


### PR DESCRIPTION
If galleries had an index.txt with no title, it was "index" instead of the folder name. This was a regression from whenever some metadata thing changed.
