### PR TITLE
Add Cactus Comments as a comments system

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -101,6 +101,7 @@
 * `Paul Ivanov <https://github.com/ivanov>`_
 * `Pelle Nilsson <https://github.com/pellenilsson>`_
 * `phora <https://github.com/phora>`_
+* `Pieter David <https://github.com/pieterdavid>`_
 * `Pierpaolo Da Fieno <https://github.com/numshub>`_
 * `pmav99 <https://github.com/pmav99>`_
 * `Puneeth Chaganti <https://github.com/punchagan>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Features
   as the only option.
 * The default ``ignore_tags`` are appended to the user-supplied
   ``ignore_tags`` added via ``typogrify_custom``.
+* Add [Cactus Comments](https://cactus.chat) as a comments system
 
 Bugfixes
 --------

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1915,6 +1915,7 @@ Nikola supports several third party comment systems:
 * `Isso <https://posativ.org/isso/>`_
 * `Commento <https://github.com/adtac/commento>`_
 * `Utterances <https://utteranc.es/>`_
+* `Cactus <https://cactus.chat/>`_
 
 By default it will use DISQUS, but you can change by setting ``COMMENT_SYSTEM``
 to one of "disqus", "intensedebate", "livefyre", "moot", "facebook", "isso" or "commento"
@@ -1941,6 +1942,10 @@ to one of "disqus", "intensedebate", "livefyre", "moot", "facebook", "isso" or "
      values can be stored in the ``GLOBAL_CONTEXT``, e.g.,
      ``GLOBAL_CONTEXT['utterances_config'] = {"issue-term": "title",
      "label": "Comments", "theme": "github-light", "crossorigin": "anonymous")``.
+   * For Cactus Comments, it's the unique identifier used to register your site
+     with a Cactus Comments Application Service, whose address should be stored in
+     the ``GLOBAL_CONTEXT``, e.g.
+     ``GLOBAL_CONTEXT['cactus_config'] = {"serverName": "cactus.chat", "defaultHomeserverUrl": "https://matrix.cactus.chat:8448"}``
 
 To use comments in a visible site, you should register with the service and
 then set the ``COMMENT_SYSTEM_ID`` option.

--- a/nikola/data/themes/base-jinja/templates/comments_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper.tmpl
@@ -7,6 +7,13 @@
 {% import 'comments_helper_isso.tmpl' as isso with context %}
 {% import 'comments_helper_commento.tmpl' as commento with context %}
 {% import 'comments_helper_utterances.tmpl' as utterances with context %}
+{% import 'comments_helper_cactus.tmpl' as cactus with context %}
+
+{% macro comment_extra_head() %}
+    {% if comment_system == 'cactus' %}
+        {{ cactus.comment_extra_head() }}
+    {% endif %}
+{% endmacro %}
 
 {% macro comment_form(url, title, identifier) %}
     {% if comment_system == 'disqus' %}
@@ -23,6 +30,8 @@
         {{ commento.comment_form(url, title, identifier) }}
     {% elif comment_system == 'utterances' %}
         {{ utterances.comment_form(url, title, identifier) }}
+    {% elif comment_system == 'cactus' %}
+        {{ cactus.comment_form(url, title, identifier) }}
     {% endif %}
 {% endmacro %}
 
@@ -41,6 +50,8 @@
         {{ commento.comment_link(link, identifier) }}
     {% elif comment_system == 'utterances' %}
         {{ utterances.comment_link(link, identifier) }}
+    {% elif comment_system == 'cactus' %}
+        {{ cactus.comment_link(link, identifier) }}
     {% endif %}
 {% endmacro %}
 
@@ -59,5 +70,7 @@
         {{ commento.comment_link_script() }}
     {% elif comment_system == 'utterances' %}
         {{ utterances.comment_link_script() }}
+    {% elif comment_system == 'cactus' %}
+        {{ cactus.comment_link_script() }}
     {% endif %}
 {% endmacro %}

