### PR TITLE
Support passing --poll to the auto plugin to better deal with symlink farms.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ New in master
 Features
 --------
 
+* Support passing ``--poll`` to ``nikola auto`` to better deal with symlink farms.
+
 Bugfixes
 --------
 

--- a/tests/integration/test_dev_server.py
+++ b/tests/integration/test_dev_server.py
@@ -60,7 +60,8 @@ def test_serves_root_dir(
         "port": find_unused_port(),
         "db-file": "/dev/null",
         "backend": "No backend",
-        "no-server": False
+        "no-server": False,
+        "poll": False
     }
 
     # We start an event loop, run the test in an executor,


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description

#### What did I do?

* I have a directory `nikola-site` and another one `nikola` side-by-side.
* I removed the pertinent files in `nikola-site/stories` and replaced them with symbolic links linking to `nikola/docs`.
* In `nikola-site`, I started `nikola auto -b`.
* I changed the content of one of the files in `nikola/docs`.

#### Expectation:

The `nikola auto` plugin does its thing and my change becomes visible in the browser.

#### Actually seen:

The required rebuild is not triggered.

## Investigation

This related to a rather [ancient bug](https://github.com/gorakhargosh/watchdog/issues/365) of `watchdog`. As I found out by playing around, the bug disappears if the polling functionality of `watchdog` is used.

## What does this PR do?

Add a command line argument to `nikola auto`, namely `--poll`. If not present, all is as it always has been. If present, the polling `watchdog` observer is used and the rebuilds happen as they should.
