### PR TITLE
Documentation glitch: support.rst says "3 admins" but has 4.

### DIFF
--- a/docs/support.rst
+++ b/docs/support.rst
@@ -48,9 +48,9 @@ Administrativia
 If you are in need of getting administrativia resolved, you may want
 to e-mail info@getnikola.com and therefore contact the people behind the
 project.  Note that this email **may not** be used for support matters.
-Messages are forwarded to all three administrators, the names and
-personal addresses (if you need to contact them personally) of you can
-find below.
+Messages are forwarded to all administrators.  If you need to
+contact them individually, you can find their names and
+personal addresses below.
 
 Administrators
 --------------


### PR DESCRIPTION
Better English, once at it.

### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable). **Not pertinent, as the change is trivial.**
- [ ] I tested my changes.

### Description

The documentation said there were **three** administrators, but the table below showed four.

Also, the English was a bit convoluted.