### PR TITLE
Allow adding comment systems from plugins

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -102,6 +102,7 @@
 * `Pelle Nilsson <https://github.com/pellenilsson>`_
 * `phora <https://github.com/phora>`_
 * `Pierpaolo Da Fieno <https://github.com/numshub>`_
+* `Pieter David <https://github.com/pieterdavid>`_
 * `pmav99 <https://github.com/pmav99>`_
 * `Puneeth Chaganti <https://github.com/punchagan>`_
 * `pwm1234 <https://github.com/pwm1234>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,7 @@ Features
 * The default ``ignore_tags`` are appended to the user-supplied
   ``ignore_tags`` added via ``typogrify_custom``.
 * Allow adding comment systems from a plugin (Issue #3544)
+* New ``CommentSystem`` plugin category (Issue #3544)
 
 Bugfixes
 --------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,6 +11,7 @@ Features
   as the only option.
 * The default ``ignore_tags`` are appended to the user-supplied
   ``ignore_tags`` added via ``typogrify_custom``.
+* Allow adding comment systems from a plugin
 
 Bugfixes
 --------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,7 +11,7 @@ Features
   as the only option.
 * The default ``ignore_tags`` are appended to the user-supplied
   ``ignore_tags`` added via ``typogrify_custom``.
-* Allow adding comment systems from a plugin
+* Allow adding comment systems from a plugin (Issue #3544)
 
 Bugfixes
 --------

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -492,6 +492,14 @@ Does nothing specific, can be used to modify the site object (and thus the confi
 Put all the magic you want in ``set_site()``, and don’t forget to run the one
 from ``super()``. Example plugin: `navstories <https://github.com/getnikola/plugins/tree/master/v7/navstories>`__
 
+
+CommentSystem Plugins
+---------------------
+
+Can be used to add a new comment system. (It doesn’t do anything by itself.) It’s expected to provide templates named ``comment_helper_foo.tmpl``.
+
+Example plugin: `cactuscomments <https://github.com/getnikola/plugins/tree/master/v8/cactuscomments>`__
+
 Shortcode Plugins
 -----------------
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1918,6 +1918,8 @@ Nikola supports several third party comment systems:
 
 By default it will use DISQUS, but you can change by setting ``COMMENT_SYSTEM``
 to one of "disqus", "intensedebate", "livefyre", "moot", "facebook", "isso" or "commento"
+It is also possible to use a comment system added by a plugin, see the
+`Cactus Comments plugin <https://plugins.getnikola.com/#cactuscomments>`_ for an example.
 
 .. sidebar:: ``COMMENT_SYSTEM_ID``
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1917,7 +1917,7 @@ Nikola supports several third party comment systems:
 * `Utterances <https://utteranc.es/>`_
 
 By default it will use DISQUS, but you can change by setting ``COMMENT_SYSTEM``
-to one of "disqus", "intensedebate", "livefyre", "moot", "facebook", "isso" or "commento"
+to one of "disqus", "intensedebate", "livefyre", "moot", "facebook", "isso", "commento" or "utterances".
 It is also possible to use a comment system added by a plugin, see the
 `Cactus Comments plugin <https://plugins.getnikola.com/#cactuscomments>`_ for an example.
 

