### PR TITLE
Add default list of filters for typogrify_custom

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,11 @@ Features
 
 * New ``auto_command_starting`` signal when ``nikola auto`` is
   starting
+* ``typogrify_custom`` filter adds a default value for
+  ``typogrify_filters`` so that ``ignore_tags`` can be specified
+  as the only option.
+* The default ``ignore_tags`` are appended to the user-supplied
+  ``ignore_tags`` added via ``typogrify_custom``.
 
 Bugfixes
 --------

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2301,23 +2301,25 @@ filters.typogrify_sans_widont
    Same as typogrify without the widont filter
 
 filters.typogrify_custom
-    Run typogrify with a custom set of filters or ignored tags. Takes ``typogrify_filters``
-    (a list of callables) or ``ignore_tags`` (a list of HTML tags to ignore). These must be
-    specified as keyword arguments to ``functools.partial``. The following code should be
+    Run typogrify with a custom set of filters or ignored HTML elements. Takes one or
+    both of the arguments ``typogrify_filters`` or ``ignore_tags``. ``typogrify_filters``
+    must be a list of typogrify filter callables to run. ``ignore_tags`` must be a list
+    of strings specifying HTML tags, CSS classes (prefixed with ``.``), tag ``id`` names
+    (prefixed with ``#``), or a tag and a class or id. The following code should be
     placed in ``conf.py``.
 
     .. code-block:: python
 
       from nikola.filters import typogrify_custom
-      from functools import partial as ft_partial
+      import functools
       # This filter will ignore HTML elements with the CSS class "typo-ignore"
       FILTERS = {
-        ".html": [ft_partial(typogrify_custom, ignore_tags=[".typo-ignore"])]
+        ".html": [functools.partial(typogrify_custom, ignore_tags=[".typo-ignore"])]
       }
       # Alternatively, to specify ``typogrify_filters``
       import typogrify.filters as typo
       FILTERS = {
-        ".html": [ft_partial(typogrify_custom, typogrify_filters=[typo.amp])]
+        ".html": [functools.partial(typogrify_custom, typogrify_filters=[typo.amp])]
       }
 
     The default value for ``typogrify_filters`` is

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2301,7 +2301,31 @@ filters.typogrify_sans_widont
    Same as typogrify without the widont filter
 
 filters.typogrify_custom
-    Run typogrify with a custom set or filters. Takes ``typogrify_filters`` (a list of callables) and ``ignore_tags`` (defaults to None).
+    Run typogrify with a custom set of filters or ignored tags. Takes ``typogrify_filters``
+    (a list of callables) or ``ignore_tags`` (a list of HTML tags to ignore). These must be
+    specified as keyword arguments to ``functools.partial``. The following code should be
+    placed in ``conf.py``.
+
+    .. code-block:: python
+
+      from nikola.filters import typogrify_custom
+      from functools import partial as ft_partial
+      # This filter will ignore HTML elements with the CSS class "typo-ignore"
+      FILTERS = {
+        ".html": [ft_partial(typogrify_custom, ignore_tags=[".typo-ignore"])]
+      }
+      # Alternatively, to specify ``typogrify_filters``
+      import typogrify.filters as typo
+      FILTERS = {
+        ".html": [ft_partial(typogrify_custom, typogrify_filters=[typo.amp])]
+      }
+
+    The default value for ``typogrify_filters`` is
+    ``[typo.amp, typo.widont, typo.smartypants, typo.caps, typo.initial_quotes]`` and the
+    default value for ``ignore_tags`` is ``["title", ".math"]``. If ``ignore_tags`` is
+    specified, the default tags will be appended to the supplied list. See the
+    `documentation <https://github.com/mintchaos/typogrify/blob/master/typogrify/filters.py#L8-L14>`__
+    for the ``process_ignores`` function in typogrify.
 
 filters.minify_lines
    **THIS FILTER HAS BEEN TURNED INTO A NOOP** and currently does nothing.

--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -272,7 +272,7 @@ def _run_typogrify(data, typogrify_filters, ignore_tags=None):
     if ignore_tags is None:
         ignore_tags = default_ignore_tags
     else:
-        ignore_tags.extend(default_ignore_tags)
+        ignore_tags = ignore_tags + default_ignore_tags
 
     data = _normalize_html(data)
 

--- a/nikola/filters.py
+++ b/nikola/filters.py
@@ -268,8 +268,11 @@ def minify_lines(data):
 
 def _run_typogrify(data, typogrify_filters, ignore_tags=None):
     """Run typogrify with ignore support."""
+    default_ignore_tags = ["title", ".math"]
     if ignore_tags is None:
-        ignore_tags = ["title", ".math"]
+        ignore_tags = default_ignore_tags
+    else:
+        ignore_tags.extend(default_ignore_tags)
 
     data = _normalize_html(data)
 
@@ -328,11 +331,13 @@ def typogrify_sans_widont(data):
 
 
 @apply_to_text_file
-def typogrify_custom(data, typogrify_filters, ignore_tags=None):
-    """Run typogrify with a custom list of fliter functions."""
+def typogrify_custom(data, typogrify_filters=None, ignore_tags=None):
+    """Run typogrify with a custom list of filter functions."""
     if typo is None:
         req_missing(['typogrify'], 'use the typogrify filter', optional=True)
         return data
+    if typogrify_filters is None:
+        typogrify_filters = [typo.amp, typo.widont, typo.smartypants, typo.caps, typo.initial_quotes]
     return _run_typogrify(data, typogrify_filters, ignore_tags)
 
 


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description

Per discussion on #3512, this implements a default list of filters for `typogrify_custom`. This allows specifying only the ignore_tags option. It also adds documentation for the `typogrify_custom` filter using `functools.partial`.