### PR TITLE
Expose the full GLOBAL_CONTEXT to the post list shortcode plugin.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ New in master
 Features
 --------
 
-* Provide the full `GLOBAL_CONTEXT` to the post list shortcode plugin
+* Provide the full ``GLOBAL_CONTEXT`` to the post list shortcode plugin
   (Issue #3481)
 
 New in v8.1.2

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+New in master
+=============
+
+Features
+--------
+
+* Provide the full `GLOBAL_CONTEXT` to the post list shortcode plugin
+  (Issue #3481)
+
 New in v8.1.2
 =============
 

--- a/nikola/plugins/shortcode/post_list.py
+++ b/nikola/plugins/shortcode/post_list.py
@@ -145,6 +145,7 @@ class PostListShortcode(ShortcodePlugin):
 
         if self_post:
             self_post.register_depfile("####MAGIC####TIMELINE", lang=lang)
+            self_post.register_depfile("####MAGIC####CONFIG:GLOBAL_CONTEXT", lang=lang)
 
         # If we get strings for start/stop, make them integers
         if start is not None:

--- a/nikola/plugins/shortcode/post_list.py
+++ b/nikola/plugins/shortcode/post_list.py
@@ -227,7 +227,8 @@ class PostListShortcode(ShortcodePlugin):
             for d in template_deps:
                 self_post.register_depfile(d, lang=lang)
 
-        template_data = {
+        template_data = site.GLOBAL_CONTEXT.copy()
+        template_data.update({
             'lang': lang,
             'posts': posts,
             # Need to provide str, not TranslatableSetting (Issue #2104)
@@ -235,7 +236,7 @@ class PostListShortcode(ShortcodePlugin):
             'post_list_id': post_list_id,
             'messages': site.MESSAGES,
             '_link': site.link,
-        }
+        })
         output = site.template_system.render_template(
             template, None, template_data)
         return output, template_deps


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Expose the `GLOBAL_CONTEXT` to the post list shortcode plugin. This enables plugin templates to use functions and other external data.

Fixes #3481