--- a/nikola/data/themes/base-jinja/templates/comments_helper_cactus.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper_cactus.tmpl
@@ -1,0 +1,34 @@
+{#  -*- coding: utf-8 -*- #}
+{% macro comment_extra_head() %}
+{% if comment_system_id %}
+<script type="text/javascript" src="https://latest.cactus.chat/cactus.js"></script>
+<link rel="stylesheet" href="https://latest.cactus.chat/style.css" type="text/css">
+{% endif %}
+{% endmacro %}
+
+{% macro comment_form(url, title, identifier) %}
+{% if comment_system_id %}
+<div id="comment-section"></div>
+<script>
+initComments({
+  node: document.getElementById("comment-section"),
+  {% if cactus_config %}
+  {% for k, v in cactus_config.items() %}
+  {{ k }}: "{{ v }}",
+  {% endfor %}
+  {% endif %}
+  siteName: "{{ comment_system_id }}",
+  commentSectionId: "{{ title|slugify }}"
+})
+</script>
+{% endif %}
+{% endmacro %}
+
+{% macro comment_link(link, identifier) %}
+{% if comment_system_id %}
+<a href="{{ link }}#comment-section">{{ messages("Comments") }}</a>
+{% endif %}
+{% endmacro %}
+
+{% macro comment_link_script() %}
+{% endmacro %}

--- a/nikola/data/themes/base-jinja/templates/post.tmpl
+++ b/nikola/data/themes/base-jinja/templates/post.tmpl
@@ -24,6 +24,7 @@
     {{ helper.twitter_card_information(post) }}
     {{ helper.meta_translations(post) }}
     {{ math.math_styles_ifpost(post) }}
+    {{ comments.comment_extra_head() }}
 {% endblock %}
 
 {% block content %}

--- a/nikola/data/themes/base/templates/comments_helper.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper.tmpl
@@ -7,6 +7,13 @@
 <%namespace name="isso" file="comments_helper_isso.tmpl"/>
 <%namespace name="commento" file="comments_helper_commento.tmpl"/>
 <%namespace name="utterances" file="comments_helper_utterances.tmpl"/>
+<%namespace name="cactus" file="comments_helper_cactus.tmpl"/>
+
+<%def name="comment_extra_head()">
+    % if comment_system == 'cactus':
+        ${cactus.comment_extra_head()}
+    % endif
+</%def>
 
 <%def name="comment_form(url, title, identifier)">
     %if comment_system == 'disqus':
@@ -23,6 +30,8 @@
         ${commento.comment_form(url, title, identifier)}
     % elif comment_system == 'utterances':
         ${utterances.comment_form(url, title, identifier)}
+    % elif comment_system == 'cactus':
+        ${cactus.comment_form(url, title, identifier)}
     %endif
 </%def>
 
@@ -41,6 +50,8 @@
         ${commento.comment_link(link, identifier)}
     % elif comment_system == 'utterances':
         ${utterances.comment_link(link, identifier)}
+    % elif comment_system == 'cactus':
+        ${cactus.comment_link(link, identifier)}
     %endif
 </%def>
 
@@ -59,5 +70,7 @@
         ${commento.comment_link_script()}
     % elif comment_system == 'utterances':
         ${utterances.comment_link_script()}
+    % elif comment_system == 'cactus':
+        ${cactus.comment_link_script()}
     %endif
 </%def>

--- a/nikola/data/themes/base/templates/comments_helper_cactus.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper_cactus.tmpl
@@ -1,0 +1,38 @@
+## -*- coding: utf-8 -*-
+<%def name="comment_extra_head()">
+%if comment_system_id:
+<script type="text/javascript" src="https://latest.cactus.chat/cactus.js"></script>
+<link rel="stylesheet" href="https://latest.cactus.chat/style.css" type="text/css">
+%endif
+</%def>
+
+<%def name="comment_form(url, title, identifier)">
+%if comment_system_id:
+<div id="comment-section"></div>
+<%
+import nikola.utils
+post_slug = nikola.utils.slugify(title)
+%>
+<script>
+initComments({
+  node: document.getElementById("comment-section"),
+  % if cactus_config:
+  % for k, v in cactus_config.items():
+  ${k}: "${v}",
+  % endfor
+  % endif
+  siteName: "${comment_system_id}",
+  commentSectionId: "${post_slug}"
+})
+</script>
+%endif
+</%def>
+
+<%def name="comment_link(link, identifier)">
+%if comment_system_id:
+<a href="${link}#comment-section">${messages("Comments")}</a>
+%endif
+</%def>
+
+<%def name="comment_link_script()">
+</%def>

--- a/nikola/data/themes/base/templates/post.tmpl
+++ b/nikola/data/themes/base/templates/post.tmpl
@@ -24,6 +24,7 @@
     ${helper.twitter_card_information(post)}
     ${helper.meta_translations(post)}
     ${math.math_styles_ifpost(post)}
+    ${comments.comment_extra_head()}
 </%block>
 
 <%block name="content">

--- a/nikola/data/themes/bootstrap4-jinja/templates/post.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/post.tmpl
@@ -25,6 +25,7 @@
     {{ helper.twitter_card_information(post) }}
     {{ helper.meta_translations(post) }}
     {{ math.math_styles_ifpost(post) }}
+    {{ comments.comment_extra_head() }}
 {% endblock %}
 
 {% block content %}

--- a/nikola/data/themes/bootstrap4/templates/post.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/post.tmpl
@@ -25,6 +25,7 @@
     ${helper.twitter_card_information(post)}
     ${helper.meta_translations(post)}
     ${math.math_styles_ifpost(post)}
+    ${comments.comment_extra_head()}
 </%block>
 
 <%block name="content">

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -101,6 +101,7 @@ LEGAL_VALUES = {
         'muut',
         'commento',
         'utterances',
+        'cactus'
     ],
     'TRANSLATIONS': {
         'af': 'Afrikaans',
@@ -839,11 +840,15 @@ class Nikola(object):
             utils.LOGGER.error('CATEGORY_PAGES_FOLLOW_DESTPATH requires CATEGORY_ALLOW_HIERARCHIES = True, CATEGORY_OUTPUT_FLAT_HIERARCHY = False.')
             sys.exit(1)
 
-        # The Utterances comment system has a required configuration value
+        # The Utterances and Cactus comment systems have required configuration values
         if self.config.get('COMMENT_SYSTEM') == 'utterances':
             utterances_config = self.config.get('GLOBAL_CONTEXT', {}).get('utterances_config', {})
             if not ('issue-term' in utterances_config or 'issue-number' in utterances_config):
                 utils.LOGGER.error("COMMENT_SYSTEM = 'utterances' must have either GLOBAL_CONTEXT['utterances_config']['issue-term'] or GLOBAL_CONTEXT['utterances_config']['issue-term'] defined.")
+        if self.config.get('COMMENT_SYSTEM') == 'cactus':
+            cactus_config = self.config.get('GLOBAL_CONTEXT', {}).get('cactus_config', {})
+            if not all(ky in cactus_config for ky in ("serverName", "defaultHomeserverUrl")):
+                utils.LOGGER.error("COMMENT_SYSTEM = 'cactus' must have GLOBAL_CONTEXT['cactus_config']['serverName'] and GLOBAL_CONTEXT['cactus_config']['defaultHomeserverUrl'] defined.")
 
         # Handle CONTENT_FOOTER and RSS_COPYRIGHT* properly.
         # We provide the arguments to format in CONTENT_FOOTER_FORMATS and RSS_COPYRIGHT_FORMATS.

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -31,7 +31,7 @@ import json
 import os
 
 from nikola.plugin_categories import TemplateSystem
-from nikola.utils import makedirs, req_missing, sort_posts, _smartjoin_filter
+from nikola.utils import makedirs, req_missing, sort_posts, _smartjoin_filter, slugify
 
 try:
     import jinja2
@@ -66,6 +66,7 @@ class JinjaTemplates(TemplateSystem):
         self.lookup.filters['tojson'] = json.dumps
         self.lookup.filters['sort_posts'] = sort_posts
         self.lookup.filters['smartjoin'] = _smartjoin_filter
+        self.lookup.filters['slugify'] = slugify
         self.lookup.globals['enumerate'] = enumerate
         self.lookup.globals['isinstance'] = isinstance
         self.lookup.globals['tuple'] = tuple


### PR DESCRIPTION
Fixes https://github.com/getnikola/nikola/issues/3542

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes: tests pass, and I tried the new system with the bootstrap4 and bootstrap4-ninja themes (it's also working on [my personal blog](https://pieterdavid.github.io/posts/welcome/#comment-section))

### Description

I tried to follow the same approach as the other comments systems as much as possible, but including the script and stylesheet in `comment_link_script` didn't work, so I added a new `comment_extra_head` macro that should be included in the `extra_head` block for templates to support this.
The `COMMENT_SYSTEM_ID` should the be site name passed to the Cactus Comments service; since the latter could be self-hosted I put that in `GLOBAL_CONTEXT["cactus_config"]`. They could also be put together in `COMMENT_SYSTEM_ID`, but then the template needs to split that again.
For the page ID (which becomes part of the Matrix room name) I used `utils.slugify(title)` because I didn't see an easy way to get the slug from the template.
I'm not very familiar with web development, the template engines, or the Nikola codebase, so please let me know if there are better solutions.