### PR TITLE
mdx_gist: inherit from InlineProcessor, work on Python 3.11 (#3630)

### DIFF
--- a/nikola/plugins/compile/markdown/mdx_gist.py
+++ b/nikola/plugins/compile/markdown/mdx_gist.py
@@ -140,10 +140,8 @@ class GistPattern(InlineProcessor):
         return resp.text
 
     def handleMatch(self, m, _):
-        """
-        Handle pattern match. The third arg is "data", wider
-        context around the match; we don't need it.
-        """
+        """Handle pattern match."""
+        # The third arg is "data", wider context around the match; we don't need it.
         gist_id = m.group('gist_id')
         gist_file = m.group('filename')
 

--- a/nikola/plugins/compile/markdown/mdx_gist.py
+++ b/nikola/plugins/compile/markdown/mdx_gist.py
@@ -82,13 +82,13 @@ from nikola.utils import get_logger
 
 try:
     from markdown.extensions import Extension
-    from markdown.inlinepatterns import Pattern
+    from markdown.inlinepatterns import InlineProcessor
     from markdown.util import AtomicString
     from markdown.util import etree
 except ImportError:
     # No need to catch this, if you try to use this without Markdown,
     # the markdown compiler will fail first
-    Extension = Pattern = object
+    Extension = InlineProcessor = object
 
 
 LOGGER = get_logger('compile_markdown.mdx_gist')
@@ -112,12 +112,12 @@ class GistFetchException(Exception):
             status_code, url)
 
 
-class GistPattern(Pattern):
+class GistPattern(InlineProcessor):
     """InlinePattern for footnote markers in a document's body text."""
 
     def __init__(self, pattern, configs):
         """Initialize the pattern."""
-        Pattern.__init__(self, pattern)
+        InlineProcessor.__init__(self, pattern)
 
     def get_raw_gist_with_filename(self, gist_id, filename):
         """Get raw gist text for a filename."""
@@ -139,8 +139,11 @@ class GistPattern(Pattern):
 
         return resp.text
 
-    def handleMatch(self, m):
-        """Handle pattern match."""
+    def handleMatch(self, m, _):
+        """
+        Handle pattern match. The third arg is "data", wider
+        context around the match; we don't need it.
+        """
         gist_id = m.group('gist_id')
         gist_file = m.group('filename')
 
@@ -170,7 +173,7 @@ class GistPattern(Pattern):
             warning_comment = etree.Comment(' WARNING: {0} '.format(e.message))
             noscript_elem.append(warning_comment)
 
-        return gist_elem
+        return (gist_elem, m.start(0), m.end(0))
 
 
 class GistExtension(MarkdownExtension, Extension):


### PR DESCRIPTION
The gist-rst pattern crashes Python 3.11, because its pattern
tries to set the multiline flag - it starts with `(?m)` - but
Markdown's `Pattern` class `__init__`, which is called by our
`GistPattern.__init__`, 'wraps' the pattern with additional
capture groups before compiling it. This causes the multiline
flag not to be at the start of the 'wrapped' pattern. From
Python 3.6 to Python 3.10 flags not being at the start of the
pattern was deprecated and triggered a warning when trying to
compile it; in Python 3.11 it's an error.

Markdown 3.0.0 added a preferred `InlineProcessor` class:
https://github.com/Python-Markdown/markdown/pull/629
which does not do this wrapping. It requires the subclass to
implement `handleMatch`, which we already do. Our `handleMatch`
uses named capture groups, so the change in the number of
capture groups in the compiled expression shouldn't matter. So
simply switching to inheriting from `InlineProcessor` instead
of `Pattern` should solve the problem.

We already required Markdown 3.0.0, so this does not mean we
require a newer Markdown than before.

Signed-off-by: Adam Williamson <awilliam@redhat.com>

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [-] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Change seems fairly trivial and should not be visible to users, so I didn't bother with AUTHORS and CHANGES. I've 'tested' this insofar as nikola now at least passes its own test suite with Python 3.11 (it did not before); the test suite does not seem to cover this file, so I don't think we'll know if it's broken, but I don't think it should be.