### PR TITLE
docs: fix simple typo, begining -> beginning

### DIFF
--- a/nikola/plugins/command/import_wordpress.py
+++ b/nikola/plugins/command/import_wordpress.py
@@ -1189,7 +1189,7 @@ def separate_qtranslate_tagged_langs(text):
             if not c.strip():
                 continue
         elif c[2:qt_end_with_lang_len].startswith(qt_end):
-            # a language specific section (with language code at the begining)
+            # a language specific section (with language code at the beginning)
             lang = c[:2]
             c = c[qt_end_with_lang_len:]
         else:


### PR DESCRIPTION
There is a small typo in nikola/plugins/command/import_wordpress.py.

Should read `beginning` rather than `begining`.


Semi-automated pull request generated by [advertisement removed].