--- a/nikola/data/themes/base-jinja/templates/comments_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper.tmpl
@@ -1,63 +1,15 @@
 {#  -*- coding: utf-8 -*- #}
 
-{% import 'comments_helper_disqus.tmpl' as disqus with context %}
-{% import 'comments_helper_intensedebate.tmpl' as intensedebate with context %}
-{% import 'comments_helper_muut.tmpl' as muut with context %}
-{% import 'comments_helper_facebook.tmpl' as facebook with context %}
-{% import 'comments_helper_isso.tmpl' as isso with context %}
-{% import 'comments_helper_commento.tmpl' as commento with context %}
-{% import 'comments_helper_utterances.tmpl' as utterances with context %}
+{% import 'comments_helper_%s.tmpl' % comment_system as comment_system_impl with context %}
 
 {% macro comment_form(url, title, identifier) %}
-    {% if comment_system == 'disqus' %}
-        {{ disqus.comment_form(url, title, identifier) }}
-    {% elif comment_system == 'intensedebate' %}
-        {{ intensedebate.comment_form(url, title, identifier) }}
-    {% elif comment_system == 'muut' %}
-        {{ muut.comment_form(url, title, identifier) }}
-    {% elif comment_system == 'facebook' %}
-        {{ facebook.comment_form(url, title, identifier) }}
-    {% elif comment_system == 'isso' %}
-        {{ isso.comment_form(url, title, identifier) }}
-    {% elif comment_system == 'commento' %}
-        {{ commento.comment_form(url, title, identifier) }}
-    {% elif comment_system == 'utterances' %}
-        {{ utterances.comment_form(url, title, identifier) }}
-    {% endif %}
+    {{ comment_system_impl.comment_form(url, title, identifier) }}
 {% endmacro %}
 
 {% macro comment_link(link, identifier) %}
-    {% if comment_system == 'disqus' %}
-        {{ disqus.comment_link(link, identifier) }}
-    {% elif comment_system == 'intensedebate' %}
-        {{ intensedebate.comment_link(link, identifier) }}
-    {% elif comment_system == 'muut' %}
-        {{ muut.comment_link(link, identifier) }}
-    {% elif comment_system == 'facebook' %}
-        {{ facebook.comment_link(link, identifier) }}
-    {% elif comment_system == 'isso' %}
-        {{ isso.comment_link(link, identifier) }}
-    {% elif comment_system == 'commento' %}
-        {{ commento.comment_link(link, identifier) }}
-    {% elif comment_system == 'utterances' %}
-        {{ utterances.comment_link(link, identifier) }}
-    {% endif %}
+    {{ comment_system_impl.comment_link(link, identifier) }}
 {% endmacro %}
 
 {% macro comment_link_script() %}
-    {% if comment_system == 'disqus' %}
-        {{ disqus.comment_link_script() }}
-    {% elif comment_system == 'intensedebate' %}
-        {{ intensedebate.comment_link_script() }}
-    {% elif comment_system == 'muut' %}
-        {{ muut.comment_link_script() }}
-    {% elif comment_system == 'facebook' %}
-        {{ facebook.comment_link_script() }}
-    {% elif comment_system == 'isso' %}
-        {{ isso.comment_link_script() }}
-    {% elif comment_system == 'commento' %}
-        {{ commento.comment_link_script() }}
-    {% elif comment_system == 'utterances' %}
-        {{ utterances.comment_link_script() }}
-    {% endif %}
+    {{ comment_system_impl.comment_link_script() }}
 {% endmacro %}

--- a/nikola/data/themes/base-jinja/templates/comments_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper.tmpl
@@ -1,15 +1,15 @@
 {#  -*- coding: utf-8 -*- #}
 
-{% import 'comments_helper_%s.tmpl' % comment_system as comment_system_impl with context %}
+{% import 'comments_helper_%s.tmpl' % comment_system as comments_helper_impl with context %}
 
 {% macro comment_form(url, title, identifier) %}
-    {{ comment_system_impl.comment_form(url, title, identifier) }}
+    {{ comments_helper_impl.comment_form(url, title, identifier) }}
 {% endmacro %}
 
 {% macro comment_link(link, identifier) %}
-    {{ comment_system_impl.comment_link(link, identifier) }}
+    {{ comments_helper_impl.comment_link(link, identifier) }}
 {% endmacro %}
 
 {% macro comment_link_script() %}
-    {{ comment_system_impl.comment_link_script() }}
+    {{ comments_helper_impl.comment_link_script() }}
 {% endmacro %}

--- a/nikola/data/themes/base/templates/comments_helper.tmpl
+++ b/nikola/data/themes/base/templates/comments_helper.tmpl
@@ -1,63 +1,15 @@
 ## -*- coding: utf-8 -*-
 
-<%namespace name="disqus" file="comments_helper_disqus.tmpl"/>
-<%namespace name="intensedebate" file="comments_helper_intensedebate.tmpl"/>
-<%namespace name="muut" file="comments_helper_muut.tmpl"/>
-<%namespace name="facebook" file="comments_helper_facebook.tmpl"/>
-<%namespace name="isso" file="comments_helper_isso.tmpl"/>
-<%namespace name="commento" file="comments_helper_commento.tmpl"/>
-<%namespace name="utterances" file="comments_helper_utterances.tmpl"/>
+<%namespace name="comments_helper_impl" file="comments_helper_${context['comment_system']}.tmpl"/>
 
 <%def name="comment_form(url, title, identifier)">
-    %if comment_system == 'disqus':
-        ${disqus.comment_form(url, title, identifier)}
-    % elif comment_system == 'intensedebate':
-        ${intensedebate.comment_form(url, title, identifier)}
-    % elif comment_system == 'muut':
-        ${muut.comment_form(url, title, identifier)}
-    % elif comment_system == 'facebook':
-        ${facebook.comment_form(url, title, identifier)}
-    % elif comment_system == 'isso':
-        ${isso.comment_form(url, title, identifier)}
-    % elif comment_system == 'commento':
-        ${commento.comment_form(url, title, identifier)}
-    % elif comment_system == 'utterances':
-        ${utterances.comment_form(url, title, identifier)}
-    %endif
+    ${comments_helper_impl.comment_form(url, title, identifier)}
 </%def>
 
 <%def name="comment_link(link, identifier)">
-    %if comment_system == 'disqus':
-        ${disqus.comment_link(link, identifier)}
-    % elif comment_system == 'intensedebate':
-        ${intensedebate.comment_link(link, identifier)}
-    % elif comment_system == 'muut':
-        ${muut.comment_link(link, identifier)}
-    % elif comment_system == 'facebook':
-        ${facebook.comment_link(link, identifier)}
-    % elif comment_system == 'isso':
-        ${isso.comment_link(link, identifier)}
-    % elif comment_system == 'commento':
-        ${commento.comment_link(link, identifier)}
-    % elif comment_system == 'utterances':
-        ${utterances.comment_link(link, identifier)}
-    %endif
+    ${comments_helper_impl.comment_link(link, identifier)}
 </%def>
 
 <%def name="comment_link_script()">
-    %if comment_system == 'disqus':
-        ${disqus.comment_link_script()}
-    % elif comment_system == 'intensedebate':
-        ${intensedebate.comment_link_script()}
-    % elif comment_system == 'muut':
-        ${muut.comment_link_script()}
-    % elif comment_system == 'facebook':
-        ${facebook.comment_link_script()}
-    % elif comment_system == 'isso':
-        ${isso.comment_link_script()}
-    % elif comment_system == 'commento':
-        ${commento.comment_link_script()}
-    % elif comment_system == 'utterances':
-        ${utterances.comment_link_script()}
-    %endif
+    ${comments_helper_impl.comment_link_script()}
 </%def>

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -1668,7 +1668,7 @@ class Nikola(object):
                 context[k] = context[k](context['lang'])
             output = self.template_system.render_template_to_string(t_data, context)
             if fname is not None:
-                dependencies = [fname] + self.template_system.get_deps(fname)
+                dependencies = [fname] + self.template_system.get_deps(fname, context)
             else:
                 dependencies = []
             return output, dependencies
@@ -1709,7 +1709,7 @@ class Nikola(object):
         for k in self._GLOBAL_CONTEXT_TRANSLATABLE:
             context[k] = context[k](context['lang'])
         output = self.template_system.render_template_to_string(t_data, context)
-        dependencies = self.template_system.get_string_deps(t_data)
+        dependencies = self.template_system.get_string_deps(t_data, context)
         return output, dependencies
 
     def register_shortcode(self, name, f):
@@ -2264,8 +2264,10 @@ class Nikola(object):
         """
         utils.LocaleBorg().set_locale(lang)
 
+        template_dep_context = context.copy()
+        template_dep_context.update(self.GLOBAL_CONTEXT)
         file_deps = copy(file_deps) if file_deps else []
-        file_deps += self.template_system.template_deps(template_name)
+        file_deps += self.template_system.template_deps(template_name, template_dep_context)
         file_deps = sorted(list(filter(None, file_deps)))
 
         context = copy(context) if context else {}

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -66,6 +66,7 @@ from .plugin_categories import (
     TemplateSystem,
     SignalHandler,
     ConfigPlugin,
+    CommentSystem,
     PostScanner,
     Taxonomy,
 )
@@ -1029,6 +1030,7 @@ class Nikola(object):
             "ShortcodePlugin": ShortcodePlugin,
             "SignalHandler": SignalHandler,
             "ConfigPlugin": ConfigPlugin,
+            "CommentSystem": CommentSystem,
             "PostScanner": PostScanner,
             "Taxonomy": Taxonomy,
         })
@@ -1172,7 +1174,8 @@ class Nikola(object):
             self.compilers[plugin_info.name] = \
                 plugin_info.plugin_object
 
-        # Load config plugins and register templated shortcodes
+        # Load comment systems, config plugins and register templated shortcodes
+        self._activate_plugins_of_category("CommentSystem")
         self._activate_plugins_of_category("ConfigPlugin")
         self._register_templated_shortcodes()
 

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -94,7 +94,7 @@ class BasePlugin(IPlugin):
         """Add 'dependency' to the target task's task_deps."""
         self.site.injected_deps[target].append(dependency)
 
-    def get_deps(self, filename):
+    def get_deps(self, filename, context=None):
         """Find the dependencies for a file."""
         return []
 
@@ -222,15 +222,15 @@ class TemplateSystem(BasePlugin):
         """Set the list of folders where templates are located and cache."""
         raise NotImplementedError()
 
-    def template_deps(self, template_name: str):
+    def template_deps(self, template_name: str, context=None):
         """Return filenames which are dependencies for a template."""
         raise NotImplementedError()
 
-    def get_deps(self, filename: str):
+    def get_deps(self, filename: str, context=None):
         """Return paths to dependencies for the template loaded from filename."""
         raise NotImplementedError()
 
-    def get_string_deps(self, text: str):
+    def get_string_deps(self, text: str, context=None):
         """Find dependencies for a template string."""
         raise NotImplementedError()
 

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -475,6 +475,12 @@ class ConfigPlugin(BasePlugin):
     name = "dummy_config_plugin"
 
 
+class CommentSystem(BasePlugin):
+    """A plugn that offers a new comment system."""
+
+    name = "dummy_comment_system"
+
+
 class ShortcodePlugin(BasePlugin):
     """A plugin that adds a shortcode."""
 

--- a/nikola/plugins/shortcode/post_list.py
+++ b/nikola/plugins/shortcode/post_list.py
@@ -219,7 +219,7 @@ class PostListShortcode(ShortcodePlugin):
 
             posts += [post]
 
-        template_deps = site.template_system.template_deps(template)
+        template_deps = site.template_system.template_deps(template, site.GLOBAL_CONTEXT)
         if state:
             # Register template as a dependency (Issue #2391)
             for d in template_deps:

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -307,10 +307,13 @@ class Galleries(Task, ImageProcessor):
                     context['post'] = post
                 else:
                     context['post'] = None
+
+                template_dep_context = context.copy()
+                template_dep_context.update(self.site.GLOBAL_CONTEXT)
                 file_dep = self.site.template_system.template_deps(
-                    template_name) + image_list + thumbs
+                    template_name, template_dep_context) + image_list + thumbs
                 file_dep_dest = self.site.template_system.template_deps(
-                    template_name) + dest_img_list + thumbs
+                    template_name, template_dep_context) + dest_img_list + thumbs
                 if post:
                     file_dep += [post.translated_base_path(l) for l in self.kw['translations']]
                     file_dep_dest += [post.translated_base_path(l) for l in self.kw['translations']]

