### PR TITLE
Support WebP images (fix #3399)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Support WebP image scaling (Issue #3399)
 * Use Luxon instead of Moment for fancy dates to make it more
   lightweight, going from 328k to 68k (Issue #3232)
 * New ``nikola console -s script.py`` option to run scripts that

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -43,7 +43,7 @@ EXIF_TAG_NAMES = {}
 class ImageProcessor(object):
     """Apply image operations."""
 
-    image_ext_list_builtin = ['.jpg', '.png', '.jpeg', '.gif', '.svg', '.svgz', '.bmp', '.tiff']
+    image_ext_list_builtin = ['.jpg', '.png', '.jpeg', '.gif', '.svg', '.svgz', '.bmp', '.tiff', '.webp']
 
     def _fill_exif_tag_names(self):
         """Connect EXIF tag names to numeric values."""
@@ -146,6 +146,10 @@ class ImageProcessor(object):
                     size = min(w, max_size * 4), min(w, max_size * 4)
             try:
                 im.thumbnail(size, Image.ANTIALIAS)
+                save_args = {}
+                if icc_profile:
+                    save_args['icc_profile'] = icc_profile
+
                 if exif is not None and preserve_exif_data:
                     # Put right size in EXIF data
                     w, h = im.size
@@ -156,9 +160,9 @@ class ImageProcessor(object):
                         exif["Exif"][piexif.ExifIFD.PixelXDimension] = w
                         exif["Exif"][piexif.ExifIFD.PixelYDimension] = h
                     # Filter EXIF data as required
-                    im.save(dst, exif=piexif.dump(exif), icc_profile=icc_profile)
-                else:
-                    im.save(dst, icc_profile=icc_profile)
+                    save_args['exif'] = piexif.dump(exif)
+
+                im.save(dst, **save_args)
             except Exception as e:
                 self.logger.warning("Can't process {0}, using original "
                                     "image! ({1})".format(src, e))


### PR DESCRIPTION
This adds WebP image support to image scaling. To make WebP work, we need a small behavior change, since the Pillow plugin differentiates between arguments missing and being None.

Fixes #3399. cc @zombie110year.