### PR TITLE
Preserve value of type metadata from plugins. Fixes #3445

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Bugfixes
 
 * Fix handling of duplicate plugins on Windows
 * Allow else clause in post-list plugin. (Issue #3436)
+* Ensure `type` metadata value from plugins is preserved (Issue 3445)
 
 New in v8.1.1
 =============

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -243,7 +243,7 @@ class CommandNewPost(Command):
         date_path_opt = options['date-path']
         date_path_auto = self.site.config['NEW_POST_DATE_PATH'] and content_type == 'post'
         date_path_format = self.site.config['NEW_POST_DATE_PATH_FORMAT'].strip('/')
-        post_type = options['type'] if 'type' in options else 'text'
+        post_type = options.get('type', 'text')
 
         if wants_available:
             self.print_compilers()

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -243,7 +243,7 @@ class CommandNewPost(Command):
         date_path_opt = options['date-path']
         date_path_auto = self.site.config['NEW_POST_DATE_PATH'] and content_type == 'post'
         date_path_format = self.site.config['NEW_POST_DATE_PATH_FORMAT'].strip('/')
-        post_type = options['type'] if str('type') in options else 'text'
+        post_type = options['type'] if 'type' in options else 'text'
 
         if wants_available:
             self.print_compilers()

--- a/nikola/plugins/command/new_post.py
+++ b/nikola/plugins/command/new_post.py
@@ -243,6 +243,7 @@ class CommandNewPost(Command):
         date_path_opt = options['date-path']
         date_path_auto = self.site.config['NEW_POST_DATE_PATH'] and content_type == 'post'
         date_path_format = self.site.config['NEW_POST_DATE_PATH_FORMAT'].strip('/')
+        post_type = options['type'] if str('type') in options else 'text'
 
         if wants_available:
             self.print_compilers()
@@ -363,7 +364,7 @@ class CommandNewPost(Command):
             'tags': tags,
             'link': '',
             'description': '',
-            'type': 'text',
+            'type': post_type,
         }
 
         if not path:
@@ -429,7 +430,7 @@ class CommandNewPost(Command):
         else:
             compiler_plugin.create_post(
                 txt_path, content=content, onefile=onefile, title=title,
-                slug=slug, date=date, tags=tags, is_page=is_page, **metadata)
+                slug=slug, date=date, tags=tags, is_page=is_page, type=post_type, **metadata)
 
         event = dict(path=txt_path)
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Ensures that, if the `type` metadata is set by a plugin, that value is written to the post file.
