### PR TITLE
Fix #3848 — fix jinja2 plugin failing to load when jinja2 is not installed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,15 @@
+New in master
+=============
+
+Features
+--------
+
+Bugfixes
+--------
+
+* Fix jinja2 plugin failing to load when jinja2 is not installed
+  (Discussion #3848)
+
 New in v8.3.3
 =============
 

--- a/nikola/plugins/template/jinja.py
+++ b/nikola/plugins/template/jinja.py
@@ -49,7 +49,7 @@ class JinjaTemplates(TemplateSystem):
     if jinja2 is None:
         lookup = None
     else:
-        lookup: Optional[jinja2.Environment] = None
+        lookup: Optional['jinja2.Environment'] = None
 
         def _basic_environment_factory(self, **args):
             return jinja2.Environment(**args)
@@ -63,7 +63,7 @@ class JinjaTemplates(TemplateSystem):
         if jinja2 is None:
             return
 
-    def set_user_engine_factory(self, factory: Callable[..., jinja2.Environment]) -> None:
+    def set_user_engine_factory(self, factory: Callable[..., 'jinja2.Environment']) -> None:
         """Accept a factory that will be used to produce the underlying jinja2.Environment.
 
         Not normally needed, but it is there if you have special requirements.


### PR DESCRIPTION
```
ERROR: PluginManager: Plugin jinja from /opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/nikola/plugins/template/jinja.plugin (/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/nikola/plugins/template/jinja.py) threw an exception while loading
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/nikola/plugin_manager.py", line 196, in load_plugins
    spec.loader.exec_module(module_object)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/nikola/plugins/template/jinja.py", line 45, in <module>
    class JinjaTemplates(TemplateSystem):
    ...<116 lines>...
                return None
  File "/opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/nikola/plugins/template/jinja.py", line 66, in JinjaTemplates
    def set_user_engine_factory(self, factory: Callable[..., jinja2.Environment]) -> None:
                                                             ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'Environment'
WARNING: PluginManager: Some plugins failed to load. Please review the above warning messages.
WARNING: PluginManager: You may need to update some plugins (from plugins.getnikola.com) or to fix their .plugin files.
WARNING: PluginManager: Waiting 2 seconds before continuing.
```