### PR TITLE
Fix chdir leaking on error out of cd-contextmanager of tests/helper.py.

### DIFF
--- a/tests/helper.py
+++ b/tests/helper.py
@@ -30,9 +30,11 @@ __all__ = ["cd", "FakeSite"]
 @contextmanager
 def cd(path):
     old_dir = os.getcwd()
-    os.chdir(path)
-    yield
-    os.chdir(old_dir)
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(old_dir)
 
 
 class FakeSite:

--- a/tests/test_test_helper.py
+++ b/tests/test_test_helper.py
@@ -1,0 +1,22 @@
+import os
+
+from .helper import cd
+
+
+class SomeTestError(Exception):
+    """An arbitrary error to be thrown by the test."""
+    pass
+
+
+def test_test_helper():
+    """Check that the cd test helper duly resets the directory even in spite of an error."""
+    old_dir = os.getcwd()
+    exception_seen = False
+    try:
+        with cd(".."):
+            raise SomeTestError("Just raising an exception, as failing tests sometimes do.")
+    except SomeTestError:
+        now_dir = os.getcwd()
+        assert old_dir == now_dir
+        exception_seen = True
+    assert exception_seen


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description

While working on something else, I happened to spot a bug in `tests/helper.py`: The change of directory can (unintentionally) leak out of the `cd` context manager if the code inside the context throws an exception. In other words, on error, the change of directory is not undone.

I added a test for the test helper that demonstrates the bug if run with the previous test helper code. Not sure whether you want that.

This is a rather trivial change not visible to the end-user, so there is no need to add to CHANGELOG.

I plead guilty not having created a separate bug issue first. Do you need it in such a trivial case?