### PR TITLE
Add referrer policy to YouTube iframe

### DIFF
--- a/nikola/plugins/compile/rest/youtube.py
+++ b/nikola/plugins/compile/rest/youtube.py
@@ -49,8 +49,8 @@ CODE = """\
 <div class="youtube-video{align}">
 <iframe width="{width}" height="{height}"
 src="https://www.youtube-nocookie.com/embed/{yid}?rel=0&wmode=transparent{start_at}"
-frameborder="0" allow="encrypted-media" referrerpolicy="strict-origin-when-cross-origin" 
-allowfullscreen
+frameborder="0" allow="encrypted-media" allowfullscreen
+referrerpolicy="strict-origin-when-cross-origin"
 ></iframe>
 </div>"""
 


### PR DESCRIPTION
Youtube started enforcing referer policy and throwing 153 if the referer was not set.

https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity

This fixes https://github.com/getnikola/nikola/issues/3879

### Pull Request Checklist

- [x] I’ve read the [guidelines for contributing](https://github.com/getnikola/nikola/blob/master/CONTRIBUTING.rst).
- [x] I updated AUTHORS.txt and CHANGES.txt (if the change is non-trivial) and documentation (if applicable).
- [x] I tested my changes.

### Description
