### PR TITLE
Fix #3471 — fix previewimages for non-server-root sites

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,8 @@ Features
 Bugfixes
 --------
 
+* Fix previewimages (post- and root-relative) in bootblog4/galleries
+  featured posts for non-server-root sites (Issue #3471)
 * Windows: Also fix symlinks when installing from source with pip; if possible,
   enable Developer Mode and run ``git config --global core.symlinks true``
   before cloning the Nikola repo

--- a/nikola/data/themes/base/templates/gallery.tmpl
+++ b/nikola/data/themes/base/templates/gallery.tmpl
@@ -21,7 +21,7 @@
             <div class="thumnbnail-container">
                 <a href="${folder}" class="thumbnail image-reference" title="${ftitle|h}">
                     % if fpost and fpost.previewimage:
-                        <img src="${url_replacer(fpost.permalink(), fpost.previewimage, lang, 'full_path')}" alt="${ftitle|h}" loading="lazy" style="max-width:${thumbnail_size}px; max-height:${thumbnail_size}px;" />
+                        <img src="${fpost.previewimage}" alt="${ftitle|h}" loading="lazy" style="max-width:${thumbnail_size}px; max-height:${thumbnail_size}px;" />
                     % else:
                         <div style="height: ${thumbnail_size}px; width: ${thumbnail_size}px; background-color: #eee;"></div>
                     % endif

--- a/nikola/data/themes/bootblog4/templates/index.tmpl
+++ b/nikola/data/themes/bootblog4/templates/index.tmpl
@@ -92,7 +92,7 @@
                         % else:
                         <div class="col-md-6 p-0 h-md-250 text-right d-none d-md-block">
                         % endif
-                            <img class="bootblog4-featured-large-image" src="${url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path')}" alt="${featured.pop(0).title()}">
+                            <img class="bootblog4-featured-large-image" src="${featured[0].previewimage}" alt="${featured.pop(0).title()}">
                         </div>
                     % else:
                         <div class="lead my-3 mb-0">${featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
@@ -117,7 +117,7 @@
                            % if featured[0].previewimage:
                                <div class="card-text mb-auto bootblog4-featured-text">${featured[0].text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
                                </div>
-                               <img class="card-img-right flex-auto d-none d-lg-block" src="${url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path')}" alt="${featured.pop(0).title()}">
+                               <img class="card-img-right flex-auto d-none d-lg-block" src="${featured[0].previewimage}" alt="${featured.pop(0).title()}">
                            % else:
                            <div class="card-text mb-auto bootblog4-featured-text">${featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
                            </div>
@@ -135,7 +135,7 @@
                            % if featured[0].previewimage:
                                <div class="card-text mb-auto bootblog4-featured-text">${featured[0].text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
                                </div>
-                               <img class="card-img-right flex-auto d-none d-lg-block" src="${url_replacer(featured[0].permalink(), featured[0].previewimage, lang, 'full_path')}" alt="${featured.pop(0).title()}">
+                               <img class="card-img-right flex-auto d-none d-lg-block" src="${featured[0].previewimage}" alt="${featured.pop(0).title()}">
                            % else:
                            <div class="card-text mb-auto bootblog4-featured-text">${featured.pop(0).text(teaser_only=True, strip_html=theme_config.get('featured_strip_html', True))}</div>
                            </div>

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1085,11 +1085,13 @@ class Post(object):
 
         image_path = self.meta[lang]['previewimage']
         if not image_path:
-            return self._default_preview_image
+            image_path = self._default_preview_image
 
-        # This is further parsed by the template, because we don’t have access
-        # to the URL replacer here.  (Issue #1473)
-        return image_path
+        if image_path.startswith("/"):
+            # Paths starting with slashes are expected to be root-relative, pass them directly.
+            return image_path
+        # Other paths are relative to the permalink. The path will be made prettier by the URL replacer later.
+        return urljoin(self.permalink(lang), image_path)
 
     def source_ext(self, prefix=False):
         """Return the source file extension.

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1087,7 +1087,7 @@ class Post(object):
         if not image_path:
             image_path = self._default_preview_image
 
-        if image_path.startswith("/"):
+        if not image_path or image_path.startswith("/"):
             # Paths starting with slashes are expected to be root-relative, pass them directly.
             return image_path
         # Other paths are relative to the permalink. The path will be made prettier by the URL replacer later.


### PR DESCRIPTION
This fixes previewimage path generation for non-server-root sites and simplifies the code for all cases.

This is #3471, cc @txels.

(There used to be a “not server root” label. Then it was removed, because we got better at it… but now, here’s a bug that this label would apply to. Although it’s my fault for overcomplicating this in the first place.)
