### PR TITLE
doc: Small additions linking templates/themes to demo site.

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -22,6 +22,8 @@ After you have Nikola `installed <https://getnikola.com/getting-started.html>`_:
 Create an empty site (with a setup wizard):
     ``nikola init mysite``
 
+    .. _demo site:
+
     You can create a site with demo files in it with ``nikola init --demo mysite``
 
     The rest of these commands have to be executed inside the new ``mysite`` folder.
@@ -1596,6 +1598,10 @@ CSS tweaking
 .. _Sass: https://sass-lang.com/
 
 Template tweaking and creating themes
+    For tweaking an existing template or adding new ones,
+    you can put the respective file under ``templates/``.
+    The `demo site`_ provides an example.
+
     If you really want to change the pages radically, you will want to do a
     :doc:`custom theme <theming>`.
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
   > since the change is trivial, I abstreined from creating an issue first.
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
  > not applicable
- [x] I tested my changes.

### Description

Adds a few lines of text pointing from the templates/themes section to the demo site section. I was missing such a link.