### PR TITLE
Add support for posts without titles (fix #3408)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ fabric.properties
 ### PyCharm Patch ###
 # Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
 
-# *.iml
+*.iml
 # modules.xml
 # .idea/misc.xml
 # *.ipr

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -72,6 +72,7 @@
 * `Mario Pozzo <https://github.com/camboris>`_
 * `Mark Eichin <https://github.com/eichin>`_
 * `Martin Bless <https://github.com/marble>`_
+* `Martin McCallion <https://github.com/devilgate>`_
 * `Martin Michlmayr <https://github.com/tbm>`_
 * `Martin Wimpress <https://github.com/wimpr1m>`_
 * `Martín Gaitán <https://github.com/mgaitan>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ New in master
 Features
 --------
 
+* Support posts without titles (Issue #3408)
 * Support WebP image scaling (Issue #3399)
 * Use Luxon instead of Moment for fancy dates to make it more
   lightweight, going from 328k to 68k (Issue #3232)

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1288,3 +1288,7 @@ GLOBAL_CONTEXT = {}
 # GLOBAL_CONTEXT as parameter when the template is about to be
 # rendered
 GLOBAL_CONTEXT_FILLER = []
+
+# Add any post types here that you want to be displayed without a title.
+# Ir your theme supports it, the titles will not be shown.
+TYPES_TO_HIDE_TITLE = []

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -619,6 +619,7 @@ class Nikola(object):
             'GITHUB_COMMIT_SOURCE': False,  # WARNING: conf.py.in overrides this with True for backwards compatibility
             'META_GENERATOR_TAG': True,
             'REST_FILE_INSERTION_ENABLED': True,
+            'TYPES_TO_HIDE_TITLE': [],
         }
 
         # set global_context for template rendering

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1794,7 +1794,7 @@ class Nikola(object):
                         else:  # let other errors raise
                             raise
             args = {
-                'title': post.title(lang),
+                'title': post.title(lang) if post.should_show_title() else None,
                 'link': post.permalink(lang, absolute=True, query=feed_append_query),
                 'description': data,
                 # PyRSS2Gen's pubDate is GMT time.

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1091,12 +1091,12 @@ class Post(object):
             return ext
 
     def should_hide_title(self):
-        """Returns True if this post's title should be hidden. Use in templates to manage posts without titles."""
+        """Return True if this post's title should be hidden. Use in templates to manage posts without titles."""
         return self.title().strip() in ('NO TITLE', '') or self.meta('hidetitle') or \
             self.meta('type').strip() in self.types_to_hide_title
 
     def should_show_title(self):
-        """Returns True if this post's title should be displayed. Use in templates to manage posts without titles."""
+        """Return True if this post's title should be displayed. Use in templates to manage posts without titles."""
         return not self.should_hide_title()
 
 

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -177,6 +177,7 @@ class Post(object):
         self.translations = self.config['TRANSLATIONS']
         self.skip_untranslated = not self.config['SHOW_UNTRANSLATED_POSTS']
         self._default_preview_image = self.config['DEFAULT_PREVIEW_IMAGE']
+        self.types_to_hide_title = self.config['TYPES_TO_HIDE_TITLE']
 
     def _set_tags(self):
         """Set post tags."""
@@ -1088,6 +1089,15 @@ class Post(object):
             return '.src' + ext
         else:
             return ext
+
+    def should_hide_title(self):
+        """Returns True if this post's title should be hidden. Use in templates to manage posts without titles."""
+        return self.title().strip() in ('NO TITLE', '') or self.meta('hidetitle') or \
+            self.meta('type').strip() in self.types_to_hide_title
+
+    def should_show_title(self):
+        """Returns True if this post's title should be displayed. Use in templates to manage posts without titles."""
+        return not self.should_hide_title()
 
 
 def get_metadata_from_file(source_path, post, config, lang, metadata_extractors_by):


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Allows theme authors to hide the title on a post. This is useful if you blog like [Dave Winer](http://scripting.com) or like to create Twitter-style microblog posts.

The title will be hidden if any of the following is true:

- the post type is in a list set in the new config variable `TYPES_TO_HIDE_TITLE`;
- the title is empty;
- the title is set to 'NO TITLE';
- the metadata item `hidetitle` is set on the post.


