### PR TITLE
Accept string datetime representations for formatting.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Features
 
 * Provide the full ``GLOBAL_CONTEXT`` to the post list shortcode plugin
   (Issue #3481)
+* Accept and parse string datetime representations passed to
+  ``post.formatted_date()``
 
 New in v8.1.2
 =============

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -531,6 +531,16 @@ class Post(object):
 
     def formatted_date(self, date_format, date=None):
         """Return the formatted date as string."""
+        if isinstance(date, str):
+            try:
+                date = to_datetime(date, self.config['__tzinfo__'])
+            except ValueError:
+                if not date:
+                    msg = 'Missing date in file {}'.format(self.source_path)
+                else:
+                    msg = "Invalid date '{0}' in file {1}".format(date, self.source_path)
+                LOGGER.error(msg)
+                raise ValueError(msg)
         return utils.LocaleBorg().formatted_date(date_format, date if date else self.date)
 
     def formatted_updated(self, date_format):


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

This addresses an issue that I asked about on the mailing list, but received no response from the community about.

`post.formatted_date()` accepts an optional second argument that allows one to format an arbitrary date. This is very convenient for template authors. However, If attempting to render custom post metadata fields, there is currently no way to convert the parsed `post.meta('fieldname')` value to a datetime for formatting.  I see two possible solutions:

1. Create a `post.parse_datetime(dt: str) -> datetime` method
2. Update the existing `post.formatted_date()` method to support strings.

I opted for the latter, here, because it feels more intuitive from the templating perspective.