### PR TITLE
Fixed broken link to cldr.unicode.org

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1662,7 +1662,7 @@ Fancy Dates
 Nikola can use various styles for presenting dates.
 
 DATE_FORMAT
-    The date format to use if there is no JS or fancy dates are off.  `Compatible with CLDR syntax. <http://cldr.unicode.org/translation/date-time>`_
+    The date format to use if there is no JS or fancy dates are off.  `Compatible with CLDR syntax. <http://cldr.unicode.org/translation/date-time-1/date-time>`_
 
 LUXON_DATE_FORMAT
     The date format to use with Luxon. A dictionary of dictionaries: the top level is languages, and the subdictionaries are of the format ``{'preset': False, 'format': 'yyyy-MM-dd HH:mm'}``. `Used by Luxon <https://moment.github.io/luxon/docs/manual/formatting>`_ (format can be the preset name, eg. ``'DATE_LONG'``).

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -195,7 +195,7 @@ TIMEZONE = ${TIMEZONE}
 # FORCE_ISO8601 = False
 
 # Date format used to display post dates. (translatable)
-# Used by babel.dates, CLDR style: http://cldr.unicode.org/translation/date-time
+# Used by babel.dates, CLDR style: http://cldr.unicode.org/translation/date-time-1/date-time
 # You can also use 'full', 'long', 'medium', or 'short'
 # DATE_FORMAT = 'yyyy-MM-dd HH:mm'
 

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -799,7 +799,7 @@ class Nikola(object):
         for val in self.config['DATE_FORMAT'].values.values():
             if '%' in val:
                 utils.LOGGER.error('The DATE_FORMAT setting needs to be upgraded.')
-                utils.LOGGER.warning("Nikola now uses CLDR-style date strings. http://cldr.unicode.org/translation/date-time")
+                utils.LOGGER.warning("Nikola now uses CLDR-style date strings. http://cldr.unicode.org/translation/date-time-1/date-time")
                 utils.LOGGER.warning("Example: %Y-%m-%d %H:%M ==> yyyy-MM-dd HH:mm")
                 utils.LOGGER.warning("(note it’s different to what moment.js uses!)")
                 sys.exit(1)


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (**Not applicable**).
- [ ] I tested my changes. (**Not applicable**)

### Description

I noticed that the link to http://cldr.unicode.org/translation/date-time present in `conf.py` was broken (404).
I used `git grep -F 'http://cldr.unicode.org/translation/date-time'` to find out where that link was referenced and fixed it (almost) everywhere.
There are still two matches but they're in `npm_assets/node_modules/luxon` and I'm not sure if I should touch that or if that's auto-generated (I'll be submitting a PR to the `luxon` project to fix the link there too).
