### PR TITLE
Add data file to dependency file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,11 @@ Features
 * Add ``start_at`` option to youtube directive (Issue #3603)
 
 
+Bugfixes
+--------
+
+* Add data files to dependency file (Issue #3608)
+
 New in v8.2.0
 =============
 

--- a/nikola/post.py
+++ b/nikola/post.py
@@ -324,6 +324,7 @@ class Post(object):
         for lang in self.translations:
             if self.meta[lang].get('data') is not None:
                 self.data[lang] = utils.load_data(self.meta[lang]['data'])
+                self.register_depfile(self.meta[lang]['data'], lang=lang)
 
     def _load_translated_metadata(self, default_metadata):
         """Load metadata from all translation sources."""


### PR DESCRIPTION
When using a data attribute for loading external data from a file, this data
file is added to the dependency file.
Changing the content of the data file now triggers a rebuild of the pages and
posts which are including it.

Signed-off-by: Andreas Brinner <andreas@everlanes.net>

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes. 

### Description

I tested with my own site and confirmed that the dependencies were added correctly.