### PR TITLE
Fix #3427 - Remove duplicate mathjax config in bootstrap4 themes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Features
 Bugfixes
 --------
 
+* Remove duplicate MathJax config in bootstrap themes (Issue #3427)
 * Fix ``doit`` requirement to ``doit>=0.32.0`` (Issue #3422)
 
 New in v8.1.0

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -284,7 +284,8 @@ Basic
 `````
 
 title
-    Title of the post. (required)
+    Title of the post. Using HTML/math in titles is not supported/recommended.
+    (required)
 
 slug
     Slug of the post. Used as the last component of the page URL.  We recommend

--- a/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
@@ -53,7 +53,6 @@ lang="{{ lang }}">
         <link rel="next" href="{{ nextlink }}" type="text/html">
     {% endif %}
 
-    {{ mathjax_config }}
     {% if use_cdn %}
         <!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
     {% else %}

--- a/nikola/data/themes/bootblog4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4/templates/base_helper.tmpl
@@ -53,7 +53,6 @@ lang="${lang}">
         <link rel="next" href="${nextlink}" type="text/html">
     %endif
 
-    ${mathjax_config}
     %if use_cdn:
         <!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
     %else:

--- a/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
@@ -53,7 +53,6 @@ lang="{{ lang }}">
         <link rel="next" href="{{ nextlink }}" type="text/html">
     {% endif %}
 
-    {{ mathjax_config }}
     {% if use_cdn %}
         <!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
     {% else %}

--- a/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
@@ -53,7 +53,6 @@ lang="${lang}">
         <link rel="next" href="${nextlink}" type="text/html">
     %endif
 
-    ${mathjax_config}
     %if use_cdn:
         <!--[if lt IE 9]><script src="https://html5shim.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
     %else:


### PR DESCRIPTION
This is #3427. Also adds a minor doc change due to this and previous issues with HTML in titles.