### PR TITLE
Revert "Patch for invalid pygments links (pygments/pygments#2013)"

### DIFF
--- a/nikola/packages/pygments_better_html/__init__.py
+++ b/nikola/packages/pygments_better_html/__init__.py
@@ -239,17 +239,3 @@ class BetterHtmlFormatter(HtmlFormatter):
 
         for t, piece in source:
             outfile.write(piece)
-
-    # FIXME patch for broken code in pygments 2.11.0/2.11.1 - remove when
-    # Pygments PR #2014 merged
-    def _wrap_lineanchors(self, inner):
-        s = self.lineanchors
-        # subtract 1 since we have to increment i *before* yielding
-        i = self.linenostart - 1
-        for t, line in inner:
-            if t:
-                i += 1
-                href = "" if self.linenos else ' href="#%s-%d"' % (s, i)
-                yield 1, '<a id="%s-%d" name="%s-%d"%s></a>' % (s, i, s, i, href) + line
-            else:
-                yield 0, line


### PR DESCRIPTION
This reverts commit 84444572529f368c515113dd517e223c9c3a0d54.

### Pull Request Checklist

- [ ] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [ ] I tested my changes.

### Description
