### PR TITLE
Fix #3785 — Ignore errors in parsing SVG files for shrinking them, copy original file to output instead

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ Features
 Bugfixes
 --------
 
+* Ignore errors in parsing SVG files for shrinking them, copy original file to output instead
+  (Issue #3785)
 * Restore `annotation_helper.tmpl` with dummy content - fix themes still mentioning it
   (Issue #3764, #3773)
 * Fix compatibility with watchdog 4 (Issue #3766)

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -28,10 +28,12 @@
 
 import datetime
 import gzip
+import logging
 import os
 import re
+import typing
 
-import lxml
+import lxml.etree
 import piexif
 from PIL import ExifTags, Image
 
@@ -42,6 +44,8 @@ EXIF_TAG_NAMES = {}
 
 class ImageProcessor(object):
     """Apply image operations."""
+    logger: logging.Logger
+    dates: typing.Dict[str, datetime.datetime]
 
     image_ext_list_builtin = ['.jpg', '.png', '.jpeg', '.gif', '.svg', '.svgz', '.bmp', '.tiff', '.webp']
 
@@ -210,6 +214,10 @@ class ImageProcessor(object):
                 op.close()
             except (KeyError, AttributeError) as e:
                 self.logger.warning("No width/height in %s. Original exception: %s" % (src, e))
+                utils.copy_file(src, dst)
+            except Exception as e:
+                self.logger.warning("Can't process {0}, using original "
+                                    "image! ({1})".format(src, e))
                 utils.copy_file(src, dst)
 
     def image_date(self, src):

--- a/nikola/image_processing.py
+++ b/nikola/image_processing.py
@@ -44,6 +44,7 @@ EXIF_TAG_NAMES = {}
 
 class ImageProcessor(object):
     """Apply image operations."""
+
     logger: logging.Logger
     dates: typing.Dict[str, datetime.datetime]
 


### PR DESCRIPTION
We already have this fallback for any errors for raster images. This fixes #3785.