### PR TITLE
Status support for galleries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+New in master
+=============
+
+Features
+--------
+
+* Gallery index pages support the `status` flag (Issue #3598)
+
+
 New in v8.2.0
 =============
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2089,8 +2089,11 @@ The ``conf.py`` options affecting images and gallery pages are these:
 
 If you add a reST file in ``galleries/gallery_name/index.txt`` its contents will be
 converted to HTML and inserted above the images in the gallery page. The
-format is the same as for posts. You can use the ``title`` and ``previewimage``
-metadata fields to change how the gallery is shown.
+format is the same as for posts. You can use the ``title``, ``previewimage``, and
+``status`` metadata fields to change how the gallery is shown.
+
+If the ``status`` is ``private``, ``draft``, or ``publish_later``, the
+gallery will not appear in the index, the RSS feeds, nor in the sitemap.
 
 If you add some image filenames in ``galleries/gallery_name/exclude.meta``, they
 will be excluded in the gallery page.

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -85,6 +85,7 @@ class Galleries(Task, ImageProcessor):
             'exif_whitelist': site.config['EXIF_WHITELIST'],
             'preserve_icc_profiles': site.config['PRESERVE_ICC_PROFILES'],
             'index_path': site.config['INDEX_PATH'],
+            'index_file': site.config['INDEX_FILE'],
             'disable_indexes': site.config['DISABLE_INDEXES'],
             'galleries_use_thumbnail': site.config['GALLERIES_USE_THUMBNAIL'],
             'galleries_default_thumbnail': site.config['GALLERIES_DEFAULT_THUMBNAIL'],
@@ -522,6 +523,9 @@ class Galleries(Task, ImageProcessor):
                     post.meta[lang]['title'] = os.path.split(gallery)[1]
             # Register the post (via #2417)
             self.site.post_per_input_file[index_path] = post
+            # Register post for the sitemap, too (#3598)
+            index_output = os.path.join(gallery, self.kw['index_file'])
+            self.site.post_per_file[index_output] = post
         else:
             post = None
         return post

--- a/nikola/plugins/task/galleries.py
+++ b/nikola/plugins/task/galleries.py
@@ -271,6 +271,10 @@ class Galleries(Task, ImageProcessor):
                 for path, folder in folder_list:
                     fpost = self.parse_index(path, input_folder, output_folder)
                     if fpost:
+                        # do not add galleries to the folders that are either
+                        # of these states (#3598)
+                        if fpost.is_draft or fpost.is_private or fpost.publish_later:
+                            continue
                         ft = fpost.title(lang) or folder
                     else:
                         ft = folder


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated ~~AUTHORS.txt and~~ CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

The index files of galleries may contain a `status:` flag. Values `private`, `draft`, and `publish_later` result in exclusion of that gallery in the index, RSS, and sitemap creation.
