### PR TITLE
Fix #3457 — add support for nbconvert>=6.0.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,7 @@ Features
 Bugfixes
 --------
 
+* Add support for ``nbconvert>=6.0.0`` (Issue #3457)
 * Don’t break slugs with slashes in ``doc`` directive (Issue #3450)
 * Avoid warnings from type annotations in ``auto`` caused by missing
   ``aiohttp`` (Issue #3451)

--- a/nikola/plugins/compile/ipynb.py
+++ b/nikola/plugins/compile/ipynb.py
@@ -31,11 +31,13 @@ import json
 import os
 
 try:
+    import nbconvert
     from nbconvert.exporters import HTMLExporter
     import nbformat
     current_nbformat = nbformat.current_nbformat
     from jupyter_client import kernelspec
     from traitlets.config import Config
+    NBCONVERT_VERSION_MAJOR = int(nbconvert.__version__.partition(".")[0])
     flag = True
 except ImportError:
     flag = None
@@ -60,7 +62,10 @@ class CompileIPynb(PageCompiler):
         c = Config(get_default_jupyter_config())
         c.merge(Config(self.site.config['IPYNB_CONFIG']))
         if 'template_file' not in self.site.config['IPYNB_CONFIG'].get('Exporter', {}):
-            c['Exporter']['template_file'] = 'basic.tpl'  # not a typo
+            if NBCONVERT_VERSION_MAJOR >= 6:
+                c['Exporter']['template_file'] = 'classic/base.html.j2'
+            else:
+                c['Exporter']['template_file'] = 'basic.tpl'  # not a typo
         exportHtml = HTMLExporter(config=c)
         body, _ = exportHtml.from_notebook_node(nb_json)
         return body


### PR DESCRIPTION
This is #3457. cc @shahinrostami.