### PR TITLE
Make rebuild/reload act only when file is modified.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,7 @@ Features
 Bug Fixes
 ---------
 
+* Fix ``auto`` command infinite loop (Issue #3677)
 * Fix API URL in CSS and JS minifiers (Issue #3658)
 * Fix ``:align: center`` for images in reST (Issue #3657)
 * ``GZIP_COMMAND`` parsing on ``win32`` platforms (Issue #3649)


### PR DESCRIPTION
Improve the event handler using directly the watchdog library's own handlers and trigger the actions only when a file is modified.

Should fix #3638

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

The original implementation triggered rebuild and reload on each possible filesystem event that is time consuming and can cause infinite loops, it's probably better to limit the rebuilding on file modification.