### PR TITLE
Aspect ratio for panoramas to >3:1, documentation

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -55,6 +55,7 @@
 * `Hardening <https://github.com/hardening>`_
 * `Hong Xu <https://www.topbug.net>`_
 * `Ivan Teoh <https://github.com/ivanteoh>`_
+* `Jesper Dramsch <https://github.com/jesperdramsch>`_
 * `John Kristensen <https://github.com/jerrykan>`_
 * `Jonathon Anderson <https://github.com/anderbubble>`_
 * `Joshua Barratt <https://github.com/jbarratt>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,7 @@ Bugfixes
   (Issue #3535)
 * Typogrify ignores ``div`` elements with ``.math`` CSS class.
   (Issue #3512)
+* Adjust panorama aspect ratio to 3:1 and document behaviour.
 
 New in v8.1.3
 =============

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -769,6 +769,7 @@ GALLERIES_DEFAULT_THUMBNAIL = None
 # options, but will have to be referenced manually to be visible on the site
 # (the thumbnail has ``.thumbnail`` added before the file extension by default,
 # but a different naming template can be configured with IMAGE_THUMBNAIL_FORMAT).
+# Panoramas (aspect ratio over 3:1) get 4x larger thumbnails due to scaling issues.
 
 IMAGE_FOLDERS = {'images': 'images'}
 # IMAGE_THUMBNAIL_SIZE = 400

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -142,7 +142,7 @@ class ImageProcessor(object):
             if w > max_size or h > max_size:
                 size = max_size, max_size
                 # Panoramas get larger thumbnails because they look *awful*
-                if bigger_panoramas and w > 2 * h:
+                if bigger_panoramas and w > 3 * h:
                     size = min(w, max_size * 4), min(w, max_size * 4)
             try:
                 im.thumbnail(size, Image.ANTIALIAS)
@@ -189,7 +189,7 @@ class ImageProcessor(object):
                 # calculate new size preserving aspect ratio.
                 ratio = float(w) / h
                 # Panoramas get larger thumbnails because they look *awful*
-                if bigger_panoramas and w > 2 * h:
+                if bigger_panoramas and w > 3 * h:
                     max_size = max_size * 4
                 if w > h:
                     w = max_size


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
Addresses #3586
Adjusted panorama aspect ratio for larger thumbnail generation to 3:1 instead of 2:1 and document behaviour in conf.py.in.