### PR TITLE
Refactor resize_image to support multiple target sizes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,8 @@ Features
 Bugfixes
 --------
 
+* Refactored scale_image causing performance increasing in image
+  resizing.
 * Don’t force absolute links for brand/languages (Issue #3229)
 * Fix RTL mirroring in base theme (``:dir()`` pseudo-class is Firefox only)
   (Issue #3353)

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -112,6 +112,7 @@ class ImageProcessor(object):
         # The jpg exclusion is Issue #3332
         is_animated = hasattr(_im, 'n_frames') and _im.n_frames > 1 and extension not in {'.jpg', '.jpeg'}
 
+        exif = None
         if "exif" in _im.info:
             exif = piexif.load(_im.info["exif"])
             # Rotate according to EXIF

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -107,14 +107,15 @@ class ImageProcessor(object):
             self.resize_svg(src, dst_paths, max_sizes, bigger_panoramas)
             return
 
-        im = Image.open(src)
+        _im = Image.open(src)
 
         for dst, max_size in zip(dst_paths, max_sizes):
             # The jpg exclusion is Issue #3332
-            if hasattr(im, 'n_frames') and im.n_frames > 1 and extension not in {'.jpg', '.jpeg'}:
+            if hasattr(_im, 'n_frames') and _im.n_frames > 1 and extension not in {'.jpg', '.jpeg'}:
                 # Animated gif, leave as-is
                 utils.copy_file(src, dst)
                 continue
+            im = _im.copy()
 
             size = w, h = im.size
             if w > max_size or h > max_size:

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -109,6 +109,7 @@ class ImageProcessor(object):
 
         _im = Image.open(src)
 
+        # The jpg exclusion is Issue #3332
         is_animated = hasattr(_im, 'n_frames') and _im.n_frames > 1 and extension not in {'.jpg', '.jpeg'}
 
         try:
@@ -131,9 +132,7 @@ class ImageProcessor(object):
         icc_profile = _im.info.get('icc_profile') if preserve_icc_profiles else None
 
         for dst, max_size in zip(dst_paths, max_sizes):
-            # The jpg exclusion is Issue #3332
-            if is_animated:
-                # Animated gif, leave as-is
+            if is_animated:  # Animated gif, leave as-is
                 utils.copy_file(src, dst)
                 continue
 

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -112,22 +112,21 @@ class ImageProcessor(object):
         # The jpg exclusion is Issue #3332
         is_animated = hasattr(_im, 'n_frames') and _im.n_frames > 1 and extension not in {'.jpg', '.jpeg'}
 
-        try:
+        if "exif" in _im.info:
             exif = piexif.load(_im.info["exif"])
             # Rotate according to EXIF
-            value = exif['0th'].get(piexif.ImageIFD.Orientation, 1)
-            if value in (3, 4):
-                _im = _im.transpose(Image.ROTATE_180)
-            elif value in (5, 6):
-                _im = _im.transpose(Image.ROTATE_270)
-            elif value in (7, 8):
-                _im = _im.transpose(Image.ROTATE_90)
-            if value in (2, 4, 5, 7):
-                _im = _im.transpose(Image.FLIP_LEFT_RIGHT)
-            exif['0th'][piexif.ImageIFD.Orientation] = 1
+            if "0th" in exif:
+                value = exif['0th'].get(piexif.ImageIFD.Orientation, 1)
+                if value in (3, 4):
+                    _im = _im.transpose(Image.ROTATE_180)
+                elif value in (5, 6):
+                    _im = _im.transpose(Image.ROTATE_270)
+                elif value in (7, 8):
+                    _im = _im.transpose(Image.ROTATE_90)
+                if value in (2, 4, 5, 7):
+                    _im = _im.transpose(Image.FLIP_LEFT_RIGHT)
+                exif['0th'][piexif.ImageIFD.Orientation] = 1
             exif = self.filter_exif(exif, exif_whitelist)
-        except KeyError:
-            exif = None
 
         icc_profile = _im.info.get('icc_profile') if preserve_icc_profiles else None
 

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -112,7 +112,7 @@ class ImageProcessor(object):
         is_animated = hasattr(_im, 'n_frames') and _im.n_frames > 1 and extension not in {'.jpg', '.jpeg'}
 
         try:
-            exif = piexif.load(im.info["exif"])
+            exif = piexif.load(_im.info["exif"])
             # Rotate according to EXIF
             value = exif['0th'].get(piexif.ImageIFD.Orientation, 1)
             if value in (3, 4):

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -102,7 +102,7 @@ class ImageProcessor(object):
         if max_sizes is None:
             max_sizes = [max_size]
         if len(max_sizes) != len(dst_paths):
-            raise ValueError(f'resize_image called with incompatible arguments: {dst_paths} / {max_sizes}')
+            raise ValueError('resize_image called with incompatible arguments: {} / {}'.format(dst_paths, max_sizes))
 
         im = None
 

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -116,19 +116,19 @@ class ImageProcessor(object):
             # Rotate according to EXIF
             value = exif['0th'].get(piexif.ImageIFD.Orientation, 1)
             if value in (3, 4):
-                im = im.transpose(Image.ROTATE_180)
+                _im = _im.transpose(Image.ROTATE_180)
             elif value in (5, 6):
-                im = im.transpose(Image.ROTATE_270)
+                _im = _im.transpose(Image.ROTATE_270)
             elif value in (7, 8):
-                im = im.transpose(Image.ROTATE_90)
+                _im = _im.transpose(Image.ROTATE_90)
             if value in (2, 4, 5, 7):
-                im = im.transpose(Image.FLIP_LEFT_RIGHT)
+                _im = _im.transpose(Image.FLIP_LEFT_RIGHT)
             exif['0th'][piexif.ImageIFD.Orientation] = 1
             exif = self.filter_exif(exif, exif_whitelist)
         except KeyError:
             exif = None
 
-        icc_profile = im.info.get('icc_profile') if preserve_icc_profiles else None
+        icc_profile = _im.info.get('icc_profile') if preserve_icc_profiles else None
 
         for dst, max_size in zip(dst_paths, max_sizes):
             # The jpg exclusion is Issue #3332

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -113,11 +113,6 @@ class ImageProcessor(object):
 
         try:
             exif = piexif.load(im.info["exif"])
-        except KeyError:
-            exif = None
-        # Inside this if, we can manipulate exif as much as
-        # we want/need and it will be preserved if required
-        if exif is not None:
             # Rotate according to EXIF
             value = exif['0th'].get(piexif.ImageIFD.Orientation, 1)
             if value in (3, 4):
@@ -130,6 +125,8 @@ class ImageProcessor(object):
                 im = im.transpose(Image.FLIP_LEFT_RIGHT)
             exif['0th'][piexif.ImageIFD.Orientation] = 1
             exif = self.filter_exif(exif, exif_whitelist)
+        except KeyError:
+            exif = None
 
         icc_profile = im.info.get('icc_profile') if preserve_icc_profiles else None
 

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -96,7 +96,6 @@ class ImageProcessor(object):
         * Either max_size or max_sizes should be set
         * Either dst or dst_paths should be set
         """
-
         if dst_paths is None:
             dst_paths = [dst]
         if max_sizes is None:

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -584,10 +584,7 @@ class Galleries(Task, ImageProcessor):
                         'bigger_panoramas': True,
                         'preserve_exif_data': self.kw['preserve_exif_data'],
                         'exif_whitelist': self.kw['exif_whitelist'],
-                        'preserve_icc_profiles': self.kw['preserve_icc_profiles'],
-                    }
-                )
-            ],
+                        'preserve_icc_profiles': self.kw['preserve_icc_profiles']})],
             'clean': True,
             'uptodate': [utils.config_changed({
                 1: self.kw['thumbnail_size'],

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -573,40 +573,29 @@ class Galleries(Task, ImageProcessor):
         orig_dest_path = os.path.join(output_gallery, img_name)
         yield utils.apply_filters({
             'basename': self.name,
-            'name': thumb_path,
+            'name': orig_dest_path,
             'file_dep': [img],
-            'targets': [thumb_path],
+            'targets': [thumb_path, orig_dest_path],
             'actions': [
                 (self.resize_image,
-                    (img, thumb_path, self.kw['thumbnail_size'], True, self.kw['preserve_exif_data'],
-                     self.kw['exif_whitelist'], self.kw['preserve_icc_profiles']))
+                    [img], {
+                        'dst_paths': [thumb_path, orig_dest_path],
+                        'max_sizes': [self.kw['thumbnail_size'], self.kw['max_image_size']],
+                        'bigger_panoramas': True,
+                        'preserve_exif_data': self.kw['preserve_exif_data'],
+                        'exif_whitelist': self.kw['exif_whitelist'],
+                        'preserve_icc_profiles': self.kw['preserve_icc_profiles'],
+                    }
+                )
             ],
             'clean': True,
             'uptodate': [utils.config_changed({
                 1: self.kw['thumbnail_size'],
-                2: self.kw['preserve_exif_data'],
-                3: self.kw['exif_whitelist'],
-                4: self.kw['preserve_icc_profiles'],
+                2: self.kw['max_image_size'],
+                3: self.kw['preserve_exif_data'],
+                4: self.kw['exif_whitelist'],
+                5: self.kw['preserve_icc_profiles'],
             }, 'nikola.plugins.task.galleries:resize_thumb')],
-        }, self.kw['filters'])
-
-        yield utils.apply_filters({
-            'basename': self.name,
-            'name': orig_dest_path,
-            'file_dep': [img],
-            'targets': [orig_dest_path],
-            'actions': [
-                (self.resize_image,
-                    (img, orig_dest_path, self.kw['max_image_size'], True, self.kw['preserve_exif_data'],
-                     self.kw['exif_whitelist'], self.kw['preserve_icc_profiles']))
-            ],
-            'clean': True,
-            'uptodate': [utils.config_changed({
-                1: self.kw['max_image_size'],
-                2: self.kw['preserve_exif_data'],
-                3: self.kw['exif_whitelist'],
-                4: self.kw['preserve_icc_profiles'],
-            }, 'nikola.plugins.task.galleries:resize_max')],
         }, self.kw['filters'])
 
     def remove_excluded_image(self, img, input_folder):

--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -32,6 +32,7 @@ from nikola.plugin_categories import Task
 from nikola.image_processing import ImageProcessor
 from nikola import utils
 
+SRCSET_IMAGE_SIZES=(400,1200,2400)
 
 class ScaleImage(Task, ImageProcessor):
     """Resize images and create thumbnails for them."""
@@ -66,8 +67,15 @@ class ScaleImage(Task, ImageProcessor):
 
     def process_image(self, src, dst, thumb):
         """Resize an image."""
-        self.resize_image(src, dst, self.kw['max_image_size'], True, preserve_exif_data=self.kw['preserve_exif_data'], exif_whitelist=self.kw['exif_whitelist'], preserve_icc_profiles=self.kw['preserve_icc_profiles'])
-        self.resize_image(src, thumb, self.kw['image_thumbnail_size'], True, preserve_exif_data=self.kw['preserve_exif_data'], exif_whitelist=self.kw['exif_whitelist'], preserve_icc_profiles=self.kw['preserve_icc_profiles'])
+        self.resize_image(
+            src,
+            dst_paths=[dst, thumb],
+            max_sizes=[self.kw['max_image_size'], self.kw['image_thumbnail_size']],
+            bigger_panoramas=True,
+            preserve_exif_data=self.kw['preserve_exif_data'],
+            exif_whitelist=self.kw['exif_whitelist'],
+            preserve_icc_profiles=self.kw['preserve_icc_profiles']
+        )
 
     def gen_tasks(self):
         """Copy static files into the output folder."""

--- a/nikola/plugins/task/scale_images.py
+++ b/nikola/plugins/task/scale_images.py
@@ -32,7 +32,6 @@ from nikola.plugin_categories import Task
 from nikola.image_processing import ImageProcessor
 from nikola import utils
 
-SRCSET_IMAGE_SIZES=(400,1200,2400)
 
 class ScaleImage(Task, ImageProcessor):
     """Resize images and create thumbnails for them."""


### PR DESCRIPTION
This could eventually lead to supporting things like #3338

In the meantime, gallery rendering in my site takes ~~112~~ 260 seconds when it takes 364 using master.

Still there are opportunities for improving performance:

* EXIF cleanup could be done only once per loop
* Probably something else

But this is not so invasive and gives a large perf improvement, so let's merge it if it's ok.