### PR TITLE
Fix #3404 — disable typogrify in title tags, restore caps filter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,12 +7,17 @@ Features
 * Add ``navbar_custom_bg`` theme option to ``bootstrap4`` and document
   options for ``bootstrap4`` better (Issue #3443)
 * Add Marathi translation
+* Restore ``caps`` typogrify filter (wraps strings of capital letters
+  with ``<span class="caps">`` (via Issue #3405)
+* Added Marathi translation
 
 Bugfixes
 --------
 
 * Ensure query strings and fragments are kept with ``URL_TYPE =
   "full_path"`` (Issue #3448)
+* Don’t run typogrify filters on ``<title>`` tag to avoid adding extra
+  tags(Issue #3405)
 * Fix handling of duplicate plugins on Windows
 * Allow else clause in post-list plugin. (Issue #3436)
 * Ensure `type` metadata value from plugins is preserved (Issue 3445)

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2289,6 +2289,9 @@ filters.typogrify
 filters.typogrify_sans_widont
    Same as typogrify without the widont filter
 
+filters.typogrify_custom
+    Run typogrify with a custom set or filters. Takes ``typogrify_filters`` (a list of callables) and ``ignore_tags`` (defaults to None).
+
 filters.minify_lines
    **THIS FILTER HAS BEEN TURNED INTO A NOOP** and currently does nothing.
 


### PR DESCRIPTION
The first part of the change makes it possible to restore the ``caps`` filter. Most typogrify filters make changes to the HTML that don’t work well with ``<title>``, so none of them apply. A relevant filter that is missing is the smartypants filter; it can be done at the input stage, or just ignored.

This supersedes #3405. cc @ncdulo.