### PR TITLE
Variant of Typogrify filter without ampersand

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -84,6 +84,7 @@
 * `Miguel Ángel García <https://github.com/magmax>`_
 * `Mitch Chapman <https://github.com/mchapman87501>`_
 * `mrabbitt <https://github.com/mrabbitt>`_
+* `ncdulo <https://github.com/ncdulo>`_
 * `Neil MartinsenBurrell <https://github.com/neilmb>`_
 * `Niels Böhm <https://github.com/blubberdiblub>`_
 * `Niko Wenselowski <https://github.com/okin>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -48,6 +48,8 @@ Bugfixes
   #3332)
 * Use correct language for hyphenation in posts that are not
   translated to all languages (Issue #3377)
+* Prevent ``<span>`` tags from appearing in certain page ``<title>``
+  blocks when using Typogrify (Issue #3404)
 
 Internal
 --------

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2285,6 +2285,9 @@ filters.html5lib_xmllike
 filters.typogrify
    Improve typography using `typogrify <http://static.mintchaos.com/projects/typogrify/>`__
 
+filters.typogrify_sans_amp
+   Same as typogrify without the ampersand filter
+
 filters.typogrify_sans_widont
    Same as typogrify without the widont filter
 

--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -329,6 +329,25 @@ def typogrify_sans_widont(data):
 
 
 @apply_to_text_file
+def typogrify_sans_amp(data):
+    """Prettify text with typogrify, skipping the ampersand filter."""
+    if typo is None:
+        req_missing(['typogrify'], 'use the typogrify filter', optional=True)
+        return data
+
+    data = _normalize_html(data)
+    # Disabled because it might leave <span> tags inside your <title> blocks
+    # if your posts or pages contain ampersands in their title
+    # data = typo.amp(data)
+    data = typo.widont(data)
+    data = typo.smartypants(data)
+    # Disabled because of typogrify bug where it breaks <title>
+    # data = typo.caps(data)
+    data = typo.initial_quotes(data)
+    return data
+
+
+@apply_to_text_file
 def php_template_injection(data):
     """Insert PHP code into Nikola templates."""
     template = re.search(r'<\!-- __NIKOLA_PHP_TEMPLATE_INJECTION source\:(.*) checksum\:(.*)__ -->', data)


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
In reference to issue #3404 this pull request adds a variation of the base Typogrify filter without the ampersand filtering. The only change made to the standard `filters.typogrify` is removal of the `typo.amp()` call. This has been tested on my own site using Nikola 8.0.4, and from a test site using Nikola `master`. The work for this PR is based off of `master`.

This pull fixes #3404 