### PR TITLE
fixes #3479

### DIFF
--- a/nikola/plugins/command/deploy.py
+++ b/nikola/plugins/command/deploy.py
@@ -54,6 +54,8 @@ class CommandDeploy(Command):
         if last_deploy is not None:
             last_deploy = dateutil.parser.parse(last_deploy)
             clean = False
+        else:
+            clean = True
 
         if self.site.config['COMMENT_SYSTEM'] and self.site.config['COMMENT_SYSTEM_ID'] == 'nikolademo':
             self.logger.warning("\nWARNING WARNING WARNING WARNING\n"
@@ -96,6 +98,8 @@ class CommandDeploy(Command):
         self.logger.info("Successful deployment")
 
         new_deploy = datetime.utcnow()
+        if last_deploy is None:
+            last_deploy = new_deploy
         self._emit_deploy_event(last_deploy, new_deploy, clean, undeployed_posts)
 
         # Store timestamp of successful deployment


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Fixes `UnboundLocalError` for `clean` in the `deploy` command.

This exposes another related issue where `last_deploy` is `None` and passed to `_emit_deploy_event`,
which throws the exception: `AttributeError: 'NoneType' object has no attribute 'tzinfo'`

This issue affects new sites where the `last_deploy` is not yet set.

Issue is at: https://github.com/getnikola/nikola/issues/3479