### PR TITLE
Treat slug='' as if there is no slug

### DIFF
--- a/nikola/post.py
+++ b/nikola/post.py
@@ -1213,12 +1213,12 @@ def get_meta(post, lang):
 
     if lang is None:
         # Only perform these checks for the default language
-        if 'slug' not in meta:
+        if 'slug' not in meta or not meta['slug']:
             # If no slug is found in the metadata use the filename
             meta['slug'] = slugify(os.path.splitext(
                 os.path.basename(post.source_path))[0], post.default_lang)
 
-        if 'title' not in meta:
+        if 'title' not in meta or not meta['title']:
             # If no title is found, use the filename without extension
             meta['title'] = os.path.splitext(
                 os.path.basename(post.source_path))[0]


### PR DESCRIPTION
When switching post metadata to YAML and having Nikola save it, it will look like this:

```yaml
---
category: ''
date: Mon, 01 Oct 2012 19:03:42 -0700
description: ''
link: ''
slug: ''
tags: books, goodreads
title: '1633'
type: text
---
```

But when reading it back, it will only use the title as the slug if the slug key is missing. That means it will consider the slug to be an empty string and try to generate `whatever/.html` which is bad.

This tiny PR fixes that.