### PR TITLE
Don't add a semicolon in docinfo fields using CSS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Bugfixes
 --------
 
 * Find substring in string instead of using `contains` in utils
+* Don't add semicolon in docinfo fields via CSS (caused duplicated
+  semicolons)
 
 New in v8.2.2
 =============

--- a/nikola/data/themes/base/assets/css/rst_base.css
+++ b/nikola/data/themes/base/assets/css/rst_base.css
@@ -123,11 +123,6 @@ dl.option-list > dd > *:first-child
   width: 100%;
   margin: 0;
 }
-/* field names followed by a colon */
-dl.field-list > dt:after,
-dl.docinfo > dt:after {
-  content: ":";
-}
 
 /* Bibliographic Fields (docinfo) */
 dl.docinfo pre.address {


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
