### PR TITLE
Skip shlex for win32 platforms

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,12 @@ Features
 
 * Add a ``--timeout`` parameter to the ``check`` plugin, defaulting to
   30s. (Issue #3643)
+* GZIP compression is now deterministic for automatic deploys (Issue #3650)
+
+Bug Fixes
+---------
+
+* `GZIP_COMMAND` parsing on `win32` platforms (Issue#3649)
 
 New in v8.2.3
 =============

--- a/nikola/plugins/task/gzip.plugin
+++ b/nikola/plugins/task/gzip.plugin
@@ -4,7 +4,7 @@ module = gzip
 
 [Documentation]
 author = Roberto Alsina
-version = 1.0
+version = 1.1
 website = https://getnikola.com/
 description = Create gzipped copies of files
 

--- a/nikola/plugins/task/gzip.py
+++ b/nikola/plugins/task/gzip.py
@@ -75,6 +75,6 @@ def create_gzipped_copy(in_path, out_path, command=None):
     if command:
         subprocess.check_call(shlex.split(command.format(filename=in_path)))
     else:
-        with gzip.GzipFile(out_path, 'wb+') as outf:
+        with gzip.GzipFile(out_path, 'wb+', mtime=0) as outf:
             with open(in_path, 'rb') as inf:
                 outf.write(inf.read())

--- a/nikola/plugins/task/gzip.py
+++ b/nikola/plugins/task/gzip.py
@@ -30,6 +30,7 @@ import gzip
 import os
 import shlex
 import subprocess
+import sys
 
 from nikola.plugin_categories import TaskMultiplier
 
@@ -73,7 +74,10 @@ class GzipFiles(TaskMultiplier):
 def create_gzipped_copy(in_path, out_path, command=None):
     """Create gzipped copy of in_path and save it as out_path."""
     if command:
-        subprocess.check_call(shlex.split(command.format(filename=in_path)))
+        if sys.platform == 'win32':
+            subprocess.check_call(command.format(filename=in_path))
+        else:
+            subprocess.check_call(shlex.split(command.format(filename=in_path)))
     else:
         with gzip.GzipFile(out_path, 'wb+', mtime=0) as outf:
             with open(in_path, 'rb') as inf:


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
Changed `GzipFile()` to create deterministic compression with `mtime=0` argument. (Issue #3650)

Fixed custom command parsing on windows due to shlex non-interoperability. (Issue #3649)