### PR TITLE
Fix #3426 — allow disabling line numbers in code blocks

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,8 +7,9 @@ Features
 Bugfixes
 --------
 
-* Default to no line numbers in code listings, honor CodeHilite
-  requesting no line numbers (Issue #3426)
+* Default to no line numbers in code blocks, honor CodeHilite
+  requesting no line numbers. Listing pages still use line numbers
+  (Issue #3426)
 * Fix ``doit`` requirement to ``doit>=0.32.0`` (Issue #3422)
 
 New in v8.1.0

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ Features
 Bugfixes
 --------
 
+* Default to no line numbers in code listings, honor CodeHilite
+  requesting no line numbers (Issue #3426)
 * Fix ``doit`` requirement to ``doit>=0.32.0`` (Issue #3422)
 
 New in v8.1.0

--- a/nikola/plugins/task/listings.py
+++ b/nikola/plugins/task/listings.py
@@ -134,7 +134,9 @@ class Listings(Task):
                         except Exception:
                             lexer = TextLexer()
                         fd.seek(0)
-                    code = highlight(fd.read(), lexer, utils.NikolaPygmentsHTML(in_name))
+                    code = highlight(
+                        fd.read(), lexer,
+                        utils.NikolaPygmentsHTML(in_name, linenos='table'))
                 title = os.path.basename(in_name)
             else:
                 code = ''

--- a/nikola/utils.py
+++ b/nikola/utils.py
@@ -1629,7 +1629,11 @@ class NikolaPygmentsHTML(BetterHtmlFormatter):
                 anchor_ref, lang=LocaleBorg().current_lang, force=True)
         self.nclasses = classes
         kwargs['cssclass'] = 'code'
+        if not kwargs.get('linenos'):
+            # Default to no line numbers (Issue #3426)
+            kwargs['linenos'] = False
         if kwargs.get('linenos') not in {'table', 'inline', 'ol', False}:
+            # Map invalid values to table
             kwargs['linenos'] = 'table'
         kwargs['anchorlinenos'] = kwargs['linenos'] == 'table'
         kwargs['nowrap'] = False


### PR DESCRIPTION
This is #3426. cc @evgeni.