### PR TITLE
Fix #3535 — correctly handle blank values in WordPress export meta fields

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,8 @@ Bugfixes
 --------
 
 * Support passing ``--backend`` and ``--db-file`` to ``nikola auto``
+* Support blank values in certain WordPress-imported structures
+  (Issue #3535)
 * Typogrify ignores ``div`` elements with ``.math`` CSS class.
   (Issue #3512)
 

--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -582,6 +582,11 @@ to
                         def add(our_key, wp_key, is_int=False, ignore_zero=False, is_float=False):
                             if wp_key in image_meta:
                                 value = image_meta[wp_key]
+                                if value in ("", b"") and (is_int or is_float):
+                                    if ignore_zero:
+                                        return
+                                    else:
+                                        dst_meta[our_key] = 0
                                 if is_int:
                                     value = int(value)
                                     if ignore_zero and value == 0:

--- a/tests/data/wordpress_import/wordpress_export_example.xml
+++ b/tests/data/wordpress_import/wordpress_export_example.xml
@@ -53,7 +53,7 @@
         </wp:postmeta>
         <wp:postmeta>
             <wp:meta_key>_wp_attachment_metadata</wp:meta_key>
-            <wp:meta_value><![CDATA[a:6:{s:5:"width";s:3:"300";s:6:"height";s:3:"299";s:14:"hwstring_small";s:22:"height='96' width='96'";s:4:"file";s:38:"2008/07/arzt_und_pfusch-sick-cover.png";s:5:"sizes";a:1:{s:9:"thumbnail";a:3:{s:4:"file";s:38:"arzt_und_pfusch-sick-cover-150x150.png";s:5:"width";s:3:"150";s:6:"height";s:3:"150";}}s:10:"image_meta";a:10:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:1:"0";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";}}]]></wp:meta_value>
+            <wp:meta_value><![CDATA[a:6:{s:5:"width";s:3:"300";s:6:"height";s:3:"299";s:14:"hwstring_small";s:22:"height='96' width='96'";s:4:"file";s:38:"2008/07/arzt_und_pfusch-sick-cover.png";s:5:"sizes";a:1:{s:9:"thumbnail";a:3:{s:4:"file";s:38:"arzt_und_pfusch-sick-cover-150x150.png";s:5:"width";s:3:"150";s:6:"height";s:3:"150";}}s:10:"image_meta";a:10:{s:8:"aperture";s:1:"0";s:6:"credit";s:0:"";s:6:"camera";s:0:"";s:7:"caption";s:0:"";s:17:"created_timestamp";s:0:"";s:9:"copyright";s:0:"";s:12:"focal_length";s:1:"0";s:3:"iso";s:1:"0";s:13:"shutter_speed";s:1:"0";s:5:"title";s:0:"";}}]]></wp:meta_value>
         </wp:postmeta>
     </item>
 


### PR DESCRIPTION
This is #3535. cc @varna9000.