### PR TITLE
Add a (configurable) timeout to the link checker

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -121,6 +121,7 @@
 * `Sean Pue <https://github.com/seanpue>`_
 * `Simon van der Veldt <https://github.com/simonvanderveldt>`_
 * `Stefan Näwe <https://github.com/snaewe>`_
+* `Stefano Rivera <https://github.com/stefanor>`_
 * `Stephan Fitzpatrick <https://github.com/knowsuchagency>`_
 * `Sukil Etxenike <https://github.com/sukiletxe>`_
 * `Ted Timmons <https://github.com/tedder>`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+New in master
+=============
+
+Features
+--------
+
+* Add a ``--timeout`` parameter to the ``check`` plugin, defaulting to
+  30s. (Issue #3643)
+
 New in v8.2.3
 =============
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Add a (configurable) timeout to the link checker.

Default to 30s, which is probably longer than necessary but is very unlikely to be too short for anybody.

Fixes: #3643