### PR TITLE
KaTeX update 

### DIFF
--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1027,6 +1027,7 @@ PRETTY_URLS = ${PRETTY_URLS}
 #     {left: "$$", right: "$$", display: true},
 #     {left: "\\\\[", right: "\\\\]", display: true},
 #     {left: "\\\\begin{equation*}", right: "\\\\end{equation*}", display: true},
+#     {left: "\\\\begin{align*}", right: "\\\\end{align*}", display: true},
 #     {left: "$", right: "$", display: false},
 #     {left: "\\\\(", right: "\\\\)", display: false}
 # ]

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1025,11 +1025,14 @@ PRETTY_URLS = ${PRETTY_URLS}
 # KATEX_AUTO_RENDER = """
 # delimiters: [
 #     {left: "$$", right: "$$", display: true},
-#     {left: "\\\\[", right: "\\\\]", display: true},
+#     {left: "\\\\[", right: "\\\\]", display: true}
 #     {left: "\\\\begin{equation*}", right: "\\\\end{equation*}", display: true},
 #     {left: "\\\\begin{align*}", right: "\\\\end{align*}", display: true},
+#     {left: "\\\\begin{alignat}", right: "\\\\end{alignat}", display: true},
+#     {left: "\\\\begin{gather}", right: "\\\\end{gather}", display: true},
+#     {left: "\\\\begin{CD}", right: "\\\\end{CD}", display: true},
 #     {left: "$", right: "$", display: false},
-#     {left: "\\\\(", right: "\\\\)", display: false}
+#     {left: "\\\\(", right: "\\\\)", display: false},
 # ]
 # """
 

--- a/nikola/conf.py.in
+++ b/nikola/conf.py.in
@@ -1025,8 +1025,10 @@ PRETTY_URLS = ${PRETTY_URLS}
 # KATEX_AUTO_RENDER = """
 # delimiters: [
 #     {left: "$$", right: "$$", display: true},
-#     {left: "\\\\[", right: "\\\\]", display: true}
+#     {left: "\\\\[", right: "\\\\]", display: true},
+#     {left: "\\\\begin{equation}", right: "\\\\end{equation}", display: true},
 #     {left: "\\\\begin{equation*}", right: "\\\\end{equation*}", display: true},
+#     {left: "\\\\begin{align}", right: "\\\\end{align}", display: true},
 #     {left: "\\\\begin{align*}", right: "\\\\end{align*}", display: true},
 #     {left: "\\\\begin{alignat}", right: "\\\\end{alignat}", display: true},
 #     {left: "\\\\begin{gather}", right: "\\\\end{gather}", display: true},

