### PR TITLE
Use --delete-after in suggested rsync commands

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -570,7 +570,7 @@ REDIRECTIONS = ${REDIRECTIONS}
 
 # Presets of commands to execute to deploy. Can be anything, for
 # example, you may use rsync:
-# "rsync -rav --delete output/ joe@my.site:/srv/www/site"
+# "rsync -rav --delete --delete-after output/ joe@my.site:/srv/www/site"
 # And then do a backup, or run `nikola ping` from the `ping`
 # plugin (`nikola plugin -i ping`).  Or run `nikola check -l`.
 # You may also want to use github_deploy (see below).
@@ -580,7 +580,7 @@ REDIRECTIONS = ${REDIRECTIONS}
 # in a `nikola deploy` command as you like.
 # DEPLOY_COMMANDS = {
 #     'default': [
-#         "rsync -rav --delete output/ joe@my.site:/srv/www/site",
+#         "rsync -rav --delete --delete-after output/ joe@my.site:/srv/www/site",
 #     ]
 # }
 


### PR DESCRIPTION
Use of `--delete` will cause files to be deleted at the beginning of the rsync by default which causes files to disappear temporarily from the site.

This is bad in itself (you get 404s temporarily), and if anything goes wrong (network breaks during deploy) the 404s become more permanent. We can avoid this using `--delete-after`. I have discovered all this the hard way!

### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