--- a/nikola/plugins/task/listings.py
+++ b/nikola/plugins/task/listings.py
@@ -179,7 +179,7 @@ class Listings(Task):
 
         yield self.group_task()
 
-        template_deps = self.site.template_system.template_deps('listing.tmpl')
+        template_deps = self.site.template_system.template_deps('listing.tmpl', self.site.GLOBAL_CONTEXT)
 
         for input_folder, output_folder in self.kw['listings_folders'].items():
             for root, dirs, files in os.walk(input_folder, followlinks=True):

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -31,7 +31,7 @@ import json
 import os
 
 from nikola.plugin_categories import TemplateSystem
-from nikola.utils import makedirs, req_missing, sort_posts, _smartjoin_filter
+from nikola.utils import makedirs, req_missing, slugify, sort_posts, _smartjoin_filter
 
 try:
     import jinja2
@@ -66,6 +66,7 @@ class JinjaTemplates(TemplateSystem):
         self.lookup.filters['tojson'] = json.dumps
         self.lookup.filters['sort_posts'] = sort_posts
         self.lookup.filters['smartjoin'] = _smartjoin_filter
+        self.lookup.filters['slugify'] = slugify
         self.lookup.globals['enumerate'] = enumerate
         self.lookup.globals['isinstance'] = isinstance
         self.lookup.globals['tuple'] = tuple

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -35,6 +35,7 @@ from nikola.utils import makedirs, req_missing, slugify, sort_posts, _smartjoin_
 
 try:
     import jinja2
