### PR TITLE
Fix #3252 — add MULTIPLE_AUTHORS_PER_POST support

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Support for multiple authors per post — comma-separated, enabled by
+  ``MULTIPLE_AUTHORS_PER_POST`` setting (Issue #3252)
 * Add ``navbar_custom_bg`` theme option to ``bootstrap4`` and document
   options for ``bootstrap4`` better (Issue #3443)
 * Add Marathi translation

--- a/docs/template-variables.rst
+++ b/docs/template-variables.rst
@@ -80,6 +80,7 @@ Name                                Type                                Descript
 ``messages``                        dict<dict<str, str>>                translated messages (``{language: {english: translated}}``)
 ``meta_generator_tag``              bool                                ``META_GENERATOR_TAG`` setting
 ``momentjs_locales``                defaultdict<str, str>               dictionary of available Moment.js locales
+``multiple_authors_per_post``       bool                                ``MULTIPLE_AUTHORS_PER_POST`` setting
 ``navigation_links``                TranslatableSetting                 ``NAVIGATION_LINKS`` setting
 ``navigation_alt_links``            TranslatableSetting                 ``NAVIGATION_ALT_LINKS`` setting
 ``needs_ipython_css``               bool                                whether or not Jupyter CSS is needed by this site

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -480,6 +480,9 @@ HIDDEN_CATEGORIES = []
 # Tag pages will still be generated.
 HIDDEN_AUTHORS = ['Guest']
 
+# Allow multiple, comma-separated authors for a post? (Requires theme support, present in built-in themes)
+# MULTIPLE_AUTHORS_PER_POST = False
+
 # Final location for the main blog page and sibling paginated pages is
 # output / TRANSLATION[lang] / INDEX_PATH / index-*.html
 # (translatable)

--- a/nikola/data/themes/base/assets/css/theme.css
+++ b/nikola/data/themes/base/assets/css/theme.css
@@ -127,6 +127,9 @@ html[dir="rtl"] #toptranslations {
 .postlist li {
 	margin-bottom: .33em;
 }
+.byline a:not(:last-child):after {
+	content: ",";
+}
 
 /* Post and archive pagers */
 .postindexpager .pager .next:before {

--- a/nikola/data/themes/base/templates/index.tmpl
+++ b/nikola/data/themes/base/templates/index.tmpl
@@ -31,7 +31,11 @@
         <h1 class="p-name entry-title"><a href="${post.permalink()}" class="u-url">${post.title()|h}</a></h1>
         <div class="metadata">
             <p class="byline author vcard"><span class="byline-name fn" itemprop="author">
-            % if author_pages_generated:
+            % if author_pages_generated and multiple_authors_per_post:
+                % for author in post.authors():
+                    <a href="${_link('author', author)}">${author|h}</a>
+                % endfor
+            % elif author_pages_generated:
                 <a href="${_link('author', post.author())}">${post.author()|h}</a>
             % else:
                 ${post.author()|h}

--- a/nikola/data/themes/base/templates/post_header.tmpl
+++ b/nikola/data/themes/base/templates/post_header.tmpl
@@ -32,7 +32,11 @@
         ${html_title()}
         <div class="metadata">
             <p class="byline author vcard p-author h-card"><span class="byline-name fn p-name" itemprop="author">
-                % if author_pages_generated:
+                % if author_pages_generated and multiple_authors_per_post:
+                    % for author in post.authors():
+                        <a class="u-url" href="${_link('author', author)}">${author|h}</a>
+                    % endfor
+                % elif author_pages_generated:
                     <a class="u-url" href="${_link('author', post.author())}">${post.author()|h}</a>
                 % else:
                     ${post.author()|h}

--- a/nikola/data/themes/bootblog4/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4/templates/index.tmpl
@@ -31,7 +31,11 @@
                 <h1 class="p-name entry-title"><a href="${post.permalink()}" class="u-url">${post.title()|h}</a></h1>
                 <div class="metadata">
                     <p class="byline author vcard"><span class="byline-name fn" itemprop="author">
-                    % if author_pages_generated:
+                    % if author_pages_generated and multiple_authors_per_post:
+                        % for author in post.authors():
+                            <a href="${_link('author', author)}">${author|h}</a>
+                        % endfor
+                    % elif author_pages_generated:
                         <a href="${_link('author', post.author())}">${post.author()|h}</a>
                     % else:
                         ${post.author()|h}

--- a/nikola/data/themes/bootstrap4/assets/css/theme.css
+++ b/nikola/data/themes/bootstrap4/assets/css/theme.css
@@ -222,6 +222,10 @@ pre.code {
     white-space: pre-wrap;
 }
 
+.byline a:not(:last-child):after {
+    content: ",";
+}
+
 /* Override incorrect Bootstrap 4 default */
 html[dir="rtl"] body {
     text-align: right;

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -547,6 +547,7 @@ class Nikola(object):
             'MATHJAX_CONFIG': '',
             'METADATA_FORMAT': 'nikola',
             'METADATA_MAPPING': {},
+            'MULTIPLE_AUTHORS_PER_POST': False,
             'NEW_POST_DATE_PATH': False,
             'NEW_POST_DATE_PATH_FORMAT': '%Y/%m/%d',
             'OLD_THEME_SUPPORT': True,
@@ -1269,6 +1270,7 @@ class Nikola(object):
         self._GLOBAL_CONTEXT['smartjoin'] = utils.smartjoin
         self._GLOBAL_CONTEXT['colorize_str'] = utils.colorize_str
         self._GLOBAL_CONTEXT['meta_generator_tag'] = self.config.get('META_GENERATOR_TAG')
+        self._GLOBAL_CONTEXT['multiple_authors_per_post'] = self.config.get('MULTIPLE_AUTHORS_PER_POST')
 
         self._GLOBAL_CONTEXT.update(self.config.get('GLOBAL_CONTEXT', {}))
 

--- a/nikola/plugins/task/authors.py
+++ b/nikola/plugins/task/authors.py
@@ -73,6 +73,7 @@ link://author_rss/joe => /authors/joe.xml""",
         """Set Nikola site."""
         super().set_site(site)
         self.show_list_as_index = site.config['AUTHOR_PAGES_ARE_INDEXES']
+        self.more_than_one_classifications_per_post = site.config.get('MULTIPLE_AUTHORS_PER_POST', False)
         self.template_for_single_list = "authorindex.tmpl" if self.show_list_as_index else "author.tmpl"
         self.translation_manager = utils.ClassificationTranslationManager()
 
@@ -86,7 +87,10 @@ link://author_rss/joe => /authors/joe.xml""",
 
     def classify(self, post, lang):
         """Classify the given post for the given language."""
-        return [post.author(lang=lang)]
+        if self.more_than_one_classifications_per_post:
+            return post.authors(lang=lang)
+        else:
+            return [post.author(lang=lang)]
 
     def get_classification_friendly_name(self, classification, lang, only_last_component=False):
         """Extract a friendly name from the classification."""

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -547,7 +547,7 @@ class Post(object):
             lang = nikola.utils.LocaleBorg().current_lang
         return self.meta[lang]['title']
 
-    def author(self, lang=None):
+    def author(self, lang=None) -> str:
         """Return localized author or BLOG_AUTHOR if unspecified.
 
         If lang is not specified, it defaults to the current language from
@@ -559,6 +559,21 @@ class Post(object):
             author = self.meta[lang]['author']
         else:
             author = self.config['BLOG_AUTHOR'](lang)
+
+        return author
+
+    def authors(self, lang=None) -> list:
+        """Return localized authors or BLOG_AUTHOR if unspecified.
+
+        If lang is not specified, it defaults to the current language from
+        templates, as set in LocaleBorg.
+        """
+        if lang is None:
+            lang = nikola.utils.LocaleBorg().current_lang
+        if self.meta[lang]['author']:
+            author = [i.strip() for i in self.meta[lang]['author'].split(",")]
+        else:
+            author = [self.config['BLOG_AUTHOR'](lang)]
 
         return author
 


### PR DESCRIPTION
This is #3252. Multiple authors are enabled by a setting (`MULTIPLE_AUTHORS_PER_POST`), and require theme support (not hard to implement) to disable authors as separate links.
