### PR TITLE
Fix #3450 — don’t break slugs with slashes in doc directive

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,7 @@ Features
 Bugfixes
 --------
 
+* Don’t break slugs with slashes in ``doc`` directive (Issue #3450)
 * Avoid warnings from type annotations in ``auto`` caused by missing
   ``aiohttp`` (Issue #3451)
 * Ensure query strings and fragments are kept with ``URL_TYPE =


### PR DESCRIPTION
This is #3450.