### PR TITLE
Suppress exception stacktraces before doit gets to see the exception. Fixes 3828.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,6 +20,7 @@ Bugfixes
   (Issue #3764, #3773)
 * Fix compatibility with watchdog 4 (Issue #3766)
 * ``nikola serve`` now works with non-root SITE_URL.
+* Stack traces meaningless for end users now more reliably suppressed (Issue #3838).
 
 New in v8.3.1
 =============

--- a/nikola/__main__.py
+++ b/nikola/__main__.py
@@ -291,7 +291,7 @@ class NikolaTaskLoader(TaskLoader2):
             signal('initialized').send(self.nikola)
         except Exception:
             LOGGER.error('Error loading tasks. An unhandled exception occurred.')
-            if self.nikola.debug or self.nikola.show_tracebacks:
+            if self.nikola.show_tracebacks:
                 raise
             _print_exception()
             sys.exit(3)
@@ -382,7 +382,7 @@ class DoitNikola(DoitMain):
             return super().run(cmd_args)
         except Exception:
             LOGGER.error('An unhandled exception occurred.')
-            if self.nikola.debug or self.nikola.show_tracebacks:
+            if self.nikola.show_tracebacks:
                 raise
             _print_exception()
             return 1
@@ -468,7 +468,7 @@ def levenshtein(s1, s2):
     return previous_row[-1]
 
 
-def _print_exception():
+def _print_exception() -> None:
     """Print an exception in a friendlier, shorter style."""
     etype, evalue, _ = sys.exc_info()
     LOGGER.error(''.join(traceback.format_exception(etype, evalue, None, limit=0, chain=False)).strip())

--- a/nikola/nikola.py
+++ b/nikola/nikola.py
@@ -401,7 +401,7 @@ class Nikola(object):
         self._MESSAGES = None
         self.filters = {}
         self.debug = DEBUG
-        self.show_tracebacks = SHOW_TRACEBACKS
+        self.show_tracebacks = SHOW_TRACEBACKS or DEBUG
         self.colorful = config.pop('__colorful__', False)
         self.invariant = config.pop('__invariant__', False)
         self.quiet = config.pop('__quiet__', False)

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -134,7 +134,7 @@ class Command(BasePlugin, DoitCommand):
             if self.site.show_tracebacks:
                 raise
             else:
-                # Do the import only now to doge circular import problems:
+                # Do the import only now to evade a circular import problems:
                 from .__main__ import _print_exception
                 _print_exception()
                 return 3

--- a/nikola/plugin_categories.py
+++ b/nikola/plugin_categories.py
@@ -127,8 +127,17 @@ class Command(BasePlugin, DoitCommand):
 
         if self.needs_config and not self.site.configured:
             LOGGER.error("This command needs to run inside an existing Nikola site.")
-            return False
-        return self._execute(options, args)
+            return 3
+        try:
+            return self._execute(options, args)
+        except Exception:
+            if self.site.show_tracebacks:
+                raise
+            else:
+                # Do the import only now to doge circular import problems:
+                from .__main__ import _print_exception
+                _print_exception()
+                return 3
 
     def _execute(self, options, args) -> int:
         """Do whatever this command does.


### PR DESCRIPTION
… Fixes #3828.

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

Suppress exception stacktraces before doit gets to see the exception. Fixes #3828.

Same test as described in #3828, but with this change, outputs the following:

```
nikola serve -p 7890
[2025-03-04 21:17:27] ERROR: Nikola: OSError: [Errno 98] Address already in use
[2025-03-04 21:17:27] WARNING: Nikola: To see more details, run Nikola in debug mode (set environment variable NIKOLA_DEBUG=1) or use NIKOLA_SHOW_TRACEBACKS=1
```