### PR TITLE
Fix compatibility with Python 3.14

### DIFF
--- a/nikola/plugins/command/auto/__init__.py
+++ b/nikola/plugins/command/auto/__init__.py
@@ -240,7 +240,7 @@ class CommandAuto(Command):
 
         # Prepare asyncio event loop
         # Required for subprocessing to work
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
 
         # Set debug setting
         loop.set_debug(self.site.debug)
@@ -305,8 +305,8 @@ class CommandAuto(Command):
         # Run the event loop forever and handle shutdowns.
         try:
             # Run rebuild queue
-            rebuild_queue_fut = asyncio.ensure_future(self.run_rebuild_queue())
-            reload_queue_fut = asyncio.ensure_future(self.run_reload_queue())
+            rebuild_queue_fut = asyncio.ensure_future(self.run_rebuild_queue(), loop=loop)
+            reload_queue_fut = asyncio.ensure_future(self.run_reload_queue(), loop=loop)
 
             self.dns_sd = dns_sd(port, (options['ipv6'] or '::' in host))
             loop.run_forever()

--- a/tests/integration/dev_server_test_helper.py
+++ b/tests/integration/dev_server_test_helper.py
@@ -41,3 +41,4 @@ class MyFakeSite(FakeSite):
         self.registered_auto_watched_folders = set()
         self.config = config
         self.configuration_filename = configuration_filename
+        self.show_tracebacks = True


### PR DESCRIPTION
Since Python 3.14, asyncio.get_event_loop() raises a RuntimeError if there is no current event loop. asyncio.ensure_future() calls asyncio.get_event_loop() if loop is not given.

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [ ] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
