### PR TITLE
Nikola scripts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* New ``nikola console -s script.py`` option to run scripts that
+  access your site (Issue #3385)
 * Allow preview images to be relative to posts for bootblog4 featured
   posts
 * Change the listings formatting to support word wrap with line

--- a/nikola/plugins/command/console.py
+++ b/nikola/plugins/command/console.py
@@ -79,6 +79,14 @@ If there is no console to use specified (as -b, -i, -p) it tries IPython, then f
             'default': None,
             'help': 'Run a single command',
         },
+        {
+            'name': 'script',
+            'short': 's',
+            'long': 'script',
+            'type': str,
+            'default': None,
+            'help': 'Execute a python script in the console context',
+        },
     ]
 
     def ipython(self, willful=True):
@@ -143,6 +151,10 @@ If there is no console to use specified (as -b, -i, -p) it tries IPython, then f
         }
         if options['command']:
             exec(options['command'], None, self.context)
+        elif options['script']:
+            with open(options['script']) as inf:
+                code = compile(inf.read(), options['script'], 'exec')
+            exec(code, None, self.context)
         elif options['bpython']:
             self.bpython(True)
         elif options['ipython']:


### PR DESCRIPTION
This adds a `-s` or `--script` option to `nikola console` to allow usage of scripts that access site internals without needing to be nikola plugins.

My usecase is that I want to do stuff with disqus comments export that needs access to the timeline.