### PR TITLE
properly support watchdog 4+ where events always have dest_path

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ Bugfixes
 
 * Restore `annotation_helper.tmpl` with dummy content - fix themes still mentioning it
   (Issue #3764, #3773)
+* Fix compatibility with watchdog 4 (Issue #3766)
 
 New in v8.3.1
 =============

--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -429,7 +429,7 @@ class CommandAuto(Command):
         # Move events have a dest_path, some editors like gedit use a
         # move on larger save operations for write protection
         if event:
-            event_path = event.dest_path if hasattr(event, 'dest_path') else event.src_path
+            event_path = event.dest_path if (hasattr(event, 'dest_path') and event.dest_path) else event.src_path
         else:
             event_path = self.site.config['OUTPUT_FOLDER']
         p = os.path.relpath(event_path, os.path.abspath(self.site.config['OUTPUT_FOLDER'])).replace(os.sep, '/')


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Since watchdog 4 all events have the `dest_path` property,
but that property can be *empty*, thus breaking `nikola auto`:

    ERROR: asyncio: Task exception was never retrieved
    future: <Task finished name='Task-57' coro=<CommandAuto.reload_page() done, defined at nikola/plugins/command/auto/__init__.py:427> exception=ValueError('no path specified')>
    Traceback (most recent call last):
      File "nikola/plugins/command/auto/__init__.py", line 440, in reload_page
        p = os.path.relpath(event_path, os.path.abspath(self.site.config['OUTPUT_FOLDER'])).replace(os.sep, '/')
      File "/usr/lib64/python3.8/posixpath.py", line 453, in relpath
        raise ValueError("no path specified")
    ValueError: no path specified

