### PR TITLE
Add a source('lang') method to Post

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -45,6 +45,12 @@ Bugfixes
 * Use correct language for hyphenation in posts that are not
   translated to all languages (Issue #3377)
 
+Internal
+--------
+
+* Added Post.source() method to get a Post's object unprocessed 
+  contents.
+
 New in v8.0.4
 =============
 

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -349,8 +349,8 @@ class PageCompiler(BasePlugin):
 
         if isinstance(extractor, MetadataExtractor):
             return extractor.split_metadata_from_text(data)
-        else:
-            return data, data
+        # Ouch!
+        return data, data
 
     def get_compiler_extensions(self) -> list:
         """Activate all the compiler extension plugins for a given compiler and return them."""

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -762,7 +762,6 @@ class Post(object):
             source_data = self.compiler.split_metadata(data, self, lang)[1]
         return source_data
 
-
     def text(self, lang=None, teaser_only=False, strip_html=False, show_read_more_link=True,
              feed_read_more_link=False, feed_links_append_query=None):
         """Read the post file for that language and return its compiled contents.

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1002,24 +1002,6 @@ class Post(object):
         else:
             return ext
 
-    def write_post(self):
-        """Do a best effort to write down the current post state, including metadata.
-
-        It will save in either 2-file or 1-file format, in the format indicated by
-        METADATA_FORMAT.
-
-        This has caveats:
-
-        * If you are extracting metadata from filename?
-        * If you are extracting metadata from document contents?
-
-        Because of how it's going to be written, that's not going to be used anymore.
-        """
-        breakpoint()
-        for lang in self.translated_to:
-            metadata = self.meta[lang]
-
-
 
 def get_metadata_from_file(source_path, post, config, lang, metadata_extractors_by):
     """Extract metadata from the file itself, by parsing contents."""

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -748,9 +748,24 @@ class Post(object):
             real_lang = sorted(self.translated_to)[0]
             return get_translation_candidate(self.config, self.base_path, real_lang), real_lang
 
+    def source(self, lang=None):
+        """Read the post and return its source."""
+        if lang is None:
+            lang = nikola.utils.LocaleBorg().current_lang
+
+        source = self.translated_source_path(lang)
+        with open(source, encoding='utf-8') as inf:
+            data = inf.read()
+        if self.is_two_file:  # Metadata is not here
+            source_data = data
+        else:
+            source_data = self.compiler.split_metadata(data, self, lang)[1]
+        return source_data
+
+
     def text(self, lang=None, teaser_only=False, strip_html=False, show_read_more_link=True,
              feed_read_more_link=False, feed_links_append_query=None):
-        """Read the post file for that language and return its contents.
+        """Read the post file for that language and return its compiled contents.
 
         teaser_only=True breaks at the teaser marker and returns only the teaser.
         strip_html=True removes HTML tags
@@ -986,6 +1001,24 @@ class Post(object):
             return '.src' + ext
         else:
             return ext
+
+    def write_post(self):
+        """Do a best effort to write down the current post state, including metadata.
+
+        It will save in either 2-file or 1-file format, in the format indicated by
+        METADATA_FORMAT.
+
+        This has caveats:
+
+        * If you are extracting metadata from filename?
+        * If you are extracting metadata from document contents?
+
+        Because of how it's going to be written, that's not going to be used anymore.
+        """
+        breakpoint()
+        for lang in self.translated_to:
+            metadata = self.meta[lang]
+
 
 
 def get_metadata_from_file(source_path, post, config, lang, metadata_extractors_by):


### PR DESCRIPTION
Fix #3384

This method returns the unprocessed source for the post in the given language.
If the post is not translated to that language, uses the same logic as compile() to return the "correct" data.