### PR TITLE
fix the path handlers on Windows

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -44,6 +44,7 @@
 * `Felix Fontein <https://github.com/felixfontein>`_
 * `Felix Schwarz <https://github.com/FelixSchwarz>`_
 * `Florian Finkernagel <https://github.com/TyberiusPrime>`_
+* `Florian Zimmermann <https://github.com/PoByBolek>`_
 * `follower <https://github.com/follower>`_
 * `George Leslie-Waksman <https://github.com/gwax>`_
 * `Grzegorz Śliwiński <https://github.com/fizyk>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Bugfixes
 * Fix handling of duplicate plugins on Windows
 * Allow else clause in post-list plugin. (Issue #3436)
 * Ensure `type` metadata value from plugins is preserved (Issue 3445)
+* Fix path handlers with slashes on Windows
 
 New in v8.1.1
 =============

--- a/nikola/plugins/task/authors.py
+++ b/nikola/plugins/task/authors.py
@@ -94,7 +94,8 @@ link://author_rss/joe => /authors/joe.xml""",
 
     def get_overview_path(self, lang, dest_type='page'):
         """Return a path for the list of all classifications."""
-        return [self.site.config['AUTHOR_PATH'](lang)], 'always'
+        path = self.site.config['AUTHOR_PATH'](lang)
+        return [component for component in path.split('/') if component], 'always'
 
     def get_path(self, classification, lang, dest_type='page'):
         """Return a path for the given classification."""

--- a/nikola/plugins/task/categories.py
+++ b/nikola/plugins/task/categories.py
@@ -112,9 +112,11 @@ link://category_rss/dogs => /categories/dogs.xml""",
         """Return a path for the list of all classifications."""
         if self.site.config['CATEGORIES_INDEX_PATH'](lang):
             path = self.site.config['CATEGORIES_INDEX_PATH'](lang)
-            return [_f for _f in [path] if _f], 'never'
+            append_index = 'never'
         else:
-            return [_f for _f in [self.site.config['CATEGORY_PATH'](lang)] if _f], 'always'
+            path = self.site.config['CATEGORY_PATH'](lang)
+            append_index = 'always'
+        return [component for component in path.split('/') if component], append_index
 
     def slugify_tag_name(self, name, lang):
         """Slugify a tag name."""

--- a/nikola/plugins/task/tags.py
+++ b/nikola/plugins/task/tags.py
@@ -102,9 +102,11 @@ link://tag_rss/cats => /tags/cats.xml""",
         """Return a path for the list of all classifications."""
         if self.site.config['TAGS_INDEX_PATH'](lang):
             path = self.site.config['TAGS_INDEX_PATH'](lang)
-            return [_f for _f in [path] if _f], 'never'
+            append_index = 'never'
         else:
-            return [_f for _f in [self.site.config['TAG_PATH'](lang)] if _f], 'always'
+            path = self.site.config['TAG_PATH'](lang)
+            append_index = 'always'
+        return [component for component in path.split('/') if component], append_index
 
     def get_path(self, classification, lang, dest_type='page'):
         """Return a path for the given classification."""

--- a/tests/test_path_handlers.py
+++ b/tests/test_path_handlers.py
@@ -1,0 +1,114 @@
+"""Test that CATEGORIES_INDEX_PATH and TAGS_INDEX_PATH return the correct values on Unix and Windows."""
+from unittest import mock
+
+from nikola import Nikola
+from nikola.plugins.misc.taxonomies_classifier import TaxonomiesClassifier
+from nikola.plugins.task.authors import ClassifyAuthors
+from nikola.plugins.task.categories import ClassifyCategories
+from nikola.plugins.task.tags import ClassifyTags
+from nikola.plugins.task.taxonomies import RenderTaxonomies
+
+import pytest
+
+
+@pytest.fixture(params=[ClassifyAuthors, ClassifyCategories, ClassifyTags], ids=["authors", "categories", "tags"])
+def taxonomy(request):
+    return request.param()
+
+
+@pytest.fixture(params=[
+    "base:", "base:blog", "base:path/with/trailing/slash/", "base:/path/with/leading/slash",
+    "index:tags.html", "index:blog/tags.html", "index:path/to/tags.html", "index:/path/with/leading/slash.html",
+])
+def path(request):
+    return request.param
+
+
+@pytest.fixture
+def fixture(taxonomy, path):
+    scheme, _, path = path.partition(':')
+    append_index = scheme == 'base'
+    if isinstance(taxonomy, ClassifyAuthors) and append_index:
+        site = Nikola(TRANSLATIONS={"en": ""}, AUTHOR_PATH=path)
+    elif isinstance(taxonomy, ClassifyAuthors) and not append_index:
+        pytest.skip("There is no AUTHORS_INDEX_PATH setting")
+    elif isinstance(taxonomy, ClassifyCategories) and append_index:
+        site = Nikola(TRANSLATIONS={"en": ""}, CATEGORY_PATH=path)
+    elif isinstance(taxonomy, ClassifyCategories) and not append_index:
+        site = Nikola(TRANSLATIONS={"en": ""}, CATEGORIES_INDEX_PATH=path)
+    elif isinstance(taxonomy, ClassifyTags) and append_index:
+        site = Nikola(TRANSLATIONS={"en": ""}, TAG_PATH=path)
+    elif isinstance(taxonomy, ClassifyTags) and not append_index:
+        site = Nikola(TRANSLATIONS={"en": ""}, TAGS_INDEX_PATH=path)
+    else:
+        raise TypeError("Unknown taxonomy %r" % type(taxonomy))
+
+    site._template_system = mock.MagicMock()
+    site._template_system.template_deps.return_value = []
+    site._template_system.name = "dummy"
+    site.hierarchy_per_classification = {taxonomy.classification_name: {"en": []}}
+    site.posts_per_classification = {taxonomy.classification_name: {"en": {}}}
+    site.taxonomy_plugins = {taxonomy.classification_name: taxonomy}
+
+    taxonomy.set_site(site)
+
+    classifier = TaxonomiesClassifier()
+    classifier.set_site(site)
+
+    expected = path.strip("/")
+    if append_index:
+        expected += "/"
+    if not expected.startswith("/"):
+        expected = "/" + expected
+
+    return site, classifier, taxonomy, append_index, expected
+
+
+def test_render_taxonomies_permalink(fixture):
+    # Arrange
+    site, _, taxonomy, _, expected = fixture
+    renderer = RenderTaxonomies()
+    renderer.set_site(site)
+
+    # Act
+    tasks = list(renderer._generate_classification_overview(taxonomy, "en"))
+
+    # Assert
+    action, args = tasks[0]["actions"][0]
+    context = args[2]
+    assert context["permalink"] == expected
+
+
+def test_taxonomy_index_path_helper(fixture):
+    # Arrange
+    site, _, taxonomy, _, expected = fixture
+
+    # Act
+    path = site.path(taxonomy.classification_name + "_index", "name", "en", is_link=True)
+
+    # Assert
+    assert path == expected
+
+
+def test_taxonomy_classifier_index_path(fixture):
+    # Arrange
+    site, classifier, taxonomy, append_index, expected = fixture
+    if append_index:
+        expected += "index.html"
+
+    # Act
+    path = classifier._taxonomy_index_path("name", "en", taxonomy)
+
+    # Assert
+    assert path == [x for x in expected.split('/') if x]
+
+
+def test_taxonomy_overview_path(fixture):
+    # Arrange
+    _, _, taxonomy, append_index, expected = fixture
+
+    # Act
+    result = taxonomy.get_overview_path("en")
+
+    # Assert
+    assert result == ([x for x in expected.split('/') if x], "always" if append_index else "never")


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.
- [x] I added more tests ;)

### Description

If one of the path components returned by a path handler contains a forward slash (``/``), ``os.path.normpath()`` turns that into a backward slash (``\``) on Windows.

For example, if I have set ``TAGS_INDEX_PATH`` to ``"blog/tags.html"``, then ``"link://tag_index"`` would render as ``"/blog%5Ctags.html"`` on Windows.

I *think* this is related to #2649 except that I noticed it because the ``permalink`` template variable in the taxonomy overviews contained ``"%5C"`` instead of ``"/"``.