--- a/nikola/data/themes/base-jinja/templates/math_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/math_helper.tmpl
@@ -1,8 +1,8 @@
 {#  Note: at present, MathJax and KaTeX do not respect the USE_CDN configuration option #}
 {% macro math_scripts() %}
     {% if use_katex %}
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js" integrity="sha384-cpW21h6RZv/phavutF+AuVYrr+dA8xD9zs6FwLpaCct6O9ctzYFfFr4dgmgccOTx" crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.js" integrity="sha384-Rma6DA2IPUwhNxmrB/7S3Tno0YY7sFu9WSYMCuulLhIqYSGZ2gKCJWIqhBWqMQfh" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/contrib/auto-render.min.js" integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh" crossorigin="anonymous"></script>
         {% if katex_auto_render %}
             <script>
                 document.addEventListener("DOMContentLoaded", function() {
@@ -45,7 +45,7 @@
 
 {% macro math_styles() %}
     {% if use_katex %}
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css" integrity="sha384-GvrOXuhMATgEsSwCs4smul74iXGOixntILdUW9XmUC6+HX0sLNAK3q71HotJqlAn" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css" integrity="sha384-zh0CIslj+VczCZtlzBcjt5ppRcsAmDnRem7ESsYwWwg3m/OaJ2l4x7YBZl9Kxxib" crossorigin="anonymous">
     {% endif %}
 {% endmacro %}
 

--- a/nikola/data/themes/base-jinja/templates/math_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/math_helper.tmpl
@@ -20,10 +20,13 @@
                         {
                             delimiters: [
                                 {left: "$$", right: "$$", display: true},
-                                {left: "\\[", right: "\\]", display: true},
+                                {left: "\\(", right: "\\)", display: false},
                                 {left: "\\begin{equation*}", right: "\\end{equation*}", display: true},
                                 {left: "\\begin{align*}", right: "\\end{align*}", display: true},
-                                {left: "\\(", right: "\\)", display: false}
+                                {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
+                                {left: "\\begin{gather}", right: "\\end{gather}", display: true},
+                                {left: "\\begin{CD}", right: "\\end{CD}", display: true},
+                                {left: "\\[", right: "\\]", display: true}
                             ]
                         }
                     );

--- a/nikola/data/themes/base-jinja/templates/math_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/math_helper.tmpl
@@ -1,28 +1,33 @@
 {#  Note: at present, MathJax and KaTeX do not respect the USE_CDN configuration option #}
 {% macro math_scripts() %}
     {% if use_katex %}
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.js" integrity="sha384-9Nhn55MVVN0/4OFx7EE5kpFBPsEMZxKTCnA+4fqDmg12eCTqGi6+BB2LjY8brQxJ" crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js" integrity="sha384-cpW21h6RZv/phavutF+AuVYrr+dA8xD9zs6FwLpaCct6O9ctzYFfFr4dgmgccOTx" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"></script>
         {% if katex_auto_render %}
             <script>
-                renderMathInElement(document.body,
-                    {
-                        {{ katex_auto_render }}
-                    }
-                );
+                document.addEventListener("DOMContentLoaded", function() {
+                    renderMathInElement(document.body,
+                        {
+                            {{ katex_auto_render }}
+                        }
+                    );
+                });
             </script>
         {% else %}
             <script>
-                renderMathInElement(document.body,
-                    {
-                        delimiters: [
-                            {left: "$$", right: "$$", display: true},
-                            {left: "\\[", right: "\\]", display: true},
-                            {left: "\\begin{equation*}", right: "\\end{equation*}", display: true},
-                            {left: "\\(", right: "\\)", display: false}
-                        ]
-                    }
-                );
+                document.addEventListener("DOMContentLoaded", function() {
+                    renderMathInElement(document.body,
+                        {
+                            delimiters: [
+                                {left: "$$", right: "$$", display: true},
+                                {left: "\\[", right: "\\]", display: true},
+                                {left: "\\begin{equation*}", right: "\\end{equation*}", display: true},
+                                {left: "\\begin{align*}", right: "\\end{align*}", display: true},
+                                {left: "\\(", right: "\\)", display: false}
+                            ]
+                        }
+                    );
+                });
             </script>
         {% endif %}
     {% else %}
@@ -40,7 +45,7 @@
 
 {% macro math_styles() %}
     {% if use_katex %}
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css" integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css" integrity="sha384-GvrOXuhMATgEsSwCs4smul74iXGOixntILdUW9XmUC6+HX0sLNAK3q71HotJqlAn" crossorigin="anonymous">
     {% endif %}
 {% endmacro %}
 

--- a/nikola/data/themes/base-jinja/templates/math_helper.tmpl
+++ b/nikola/data/themes/base-jinja/templates/math_helper.tmpl
@@ -1,8 +1,8 @@
 {#  Note: at present, MathJax and KaTeX do not respect the USE_CDN configuration option #}
 {% macro math_scripts() %}
     {% if use_katex %}
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.js" integrity="sha384-Rma6DA2IPUwhNxmrB/7S3Tno0YY7sFu9WSYMCuulLhIqYSGZ2gKCJWIqhBWqMQfh" crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/contrib/auto-render.min.js" integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh" crossorigin="anonymous"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.44/dist/katex.min.js" integrity="sha384-m/s9umSlhJbqEdA/j7pQVdGCMx2fHf7GXtgCVhNGOwLuu+1qJQES5AzIE8pn3nKQ" crossorigin="anonymous"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.44/dist/contrib/auto-render.min.js" integrity="sha384-bjyGPfbij8/NDKJhSGZNP/khQVgtHUE5exjm4Ydllo42FwIgYsdLO2lXGmRBf5Mz" crossorigin="anonymous"></script>
         {% if katex_auto_render %}
             <script>
                 document.addEventListener("DOMContentLoaded", function() {
@@ -48,7 +48,7 @@
 
 {% macro math_styles() %}
     {% if use_katex %}
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css" integrity="sha384-zh0CIslj+VczCZtlzBcjt5ppRcsAmDnRem7ESsYwWwg3m/OaJ2l4x7YBZl9Kxxib" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.44/dist/katex.min.css" integrity="sha384-irXK0JiCGinqGL+slwVklbhJetrjczNwaP2lANewD8lKAs9n61SbQ3As28iSqXUE" crossorigin="anonymous">
     {% endif %}
 {% endmacro %}
 

--- a/nikola/data/themes/base/templates/math_helper.tmpl
+++ b/nikola/data/themes/base/templates/math_helper.tmpl
@@ -1,28 +1,33 @@
 ### Note: at present, MathJax and KaTeX do not respect the USE_CDN configuration option
 <%def name="math_scripts()">
     %if use_katex:
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.js" integrity="sha384-9Nhn55MVVN0/4OFx7EE5kpFBPsEMZxKTCnA+4fqDmg12eCTqGi6+BB2LjY8brQxJ" crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/contrib/auto-render.min.js" integrity="sha384-kWPLUVMOks5AQFrykwIup5lo0m3iMkkHrD0uJ4H5cjeGihAutqP0yW0J6dpFiVkI" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js" integrity="sha384-cpW21h6RZv/phavutF+AuVYrr+dA8xD9zs6FwLpaCct6O9ctzYFfFr4dgmgccOTx" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"></script>
         % if katex_auto_render:
             <script>
-                renderMathInElement(document.body,
-                    {
-                        ${katex_auto_render}
-                    }
-                );
+                document.addEventListener("DOMContentLoaded", function() {
+                    renderMathInElement(document.body,
+                        {
+                            ${katex_auto_render}
+                        }
+                    );
+                });
             </script>
         % else:
             <script>
-                renderMathInElement(document.body,
-                    {
-                        delimiters: [
-                            {left: "$$", right: "$$", display: true},
-                            {left: "\\[", right: "\\]", display: true},
-                            {left: "\\begin{equation*}", right: "\\end{equation*}", display: true},
-                            {left: "\\(", right: "\\)", display: false}
-                        ]
-                    }
-                );
+                document.addEventListener("DOMContentLoaded", function() {
+                    renderMathInElement(document.body,
+                        {
+                            delimiters: [
+                                {left: "$$", right: "$$", display: true},
+                                {left: "\\[", right: "\\]", display: true},
+                                {left: "\\begin{equation*}", right: "\\end{equation*}", display: true},
+                                {left: "\\begin{align*}", right: "\\end{align*}", display: true},
+                                {left: "\\(", right: "\\)", display: false}
+                            ]
+                        }
+                    );
+                });
             </script>
         % endif
     %else:
@@ -40,7 +45,7 @@
 
 <%def name="math_styles()">
     % if use_katex:
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css" integrity="sha384-yFRtMMDnQtDRO8rLpMIKrtPCD5jdktao2TV19YiZYWMDkUR5GQZR/NOVTdquEx1j" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css" integrity="sha384-GvrOXuhMATgEsSwCs4smul74iXGOixntILdUW9XmUC6+HX0sLNAK3q71HotJqlAn" crossorigin="anonymous">
     % endif
 </%def>
 

--- a/nikola/data/themes/base/templates/math_helper.tmpl
+++ b/nikola/data/themes/base/templates/math_helper.tmpl
@@ -20,10 +20,13 @@
                         {
                             delimiters: [
                                 {left: "$$", right: "$$", display: true},
-                                {left: "\\[", right: "\\]", display: true},
+                                {left: "\\(", right: "\\)", display: false},
                                 {left: "\\begin{equation*}", right: "\\end{equation*}", display: true},
                                 {left: "\\begin{align*}", right: "\\end{align*}", display: true},
-                                {left: "\\(", right: "\\)", display: false}
+                                {left: "\\begin{alignat}", right: "\\end{alignat}", display: true},
+                                {left: "\\begin{gather}", right: "\\end{gather}", display: true},
+                                {left: "\\begin{CD}", right: "\\end{CD}", display: true},
+                                {left: "\\[", right: "\\]", display: true}
                             ]
                         }
                     );

--- a/nikola/data/themes/base/templates/math_helper.tmpl
+++ b/nikola/data/themes/base/templates/math_helper.tmpl
@@ -1,8 +1,8 @@
 ### Note: at present, MathJax and KaTeX do not respect the USE_CDN configuration option
 <%def name="math_scripts()">
     %if use_katex:
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.js" integrity="sha384-cpW21h6RZv/phavutF+AuVYrr+dA8xD9zs6FwLpaCct6O9ctzYFfFr4dgmgccOTx" crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js" integrity="sha384-+VBxd3r6XgURycqtZ117nYw44OOcIax56Z4dCRWbxyPt0Koah1uHoK0o4+/RRE05" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.js" integrity="sha384-Rma6DA2IPUwhNxmrB/7S3Tno0YY7sFu9WSYMCuulLhIqYSGZ2gKCJWIqhBWqMQfh" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/contrib/auto-render.min.js" integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh" crossorigin="anonymous"></script>
         % if katex_auto_render:
             <script>
                 document.addEventListener("DOMContentLoaded", function() {
@@ -45,7 +45,7 @@
 
 <%def name="math_styles()">
     % if use_katex:
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css" integrity="sha384-GvrOXuhMATgEsSwCs4smul74iXGOixntILdUW9XmUC6+HX0sLNAK3q71HotJqlAn" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css" integrity="sha384-zh0CIslj+VczCZtlzBcjt5ppRcsAmDnRem7ESsYwWwg3m/OaJ2l4x7YBZl9Kxxib" crossorigin="anonymous">
     % endif
 </%def>
 

--- a/nikola/data/themes/base/templates/math_helper.tmpl
+++ b/nikola/data/themes/base/templates/math_helper.tmpl
@@ -1,8 +1,8 @@
 ### Note: at present, MathJax and KaTeX do not respect the USE_CDN configuration option
 <%def name="math_scripts()">
     %if use_katex:
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.js" integrity="sha384-Rma6DA2IPUwhNxmrB/7S3Tno0YY7sFu9WSYMCuulLhIqYSGZ2gKCJWIqhBWqMQfh" crossorigin="anonymous"></script>
-        <script src="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/contrib/auto-render.min.js" integrity="sha384-hCXGrW6PitJEwbkoStFjeJxv+fSOOQKOPbJxSfM6G5sWZjAyWhXiTIIAmQqnlLlh" crossorigin="anonymous"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.44/dist/katex.min.js" integrity="sha384-m/s9umSlhJbqEdA/j7pQVdGCMx2fHf7GXtgCVhNGOwLuu+1qJQES5AzIE8pn3nKQ" crossorigin="anonymous"></script>
+        <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.44/dist/contrib/auto-render.min.js" integrity="sha384-bjyGPfbij8/NDKJhSGZNP/khQVgtHUE5exjm4Ydllo42FwIgYsdLO2lXGmRBf5Mz" crossorigin="anonymous"></script>
         % if katex_auto_render:
             <script>
                 document.addEventListener("DOMContentLoaded", function() {
@@ -48,7 +48,7 @@
 
 <%def name="math_styles()">
     % if use_katex:
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.21/dist/katex.min.css" integrity="sha384-zh0CIslj+VczCZtlzBcjt5ppRcsAmDnRem7ESsYwWwg3m/OaJ2l4x7YBZl9Kxxib" crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.44/dist/katex.min.css" integrity="sha384-irXK0JiCGinqGL+slwVklbhJetrjczNwaP2lANewD8lKAs9n61SbQ3As28iSqXUE" crossorigin="anonymous">
     % endif
 </%def>
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description

tested by creating a demo site and adding
                                                                                             
    $$\\sin(x) = \\frac{1}{3}$$                                                                          
    \\begin{align*} \\sin(x) &= \\frac{1}{3} \\\\  \\cos(x)+5  &= \\int^1_0\exp(x) \\end{align*}         
    
to the post.

Based on #3710, Fixes #3709

Review needed since I haven't used math mode in nikola before and, for example, not sure about "double \" needed in input. Also, KaTeX seems to support some more environment and I'm not sure if the the setup one should only use the * version of those or the one without star or both?