+    import jinja2.nodes
     from jinja2 import meta
 except ImportError:
     jinja2 = None
@@ -105,29 +106,35 @@ class JinjaTemplates(TemplateSystem):
         """Render template to a string using context."""
         return self.lookup.from_string(template).render(**context)
 
-    def get_string_deps(self, text):
+    def get_string_deps(self, text, context=None):
         """Find dependencies for a template string."""
         deps = set([])
         ast = self.lookup.parse(text)
-        dep_names = [d for d in meta.find_referenced_templates(ast) if d]
+        simple_dep_names = [d for d in meta.find_referenced_templates(ast) if d]
+        formatted_dep_names = [
+            imp.template.left.value % (context[imp.template.right.name],)
+            for imp in ast.find_all(jinja2.nodes.Import)
+            if isinstance(imp.template, jinja2.nodes.Mod)
+        ]
+        dep_names = simple_dep_names + formatted_dep_names
         for dep_name in dep_names:
             filename = self.lookup.loader.get_source(self.lookup, dep_name)[1]
-            sub_deps = [filename] + self.get_deps(filename)
+            sub_deps = [filename] + self.get_deps(filename, context)
             self.dependency_cache[dep_name] = sub_deps
             deps |= set(sub_deps)
         return list(deps)
 
-    def get_deps(self, filename):
+    def get_deps(self, filename, context=None):
         """Return paths to dependencies for the template loaded from filename."""
         with io.open(filename, 'r', encoding='utf-8-sig') as fd:
             text = fd.read()
