### PR TITLE
Remove unnecessary `polyfill.io`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,7 @@ Other
   promising support for versions supported by the Python core team,
   Ubuntu LTS, or Debian stable, and taking into consideration
   Debian oldstable and PyPy.
+* Remove polyfill from `polyfill.io`.
 
 New in v8.3.0
 =============

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -1690,10 +1690,6 @@ For Mako:
 .. code:: html
 
     % if date_fanciness != 0:
-    %if date_fanciness == 2:
-        <!-- Polyfill for relative dates in Safari -- best handled with a CDN -->
-        <script src="https://polyfill.io/v3/polyfill.js?features=Intl.RelativeTimeFormat.%7Elocale.${luxon_locales[lang]}"></script>
-    %endif
     <!-- required scripts -- best handled with bundles -->
     <script src="/assets/js/luxon.min.js"></script>
     <script src="/assets/js/fancydates.js"></script>
@@ -1712,10 +1708,6 @@ For Jinja2:
 .. code:: html
 
     {% if date_fanciness != 0 %}
-    {% if date_fanciness == 2 %}
-        <!-- Polyfill for relative dates in Safari -- best handled with a CDN -->
-        <script src="https://polyfill.io/v3/polyfill.js?features=Intl.RelativeTimeFormat.%7Elocale.{{ luxon_locales[lang] }}"></script>
-    {% endif %}
     <!-- required scripts -- best handled with bundles -->
     <script src="/assets/js/luxon.min.js"></script>
     <script src="/assets/js/fancydates.js"></script>

--- a/nikola/data/themes/base-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/base_helper.tmpl
@@ -78,9 +78,6 @@ lang="{{ lang }}">
         {% endif %}
     {% endif %}
     {% if date_fanciness != 0 %}
-        {% if date_fanciness == 2 %}
-            <script src="https://polyfill.io/v3/polyfill.js?features=Intl.RelativeTimeFormat.%7Elocale.{{ luxon_locales[lang] }}"></script>
-        {% endif %}
         {% if use_cdn %}
             <script src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js" integrity="sha256-Nn+JGDrq3PuTxcDfJmmI0Srj5LpfOFlKqEiPwQK7y40=" crossorigin="anonymous"></script>
         {% else %}

--- a/nikola/data/themes/base/templates/base_helper.tmpl
+++ b/nikola/data/themes/base/templates/base_helper.tmpl
@@ -78,9 +78,6 @@ lang="${lang}">
         % endif
     % endif
     % if date_fanciness != 0:
-        % if date_fanciness == 2:
-            <script src="https://polyfill.io/v3/polyfill.js?features=Intl.RelativeTimeFormat.%7Elocale.${luxon_locales[lang]}"></script>
-        % endif
         % if use_cdn:
             <script src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js" integrity="sha256-Nn+JGDrq3PuTxcDfJmmI0Srj5LpfOFlKqEiPwQK7y40=" crossorigin="anonymous"></script>
         % else:

--- a/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4-jinja/templates/base_helper.tmpl
@@ -82,9 +82,6 @@ lang="{{ lang }}">
         {% endif %}
     {% endif %}
     {% if date_fanciness != 0 %}
-        {% if date_fanciness == 2 %}
-            <script src="https://polyfill.io/v3/polyfill.js?features=Intl.RelativeTimeFormat.%7Elocale.{{ luxon_locales[lang] }}"></script>
-        {% endif %}
         {% if use_cdn %}
             <script src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js" integrity="sha256-Nn+JGDrq3PuTxcDfJmmI0Srj5LpfOFlKqEiPwQK7y40=" crossorigin="anonymous"></script>
         {% else %}

--- a/nikola/data/themes/bootblog4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootblog4/templates/base_helper.tmpl
@@ -82,9 +82,6 @@ lang="${lang}">
         %endif
     %endif
     %if date_fanciness != 0:
-        %if date_fanciness == 2:
-            <script src="https://polyfill.io/v3/polyfill.js?features=Intl.RelativeTimeFormat.%7Elocale.${luxon_locales[lang]}"></script>
-        %endif
         %if use_cdn:
             <script src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js" integrity="sha256-Nn+JGDrq3PuTxcDfJmmI0Srj5LpfOFlKqEiPwQK7y40=" crossorigin="anonymous"></script>
         %else:

--- a/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4-jinja/templates/base_helper.tmpl
@@ -82,9 +82,6 @@ lang="{{ lang }}">
         {% endif %}
     {% endif %}
     {% if date_fanciness != 0 %}
-        {% if date_fanciness == 2 %}
-            <script src="https://polyfill.io/v3/polyfill.js?features=Intl.RelativeTimeFormat.%7Elocale.{{ luxon_locales[lang] }}"></script>
-        {% endif %}
         {% if use_cdn %}
             <script src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js" integrity="sha256-Nn+JGDrq3PuTxcDfJmmI0Srj5LpfOFlKqEiPwQK7y40=" crossorigin="anonymous"></script>
         {% else %}

--- a/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
+++ b/nikola/data/themes/bootstrap4/templates/base_helper.tmpl
@@ -82,9 +82,6 @@ lang="${lang}">
         %endif
     %endif
     %if date_fanciness != 0:
-        %if date_fanciness == 2:
-            <script src="https://polyfill.io/v3/polyfill.js?features=Intl.RelativeTimeFormat.%7Elocale.${luxon_locales[lang]}"></script>
-        %endif
         %if use_cdn:
             <script src="https://cdn.jsdelivr.net/npm/luxon@3.3.0/build/global/luxon.min.js" integrity="sha256-Nn+JGDrq3PuTxcDfJmmI0Srj5LpfOFlKqEiPwQK7y40=" crossorigin="anonymous"></script>
         %else:


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

I haven't updated the `AUTHORS.txt` as I though small changes like this should not qualify.

The PR replaces all `polyfill.io` with `cdnjs.cloudflare.com/polyfill` in the docs and the template.

`polyfill.io` was acquired by **a China-based CDN company** "Funnull", see [the announcement from the `polyfill.io` domain owner's Twitter](https://x.com/JakeDChampion/status/1761315227008643367) and https://github.com/polyfillpolyfill/polyfill-service/issues/2834. Despite Funnull's claims of operating in the United States, the predominance of Simplified Chinese on its website suggests otherwise, and it turns out that **"Funnull" is notorious for providing service for the betting and pornography industries**.

[The original creator of the `polyfill.io` has voiced his concern on Twitter](https://twitter.com/triblondon/status/1761852117579427975). And since the acquisition, numerous issues have emerged (https://github.com/polyfillpolyfill/polyfill-service/issues/2835, https://github.com/polyfillpolyfill/polyfill-service/issues/2838, https://github.com/alist-org/alist/issues/6100), rendering the `polyfill.io` service **extremely unstable**. Since then, Fastly ([Announcement](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540)) and Cloudflare ([Announcement](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk)) has hosted their own instances of `polyfill.io` service.
