### PR TITLE
Fix #3510 — fix time zone guessing in init (handle gettz returning None)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ New in v8.1.2
 Features
 --------
 
+* Fix time zone guessing logic in ``nikola init`` (Issue #3510)
 * Support for multiple authors per post — comma-separated, enabled by
   ``MULTIPLE_AUTHORS_PER_POST`` setting (Issue #3252)
 * Add ``navbar_custom_bg`` theme option to ``bootstrap4`` and document

--- a/nikola/packages/tzlocal/unix.py
+++ b/nikola/packages/tzlocal/unix.py
@@ -116,8 +116,9 @@ def _get_localzone(_root="/"):
         while start != 0:
             tzpath = tzpath[start:]
             try:
-                dateutil.tz.gettz(tzpath)
-                return tzpath
+                tested_tz = dateutil.tz.gettz(tzpath)
+                if tested_tz:
+                    return tzpath
             except Exception:
                 pass
             start = tzpath.find("/") + 1


### PR DESCRIPTION
This is #3510.