-        return self.get_string_deps(text)
+        return self.get_string_deps(text, context)
 
-    def template_deps(self, template_name):
+    def template_deps(self, template_name, context=None):
         """Generate list of dependencies for a template."""
         if self.dependency_cache.get(template_name) is None:
             filename = self.lookup.loader.get_source(self.lookup, template_name)[1]
-            self.dependency_cache[template_name] = [filename] + self.get_deps(filename)
+            self.dependency_cache[template_name] = [filename] + self.get_deps(filename, context)
         return self.dependency_cache[template_name]
 
     def get_template_path(self, template_name):

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -61,11 +61,11 @@ class MakoTemplates(TemplateSystem):
         for n in lex.template.nodes:
             keyword = getattr(n, 'keyword', None)
             if keyword in ["inherit", "namespace"] or isinstance(n, parsetree.IncludeTag):
-                if n.attributes["file"] == n.parsed_attributes["file"].strip("'"):
-                    deps.append(n.attributes['file'])
+                if ( n.attributes.get('name') == "comments_helper_impl" and
+                        n.attributes["file"] != n.parsed_attributes["file"].strip("'") ):
+                    pass # comment system loading, ignore dependency for now
                 else:
-                    LOGGER.warning("Ignoring file=%s for template string dependencies in %s",
-                                   n.attributes["file"], filename)
+                    deps.append(n.attributes['file'])
         # Some templates will include "foo.tmpl" and we need paths, so normalize them
         # using the template lookup
         for i, d in enumerate(deps):

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -61,7 +61,11 @@ class MakoTemplates(TemplateSystem):
         for n in lex.template.nodes:
             keyword = getattr(n, 'keyword', None)
             if keyword in ["inherit", "namespace"] or isinstance(n, parsetree.IncludeTag):
