### PR TITLE
Add note about how to debug with doit

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -44,7 +44,7 @@ The Build Command
 
 Nikola's goal is similar, deep at heart, to a Makefile. Take sources, compile them
 into something, in this case a website. Instead of a Makefile, Nikola uses
-`doit <https://pydoit.org>`_
+`doit <https://pydoit.org>`_.
 
 Doit has the concept of "tasks". The 1 minute summary of tasks is that they have:
 
@@ -64,7 +64,11 @@ basename:name
 .. sidebar:: More about tasks
 
    If you ever want to do your own tasks, you really should read the doit
-   `documentation on tasks <https://pydoit.org/tasks.html>`_
+   `documentation on tasks <https://pydoit.org/tasks.html>`_.
+   
+   Notably, by default doit redirects ``stdout`` and ``stderr``. To get a
+   proper PDB debugging shell, you need to use doit's own
+   `set_trace <https://pydoit.org/tools.html#set-trace>`_ function.
 
 So, what Nikola does, when you use the build command, is to read the
 configuration ``conf.py`` from the current folder, instantiate


### PR DESCRIPTION
People used to debugging with Python might be confused about why they're not able to get the PDB shell after inserting a regular ``set_trace``. I think it's helpful to add a short note in the doc about the need to use doit's own ``set_trace``.

(It's me, I'm people. I used doit's ``set_trace`` in the past to debug a custom Task, but then I forgot about it recently when I needed to do more debugging. Hopefully this is helpful to those who come after me.)

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).

### Description
