### PR TITLE
Add NIKOLA_LOG_FORMAT & NIKOLA_LOG_TIME_FORMAT environment variables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,8 @@ Features
   by specifying a dict of ``{".extension": [options]}`` (Issue #3492)
 * Allow boolean/integer ``pretty_url`` post meta values in YAML/TOML
   (Issue #3503)
+* Add ``NIKOLA_LOG_FORMAT`` & ``NIKOLA_LOG_TIME_FORMAT`` environment
+  variables to configure the logging format
 
 Bugfixes
 --------

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -3141,6 +3141,12 @@ To show more logging messages, as well as full tracebacks, you need to set an
 environment variable: ``NIKOLA_DEBUG=1``. If you want to only see tracebacks,
 set ``NIKOLA_SHOW_TRACEBACKS=1``.
 
+Log Format
+~~~~~~~~~~
+
+The format of log messages can be configured via ``NIKOLA_LOG_FORMAT`` & ``NIKOLA_LOG_TIME_FORMAT``
+environment variables.
+
 Shell Tab Completion
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/nikola/log.py
+++ b/nikola/log.py
@@ -28,6 +28,7 @@
 
 import enum
 import logging
+from os import getenv
 import warnings
 
 from nikola import DEBUG
@@ -103,8 +104,8 @@ def configure_logging(logging_mode: LoggingMode = LoggingMode.NORMAL) -> None:
     handler = logging.StreamHandler()
     handler.setFormatter(
         ColorfulFormatter(
-            fmt="[%(asctime)s] %(levelname)s: %(name)s: %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
+            fmt=getenv('NIKOLA_LOG_FORMAT', "[%(asctime)s] %(levelname)s: %(name)s: %(message)s"),
+            datefmt=getenv('NIKOLA_LOG_TIME_FORMAT', "%Y-%m-%d %H:%M:%S"),
         )
     )
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Add `NIKOLA_LOG_FORMAT` & `NIKOLA_LOG_TIME_FORMAT` environment variables to configure the logging format.

Inspired by some plugin debugging where I needed to see millisecond timestamps and the process ids during auto builds.