### PR TITLE
Fix some deprecation warnings generated during the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 tmp/
 cache/
 output/
-tags
+/tags
 
 # GitHub token
 .pypt/gh-token

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 tmp/
 cache/
 output/
+tags
 
 # GitHub token
 .pypt/gh-token

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -145,7 +145,7 @@ class ImageProcessor(object):
                 if bigger_panoramas and w > 3 * h:
                     size = min(w, max_size * 4), min(w, max_size * 4)
             try:
-                im.thumbnail(size, Image.ANTIALIAS)
+                im.thumbnail(size, Image.Resampling.LANCZOS)
                 save_args = {}
                 if icc_profile:
                     save_args['icc_profile'] = icc_profile

--- a/nikola/plugins/compile/rest/__init__.py
+++ b/nikola/plugins/compile/rest/__init__.py
@@ -77,7 +77,7 @@ class CompileRest(PageCompiler):
         meta = {}
         if 'title' in document:
             meta['title'] = document['title']
-        for docinfo in document.traverse(docutils.nodes.docinfo):
+        for docinfo in document.findall(docutils.nodes.docinfo):
             for element in docinfo.children:
                 if element.tagname == 'field':  # custom fields (e.g. summary)
                     name_elem, body_elem = element.children


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

I added a trivial item to .gitignore. The 'tags' file is produced by utilities like 'ctags' (incl. the venerable exhuberant-ctags, and the modern universal-ctags), and is used by programs like Vim for 'go to definition' functionality.

I fixed two deprecation warnings that were generated when I ran the test suite, by making the substitutions suggested by the deprecation warnings themselves. Tests still pass, and the relevant functionality (RST to HTML and antialiasing in thumbnails) still seems to work in a freshly-built site.

The test suite does still generate two deprecation warnings, but they are from code in a dependency of ours (yapsy), and we are using the latest version of that.