### PR TITLE
Close ``<a>`` tag instead of opening another one in ``tag.tmpl``

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ Bugfixes
 
 * Fix jinja2 plugin failing to load when jinja2 is not installed
   (Discussion #3848)
+* Minor bugfix in the base-jinja `tag.tmpl` template: Close an `<a>`
+  instead of opening another one.
 
 New in v8.3.3
 =============

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ Bugfixes
 
 * Fix jinja2 plugin failing to load when jinja2 is not installed
   (Discussion #3848)
-* Close `<a>` tag instead of opening another one in ``tag.tmpl``
+* Close ``<a>`` tag instead of opening another one in ``tag.tmpl``
 
 New in v8.3.3
 =============

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,8 +9,7 @@ Bugfixes
 
 * Fix jinja2 plugin failing to load when jinja2 is not installed
   (Discussion #3848)
-* Minor bugfix in the base-jinja `tag.tmpl` template: Close an `<a>`
-  instead of opening another one.
+* Close `<a>` tag instead of opening another one in ``tag.tmpl``
 
 New in v8.3.3
 =============

--- a/nikola/data/themes/base-jinja/templates/tag.tmpl
+++ b/nikola/data/themes/base-jinja/templates/tag.tmpl
@@ -29,7 +29,7 @@
     {% if posts %}
         <ul class="postlist">
         {% for post in posts %}
-            <li><time class="listdate" datetime="{{ post.formatted_date('webiso') }}" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time> <a href="{{ post.permalink() }}" class="listtitle">{{ post.title()|e }}<a></li>
+            <li><time class="listdate" datetime="{{ post.formatted_date('webiso') }}" title="{{ post.formatted_date(date_format)|e }}">{{ post.formatted_date(date_format)|e }}</time> <a href="{{ post.permalink() }}" class="listtitle">{{ post.title()|e }}</a></li>
         {% endfor %}
         </ul>
     {% endif %}

--- a/nikola/data/themes/base/templates/tag.tmpl
+++ b/nikola/data/themes/base/templates/tag.tmpl
@@ -29,7 +29,7 @@
     %if posts:
         <ul class="postlist">
         % for post in posts:
-            <li><time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time> <a href="${post.permalink()}" class="listtitle">${post.title()|h}<a></li>
+            <li><time class="listdate" datetime="${post.formatted_date('webiso')}" title="${post.formatted_date(date_format)|h}">${post.formatted_date(date_format)|h}</time> <a href="${post.permalink()}" class="listtitle">${post.title()|h}</a></li>
         % endfor
         </ul>
     %endif


### PR DESCRIPTION
### Pull Request Checklist

- [X] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [X] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [X] I tested my changes.

### Description

There is a HTML glitch in the tags template: Some `<a>` is not closed with a corresponding `</a>`, but instead, another `<a>`  is opened.

This trivial pull request fixes this.