-                deps.append(n.attributes['file'])
+                if n.attributes["file"] == n.parsed_attributes["file"].strip("'"):
+                    deps.append(n.attributes['file'])
+                else:
+                    LOGGER.warning("Ignoring file=%s for template string dependencies in %s",
+                                   n.attributes["file"], filename)
         # Some templates will include "foo.tmpl" and we need paths, so normalize them
         # using the template lookup
         for i, d in enumerate(deps):

--- a/nikola/plugins/template/mako.py
+++ b/nikola/plugins/template/mako.py
@@ -61,9 +61,9 @@ class MakoTemplates(TemplateSystem):
         for n in lex.template.nodes:
             keyword = getattr(n, 'keyword', None)
             if keyword in ["inherit", "namespace"] or isinstance(n, parsetree.IncludeTag):
-                if ( n.attributes.get('name') == "comments_helper_impl" and
-                        n.attributes["file"] != n.parsed_attributes["file"].strip("'") ):
-                    pass # comment system loading, ignore dependency for now
+                if (n.attributes.get('name') == "comments_helper_impl" and
+                        n.attributes["file"] != n.parsed_attributes["file"].strip("'")):
+                    pass  # comment system loading, ignore dependency for now
                 else:
                     deps.append(n.attributes['file'])
         # Some templates will include "foo.tmpl" and we need paths, so normalize them


### PR DESCRIPTION
Closes https://github.com/getnikola/nikola/issues/3544

I had a look at how https://github.com/getnikola/nikola/issues/3544 could be implemented. Since all existing (and probably most future) comment systems implement the same interface with `comments_helper_<comment_system>.tmpl`, the key change is to load the file corresponding to the comment_system configuration option, rather than comparing to a fixed list.
Then it is sufficient for templates to provide `comments_helper_<system>.tmpl` for both template engines (see e.g. https://github.com/getnikola/plugins/pull/381), and the existing systems work without changes.
There are at least two things that need to be improved in this PR (hence the WIP status):
- the dependency detection code in the mako plugin cannot handle expressions in the "file" attribute (while it is supported for rendering). I put an if-statement that ignores such dependencies (with a warning), which seems to work, but is almost certainly not the proper solution.
- I added the slugify filter for jinja, which is an unrelated change (but could be useful, I can make it a separate PR if that's preferred), because adding it to TEMPLATE_FILTERS from the plugin seemed not to work (maybe I missed something)

Any help or feedback on these two points, or on the approach in general, would be much appreciated.