### PR TITLE
Add support for the utterances comment system (https://utteranc.es)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,3 +1,4 @@
+* `Aaron Meurer <https://github.com/asmeurer>`_
 * `Agustin Henze <https://github.com/agustinhenze>`_
 * `Alberto Berti <https://github.com/azazel75>`_
 * `Alex Popescu <https://github.com/al3xandru>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Features
 * Improve ``nikola auto`` performance with rate-limiting, support
   ``-n`` argument to pass to ``nikola build`` (Issue #3401)
 * Added Marathi translation
+* Add support for the `Utterances <https://utteranc.es>`_ comment system.
 
 Bugfixes
 --------

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1983,6 +1983,14 @@ You can disable comments for a post by adding a "nocomments" metadata field to i
     You need jQuery, but not because Facebook wants it (see Issue
     #639).
 
+.. admonition:: Utterances Support
+
+   You can copy the configuration options from the `Utterances setup page
+   <https://utteranc.es>`_ into ``GLOBAL_CONTEXT['utterances_config']``,
+   except for ``repo``, which should be set as ``COMMENT_SYSTEM_ID``. Note
+   that the either ``issue-term`` or ``issue-number`` must be provided. All
+   other Utterances configuration options are optional.
+
 Images and Galleries
 --------------------
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1911,6 +1911,7 @@ Nikola supports several third party comment systems:
 * `Facebook <https://facebook.com/>`_
 * `Isso <https://posativ.org/isso/>`_
 * `Commento <https://github.com/adtac/commento>`_
+* `Utterances <https://utteranc.es/>`_
 
 By default it will use DISQUS, but you can change by setting ``COMMENT_SYSTEM``
 to one of "disqus", "intensedebate", "livefyre", "moot", "facebook", "isso" or "commento"
@@ -1929,9 +1930,14 @@ to one of "disqus", "intensedebate", "livefyre", "moot", "facebook", "isso" or "
    * For Isso, it's the URL of your Isso instance (must be world-accessible, encoded with
      Punycode (if using Internationalized Domain Names) and **have a trailing slash**,
      default ``http://localhost:8080/``). You can add custom config options via
-     GLOBAL_CONTEXT, eg. ``GLOBAL_CONTEXT['isso_config'] = {"require-author": "true"}``
+     ``GLOBAL_CONTEXT``, e.g., ``GLOBAL_CONTEXT['isso_config'] = {"require-author": "true"}``
    * For Commento, it's the URL of the commento instance as required by the ``serverUrl``
      parameter in commento's documentation.
+   * For Utterances, it's the **repo name** (``"org/user"``) on GitHub whose
+     issue tracker is used for comments. Additional Utterances configuration
+     values can be stored in the ``GLOBAL_CONTEXT``, e.g.,
+     ``GLOBAL_CONTEXT['utterances_config'] = {"issue-term": "title",
+     "label": "Comments", "theme": "github-light", "crossorigin": "anonymous")``.
 
 To use comments in a visible site, you should register with the service and
 then set the ``COMMENT_SYSTEM_ID`` option.

--- a/nikola/data/themes/base/templates/comments_helper.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper.tmpl
@@ -6,6 +6,7 @@
 <%namespace name="facebook" file="comments_helper_facebook.tmpl"/>
 <%namespace name="isso" file="comments_helper_isso.tmpl"/>
 <%namespace name="commento" file="comments_helper_commento.tmpl"/>
+<%namespace name="utterances" file="comments_helper_utterances.tmpl"/>
 
 <%def name="comment_form(url, title, identifier)">
     %if comment_system == 'disqus':
@@ -20,6 +21,8 @@
         ${isso.comment_form(url, title, identifier)}
     % elif comment_system == 'commento':
         ${commento.comment_form(url, title, identifier)}
+    % elif comment_system == 'utterances':
+        ${utterances.comment_form(url, title, identifier)}
     %endif
 </%def>
 
@@ -36,6 +39,8 @@
         ${isso.comment_link(link, identifier)}
     % elif comment_system == 'commento':
         ${commento.comment_link(link, identifier)}
+    % elif comment_system == 'utterances':
+        ${utterances.comment_link(link, identifier)}
     %endif
 </%def>
 
@@ -52,5 +57,7 @@
         ${isso.comment_link_script()}
     % elif comment_system == 'commento':
         ${commento.comment_link_script()}
+    % elif comment_system == 'utterances':
+        ${utterances.comment_link_script()}
     %endif
 </%def>

--- a/nikola/data/themes/base/templates/comments_helper_utterances.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper_utterances.tmpl
@@ -20,7 +20,4 @@
 
 
 <%def name="comment_link_script()">
-    %if comment_system_id and 'index' in pagekind:
-        <script src="${comment_system_id}js/count.min.js" data-utterances="${comment_system_id}" data-utterances-lang="${lang}"></script>
-    %endif
 </%def>

--- a/nikola/data/themes/base/templates/comments_helper_utterances.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper_utterances.tmpl
@@ -1,0 +1,26 @@
+## -*- coding: utf-8 -*-
+<%def name="comment_form(url, title, identifier)">
+    %if comment_system_id:
+        <div data-title="${title|h}" id="utterances-thread"></div>
+        <script src="https://utteranc.es/client.js" repo="${comment_system_id}"
+        % if utterances_config:
+        % for k, v in utterances_config.items():
+        ${k}="${v}"
+        % endfor
+        % endif
+        ></script>
+    %endif
+</%def>
+
+<%def name="comment_link(link, identifier)">
+    %if comment_system_id:
+        <a href="${link}#utterances-thread">${messages("Comments")}</a>
+    %endif
+</%def>
+
+
+<%def name="comment_link_script()">
+    %if comment_system_id and 'index' in pagekind:
+        <script src="${comment_system_id}js/count.min.js" data-utterances="${comment_system_id}" data-utterances-lang="${lang}"></script>
+    %endif
+</%def>

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -100,6 +100,7 @@ LEGAL_VALUES = {
         'isso',
         'muut',
         'commento',
+        'utterances',
     ],
     'TRANSLATIONS': {
         'af': 'Afrikaans',

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -836,6 +836,13 @@ class Nikola(object):
             utils.LOGGER.error('CATEGORY_PAGES_FOLLOW_DESTPATH requires CATEGORY_ALLOW_HIERARCHIES = True, CATEGORY_OUTPUT_FLAT_HIERARCHY = False.')
             sys.exit(1)
 
+        # The Utterances comment system has a required configuration value
+        if self.config.get('COMMENT_SYSTEM') == 'utterances':
+            utterances_config = self.config.get('GLOBAL_CONTEXT', {}).get('utterances_config', {})
+            if not ('issue-term' in utterances_config or 'issue-number' in utterances_config):
+                utils.LOGGER.error("COMMENT_SYSTEM = 'utterances' must have either GLOBAL_CONTEXT['utterances_config']['issue-term'] or GLOBAL_CONTEXT['utterances_config']['issue-term'] defined.")
+                sys.exit(1)
+
         # Handle CONTENT_FOOTER and RSS_COPYRIGHT* properly.
         # We provide the arguments to format in CONTENT_FOOTER_FORMATS and RSS_COPYRIGHT_FORMATS.
         self.config['CONTENT_FOOTER'].langformat(self.config['CONTENT_FOOTER_FORMATS'])

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -842,7 +842,6 @@ class Nikola(object):
             utterances_config = self.config.get('GLOBAL_CONTEXT', {}).get('utterances_config', {})
             if not ('issue-term' in utterances_config or 'issue-number' in utterances_config):
                 utils.LOGGER.error("COMMENT_SYSTEM = 'utterances' must have either GLOBAL_CONTEXT['utterances_config']['issue-term'] or GLOBAL_CONTEXT['utterances_config']['issue-term'] defined.")
-                sys.exit(1)
 
         # Handle CONTENT_FOOTER and RSS_COPYRIGHT* properly.
         # We provide the arguments to format in CONTENT_FOOTER_FORMATS and RSS_COPYRIGHT_FORMATS.


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [ ] I tested my changes.

### Description

Fixes #3453

There is one issue with this, which is that the configuration options for
Utterances are stored in GLOBAL_CONTEXT['utterances_config'], similar to isso,
but one configuration option is required (either issue-term or issue-number).
How can we make this error in the build if it isn't provided? Otherwise, the
only indication that it isn't working is an error in the console log.