### PR TITLE
Fix test_compile_markdown.py, which needs Pygment version at least 2.19.0. Fixes #3813

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 doit>=0.33.1
-Pygments>=2.4.2
+Pygments>=2.19.0
 Pillow>=9.1.0
 python-dateutil>=2.8.2
 docutils>=0.19


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable). **Not applicable.**
- [ ] I tested my changes.

### Description

See #3813 .