### PR TITLE
Fix symlinks in ./setup.py build and pip on Windows

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,9 @@ Features
 Bugfixes
 --------
 
+* Also fix symlinks when installing from source with pip; if possible,
+  enable Developer Mode and run ``git config --global core.symlinks true``
+  before cloning the Nikola repo
 * Fix ``LINK_CHECK_WHITELIST`` having issues due to mixing Unicode
   and bytestrings (Issue #3466)
 * Add support for ``nbconvert>=6.0.0`` (Issue #3457)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import sys
 import shutil
 from setuptools import setup, find_packages
 from setuptools.command.install import install
+from setuptools.command.build_py import build_py
 
 
 with open('requirements.txt', 'r') as fh:
@@ -98,6 +99,12 @@ class nikola_install(install):
         install.run(self)
 
 
+class nikola_build_py(build_py):
+    def run(self):
+        expands_symlinks_for_windows()
+        build_py.run(self)
+
+
 setup(name='Nikola',
       version='8.1.1',
       description='A modular, fast, simple, static website and blog generator',
@@ -132,7 +139,7 @@ setup(name='Nikola',
       extras_require=extras,
       include_package_data=True,
       python_requires='>=3.5',
-      cmdclass={'install': nikola_install},
+      cmdclass={'install': nikola_install, 'build_py': nikola_build_py},
       data_files=[
               ('share/doc/nikola', [
                'docs/manual.rst',


### PR DESCRIPTION
This fixes symlinks when people run `./setup.py build` and `pip install .`, on Windows with symlinks disabled.

Windows users: we need this tested, with both symlinks enabled and disabled.