### PR TITLE
Obvious (provisorical) fix to lxml dependency incompatibility problem.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,7 @@ natsort>=3.5.2
 requests>=2.2.0
 piexif>=1.0.3
 Babel>=2.6.0
+
+# remove when the lxml 5.x.y compatibility has been re-established
+# via https://github.com/getnikola/nikola/issues/3732
+lxml>=4.9.4,<5.0.0


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable). **Not applicable.**
- [X] I tested my changes.

### Description

For now, pin the lxml version to the last 4.x.y to maintain compatibility with existing code.

This is a band-aid. No root cause analysis of the incompatibility has been made yet.