### PR TITLE
Add math CSS class to typogrify ignores

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,12 @@ Features
 * New ``auto_command_starting`` signal when ``nikola auto`` is
   starting
 
+Bugfixes
+--------
+
+* Typogrify ignores ``div`` elements with ``.math`` CSS class.
+  (Issue #3512)
+
 New in v8.1.3
 =============
 

--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -269,7 +269,7 @@ def minify_lines(data):
 def _run_typogrify(data, typogrify_filters, ignore_tags=None):
     """Run typogrify with ignore support."""
     if ignore_tags is None:
-        ignore_tags = ["title"]
+        ignore_tags = ["title", ".math"]
 
     data = _normalize_html(data)
 


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description

The styling of div elements with the math class is handled by the math
formatter (MathJax or katex), so typogrify should not interefere.

Fixes #3512.
