### PR TITLE
New 'auto_command_starting' signal when 'nikola auto' is starting.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+New in master
+=============
+
+Features
+--------
+
+* New ``auto_command_starting`` signal when ``nikola auto`` is
+  starting
+
 New in v8.1.3
 =============
 

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -149,7 +149,7 @@ class CommandAuto(Command):
             req_missing(['aiohttp'], 'use the "auto" command')
         elif Observer is None:
             req_missing(['watchdog'], 'use the "auto" command')
-            
+
         blinker.signal('auto_command_starting').send(self.site)
 
         if sys.argv[0].endswith('__main__.py'):

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -136,9 +136,8 @@ class CommandAuto(Command):
     ]
 
     def _execute(self, options, args):
-        blinker.signal('auto_command_starting').send(self.site)
-
         """Start the watcher."""
+
         self.sockets = []
         self.rebuild_queue = asyncio.Queue()
         self.reload_queue = asyncio.Queue()
@@ -151,6 +150,8 @@ class CommandAuto(Command):
             req_missing(['aiohttp'], 'use the "auto" command')
         elif Observer is None:
             req_missing(['watchdog'], 'use the "auto" command')
+            
+        blinker.signal('auto_command_starting').send(self.site)
 
         if sys.argv[0].endswith('__main__.py'):
             self.nikola_cmd = [sys.executable, '-m', 'nikola', 'build']

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -137,7 +137,6 @@ class CommandAuto(Command):
 
     def _execute(self, options, args):
         """Start the watcher."""
-
         self.sockets = []
         self.rebuild_queue = asyncio.Queue()
         self.reload_queue = asyncio.Queue()

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -37,6 +37,7 @@ import sys
 import typing
 import webbrowser
 
+import blinker
 import pkg_resources
 
 from nikola.plugin_categories import Command
@@ -135,6 +136,8 @@ class CommandAuto(Command):
     ]
 
     def _execute(self, options, args):
+        blinker.signal('auto_command_starting').send(self.site)
+
         """Start the watcher."""
         self.sockets = []
         self.rebuild_queue = asyncio.Queue()


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

When adding support for the PlantUML PicoWeb server (getnikola/plugins#378) I would like `nikola auto` to start one PicoWeb server and share it with all child build processes.  So the `plantuml` plugin needs to know when `nikola auto` is happening.

The simplest solution I've thought of is a new `auto_command_starting` signal but perhaps something like these more generic solutions would be preferred?
*  A new `command_starting` signal including command name as a param
* `BasePlugin.get_command_name()`

(Haven't looked closely if either of those is actually possible)