### PR TITLE
Deprecate yapsy compatibility function names.

### DIFF
--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -106,6 +106,17 @@ def test_load_plugins():
     assert plugin_manager.get_plugin_by_name("2nd").plugin_object.two_site_set
     assert plugin_manager.get_plugin_by_name("2nd", "Command") is None
 
+    deprecation_warning_seen = False
+    def expect_deprecation_warning(msg:str, deprecated_method:str, name:str, filename:str, lineno:int = -1):
+        nonlocal deprecation_warning_seen
+        deprecation_warning_seen = True
+        assert deprecated_method == "getPluginByName"
+        assert filename.endswith("/test_plugin_manager.py")
+
+    plugin_manager.logger.warning = expect_deprecation_warning
+    assert plugin_manager.getPluginByName("2nd", "Command") is None
+    assert deprecation_warning_seen
+
 
 def test_load_plugins_twice():
     """Ensure that extra plugins can be added."""


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable). **Not applicable.**
- [X] I tested my changes.

### Description

Output a deprecation warning for people that use the old, Yapsy function names, so those can eventually be removed.

It is ok with me if my work is in the end squashed into one commit, together with the other work on the `new-plugin-mananger` branch.