### PR TITLE
[WIP] Added opengraph metadata to galleries

### DIFF
--- a/nikola/data/themes/base/templates/gallery.tmpl
+++ b/nikola/data/themes/base/templates/gallery.tmpl
@@ -2,6 +2,7 @@
 <%inherit file="base.tmpl"/>
 <%namespace name="comments" file="comments_helper.tmpl"/>
 <%namespace name="ui" file="ui_helper.tmpl"/>
+<%namespace name="post_helper" file="post_helper.tmpl"/>
 <%block name="sourcelink"></%block>
 
 <%block name="content">
@@ -72,6 +73,10 @@ ${parent.extra_head()}
     %endfor
 %endif
 <link rel="alternate" type="application/rss+xml" title="RSS" href="rss.xml">
+%if post:
+    ${post_helper.open_graph_metadata(post)}
+    ${post_helper.twitter_card_information(post)}
+%endif
 </%block>
 
 <%block name="extra_js">


### PR DESCRIPTION
Adds opengraph metadata to galleries that have preview images, looks like this:

![image](https://user-images.githubusercontent.com/1579/78724376-b6fb3280-7903-11ea-9743-fafd69d8eb54.png)

