### PR TITLE
Fix handling of duplicate plugins on Windows

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Features
 Bugfixes
 --------
 
+* Fixed handling of duplicate plugins on Windows
+
 New in v8.1.1
 =============
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -988,6 +988,8 @@ class Nikola(object):
             for i, place in enumerate(self._plugin_places):
                 if plugin[0].startswith(place):
                     return i
+            utils.LOGGER.warn("Duplicate plugin found in unexpected location: {}".format(plugin[0]))
+            return len(self._plugin_places)
 
         plugin_dict = defaultdict(list)
         for data in plugin_list:
@@ -1025,7 +1027,7 @@ class Nikola(object):
         extra_plugins_dirs = self.config['EXTRA_PLUGINS_DIRS']
         self._plugin_places = [
             resource_filename('nikola', 'plugins'),
-            os.path.expanduser('~/.nikola/plugins'),
+            os.path.expanduser(os.path.join('~', '.nikola', 'plugins')),
             os.path.join(os.getcwd(), 'plugins'),
         ] + [path for path in extra_plugins_dirs if path]
 

--- a/nikola/plugins/command/plugin.py
+++ b/nikola/plugins/command/plugin.py
@@ -140,7 +140,7 @@ class CommandPlugin(Command):
                 user_mode = True
 
             if user_mode:
-                self.output_dir = os.path.expanduser('~/.nikola/plugins')
+                self.output_dir = os.path.expanduser(os.path.join('~', '.nikola', 'plugins'))
             else:
                 self.output_dir = 'plugins'
 


### PR DESCRIPTION
A classic slashes-vs-backslashes bug. Pathlib would have solved all of them, but it’s a bit too late for a rewrite, and I think we're doing pretty well on Windows anyway.