### PR TITLE
Fix #3569: Add missing helper in `base-jinja` theme for dummy comment system

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -22,6 +22,7 @@
 * `Christian Lawson-Perfect <https://github.com/christianp>`_
 * `Christopher Arndt <https:/github.com/SpotlightKid>`_
 * `Claudio Canepa <https://github.com/ccanepa>`_
+* `Clayton A. Davis <https://github.com/clayadavis>`_
 * `Damien Tournoud <https://github.com/damz>`_
 * `Damián Avila <https://github.com/damianavila>`_
 * `Daniel Aleksandersen <https://github.com/Aeyoun>`_

--- a/nikola/data/themes/base-jinja/templates/comments_helper_dummy.tmpl
+++ b/nikola/data/themes/base-jinja/templates/comments_helper_dummy.tmpl
@@ -1,0 +1,10 @@
+{#  -*- coding: utf-8 -*- #}
+
+{% macro comment_form(url, title, identifier) %}
+{% endmacro %}
+
+{% macro comment_link(link, identifier) %}
+{% endmacro %}
+
+{% macro comment_link_script() %}
+{% endmacro %}


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Fixes the issue in #3569 by adding a missing template helper present in the Mako `base` template.
