### PR TITLE
Relative previewimage

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Allow preview images to be relative to posts for bootblog4 featured
+  posts
 * Change the listings formatting to support word wrap with line
   numbers and improve appearance
 * Put the current language’s feed links first so that feed readers

--- a/nikola/data/themes/base-jinja/templates/gallery.tmpl
+++ b/nikola/data/themes/base-jinja/templates/gallery.tmpl
@@ -20,7 +20,7 @@
             <div class="thumnbnail-container">
                 <a href="{{ folder }}" class="thumbnail image-reference" title="{{ ftitle|e }}">
                     {% if fpost and fpost.previewimage %}
-                        <img src="{{ fpost.previewimage }}" alt="{{ ftitle|e }}" loading="lazy" style="max-width:{{ thumbnail_size }}px; max-height:{{ thumbnail_size }}px;" />
+                        <img src="{{ url_replacer(fpost.permalink(), fpost.previewimage, lang, 'full_path') }}" alt="{{ ftitle|e }}" loading="lazy" style="max-width:{{ thumbnail_size }}px; max-height:{{ thumbnail_size }}px;" />
                     {% else %}
                         <div style="height: {{ thumbnail_size }}px; width: {{ thumbnail_size }}px; background-color: #eee;"></div>
                     {% endif %}

--- a/nikola/data/themes/base/templates/gallery.tmpl
+++ b/nikola/data/themes/base/templates/gallery.tmpl
@@ -20,7 +20,7 @@
             <div class="thumnbnail-container">
                 <a href="${folder}" class="thumbnail image-reference" title="${ftitle|h}">
                     % if fpost and fpost.previewimage:
-                        <img src="${fpost.previewimage}" alt="${ftitle|h}" loading="lazy" style="max-width:${thumbnail_size}px; max-height:${thumbnail_size}px;" />
+                        <img src="${url_replacer(fpost.permalink(), fpost.previewimage, lang, 'full_path')}" alt="${ftitle|h}" loading="lazy" style="max-width:${thumbnail_size}px; max-height:${thumbnail_size}px;" />
                     % else:
                         <div style="height: ${thumbnail_size}px; width: ${thumbnail_size}px; background-color: #eee;"></div>
                     % endif

--- a/nikola/data/themes/bootblog4-jinja/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/index.tmpl
@@ -88,7 +88,7 @@
                         {% else %}
                         <div class="col-md-6 p-0 h-md-250 text-right d-none d-md-block">
                         {% endif %}
-                            <img class="bootblog4-featured-large-image" src="{{ featured[0].previewimage }}" alt="{{ featured.pop(0).title() }}">
+                            <img class="bootblog4-featured-large-image" src="{{ url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path') }}" alt="{{ featured.pop(0).title() }}">
                         </div>
                     {% else %}
                         <div class="lead my-3 mb-0">{{ featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True)) }}</div>
@@ -113,7 +113,7 @@
                            {% if featured[0].previewimage %}
                                <div class="card-text mb-auto bootblog4-featured-text">{{ featured[0].text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True)) }}</div>
                                </div>
-                               <img class="card-img-right flex-auto d-none d-lg-block" src="{{ featured[0].previewimage }}" alt="{{ featured.pop(0).title() }}">
+                               <img class="card-img-right flex-auto d-none d-lg-block" src="{{ url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path') }}" alt="{{ featured.pop(0).title() }}">
                            {% else %}
                            <div class="card-text mb-auto bootblog4-featured-text">{{ featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True)) }}</div>
                            </div>
@@ -131,7 +131,7 @@
                            {% if featured[0].previewimage %}
                                <div class="card-text mb-auto bootblog4-featured-text">{{ featured[0].text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True)) }}</div>
                                </div>
-                               <img class="card-img-right flex-auto d-none d-lg-block" src="{{ featured[0].previewimage }}" alt="{{ featured.pop(0).title() }}">
+                               <img class="card-img-right flex-auto d-none d-lg-block" src="{{ url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path') }}" alt="{{ featured.pop(0).title() }}">
                            {% else %}
                            <div class="card-text mb-auto bootblog4-featured-text">{{ featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True)) }}</div>
                            </div>

--- a/nikola/data/themes/bootblog4/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4/templates/index.tmpl
@@ -88,7 +88,7 @@
                         % else:
                         <div class="col-md-6 p-0 h-md-250 text-right d-none d-md-block">
                         % endif
-                            <img class="bootblog4-featured-large-image" src="${featured[0].previewimage}" alt="${featured.pop(0).title()}">
+                            <img class="bootblog4-featured-large-image" src="${url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path')}" alt="${featured.pop(0).title()}">
                         </div>
                     % else:
                         <div class="lead my-3 mb-0">${featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
@@ -113,7 +113,7 @@
                            % if featured[0].previewimage:
                                <div class="card-text mb-auto bootblog4-featured-text">${featured[0].text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
                                </div>
-                               <img class="card-img-right flex-auto d-none d-lg-block" src="${featured[0].previewimage}" alt="${featured.pop(0).title()}">
+                               <img class="card-img-right flex-auto d-none d-lg-block" src="${url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path')}" alt="${featured.pop(0).title()}">
                            % else:
                            <div class="card-text mb-auto bootblog4-featured-text">${featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
                            </div>
@@ -131,7 +131,7 @@
                            % if featured[0].previewimage:
                                <div class="card-text mb-auto bootblog4-featured-text">${featured[0].text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
                                </div>
-                               <img class="card-img-right flex-auto d-none d-lg-block" src="${featured[0].previewimage}" alt="${featured.pop(0).title()}">
+                               <img class="card-img-right flex-auto d-none d-lg-block" src="${url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path')}" alt="${featured.pop(0).title()}">
                            % else:
                            <div class="card-text mb-auto bootblog4-featured-text">${featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
                            </div>

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -496,9 +496,8 @@ class Galleries(Task, ImageProcessor):
     def parse_index(self, gallery, input_folder, output_folder):
         """Return a Post object if there is an index.txt."""
         index_path = os.path.join(gallery, "index.txt")
-        destination = os.path.join(
-            self.kw["output_folder"], output_folder,
-            os.path.relpath(gallery, input_folder))
+        destination = os.path.join(output_folder,
+                                   os.path.relpath(gallery, input_folder))
         if os.path.isfile(index_path):
             post = Post(
                 index_path,


### PR DESCRIPTION
This is an attempt to allow previewimages to be relative to the gallery, as discussed in #3372. I also copied that code to bootblog4’s featured post image handling.