### PR TITLE
Extend documentation on using reST files for galleries overview pages

### DIFF
--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -2088,10 +2088,14 @@ The ``conf.py`` options affecting images and gallery pages are these:
     IMAGE_THUMBNAIL_SIZE = 400
     IMAGE_THUMBNAIL_FORMAT = '{name}.thumbnail{ext}'
 
-If you add a reST file in ``galleries/gallery_name/index.txt`` its contents will be
-converted to HTML and inserted above the images in the gallery page. The
-format is the same as for posts. You can use the ``title``, ``previewimage``, and
-``status`` metadata fields to change how the gallery is shown.
+If you add a reST file ``galleries/gallery_name/index.txt``, its contents will be
+converted to HTML and inserted above the images on the gallery page. The format is the
+same as for posts. You can use the ``title``, ``previewimage``, and ``status`` metadata
+fields to control how the gallery is displayed.
+
+Additionally, you can add a reST file ``galleries/index.txt`` for the same purpose.
+Its contents will also be converted to HTML and inserted above the gallery overview.
+The format and available metadata fields are the same as for posts and gallery indexes.
 
 If the ``status`` is ``private``, ``draft``, or ``publish_later``, the
 gallery will not appear in the index, the RSS feeds, nor in the sitemap.


### PR DESCRIPTION
### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- ~~[ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).~~ no, since i'ts a trivial documentation change.
- ~~[ ] I tested my changes.~~ n/a

### Description
The use of a `galleries\index.txt` file is also possible for gallery overview pages. I have expanded the documentation a little to reflect this.