### PR TITLE
Fix #3753 — make import_wordpress tests pass with pytest 8.0.0

### DIFF
--- a/tests/test_command_import_wordpress.py
+++ b/tests/test_command_import_wordpress.py
@@ -59,9 +59,8 @@ def test_importing_posts_and_attachments(module, import_command, import_filename
     import_command.context = import_command.populate_context(channel)
 
     # Ensuring clean results
-    # assert not import_command.url_map
-    assert not module.links
     import_command.url_map = {}
+    module.links.clear()
 
     write_metadata = mock.MagicMock()
     write_content = mock.MagicMock()


### PR DESCRIPTION
### Pull Request Checklist

- [ ] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [ ] I tested my changes.

### Description
